### PR TITLE
fix error of node_id-s  repeating

### DIFF
--- a/core/composer/chain.py
+++ b/core/composer/chain.py
@@ -1,10 +1,10 @@
-from copy import deepcopy
 from typing import Optional, List
 
 import networkx as nx
 
 from core.composer.node import Node, SecondaryNode, PrimaryNode, CachedNodeResult
 from core.models.data import InputData
+from copy import deepcopy
 
 ERROR_PREFIX = 'Invalid chain configuration:'
 
@@ -39,7 +39,7 @@ class Chain:
         self.nodes.append(new_node)
 
     def replace_node(self, old_node: Node, new_node: Node):
-        new_node = deepcopy(new_node)
+        new_node = new_node.duplicate
         old_node_offspring = self._node_childs(old_node)
         for old_node_child in old_node_offspring:
             old_node_child.nodes_from[old_node_child.nodes_from.index(old_node)] = new_node
@@ -96,11 +96,18 @@ class Chain:
 
         return _depth_recursive(self.root_node)
 
+    @property
+    def duplicate(self) -> 'Chain':
+        duplicate_chain = deepcopy(self)
+        root_node_duplicate = self.root_node.duplicate
+        duplicate_chain.nodes = root_node_duplicate.subtree_nodes
+        return duplicate_chain
+
     def _flat_nodes_tree(self, node):
         raise NotImplementedError()
 
 
-def as_nx_graph(chain: Chain):
+def as_nx_graph(chain: Chain) -> (nx.DiGraph, dict):
     """force_node_model_name should be True in case when parameter mode_math of function nx.is_isomorphic is the
     function which compares nodes model names"""
     graph = nx.DiGraph()
@@ -122,10 +129,9 @@ def as_nx_graph(chain: Chain):
     return graph, node_labels
 
 
-def _is_cache_actual(node, cache: CachedNodeResult):
+def _is_cache_actual(node, cache: CachedNodeResult) -> bool:
     if cache is not None and cache.is_actual(node):
         return True
-
     return False
 
 

--- a/core/composer/composer.py
+++ b/core/composer/composer.py
@@ -18,7 +18,7 @@ from core.repository.model_types_repository import ModelTypesIdsEnum
 class ComposerRequirements:
     primary: List[ModelTypesIdsEnum]
     secondary: List[ModelTypesIdsEnum]
-    max_lead_time: Optional[datetime.timedelta] = datetime.timedelta(minutes=10)
+    max_lead_time: Optional[datetime.timedelta] = datetime.timedelta(minutes=30)
     max_depth: Optional[int] = None
     max_arity: Optional[int] = None
 

--- a/core/composer/gp_composer/gp_composer.py
+++ b/core/composer/gp_composer/gp_composer.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from typing import (
@@ -14,6 +13,7 @@ from core.composer.node import NodeGenerator
 from core.composer.optimisers.gp_optimiser import GPChainOptimiser
 from core.composer.visualisation import ComposerVisualiser
 from core.models.data import InputData
+from core.chain_validation import validate
 
 
 @dataclass
@@ -62,13 +62,16 @@ class GPComposer(Composer):
 
 
 def tree_to_chain(tree_root: GPNode) -> Chain:
+
     chain = Chain()
-    nodes = flat_nodes_tree(deepcopy(tree_root))
+    nodes = flat_nodes_tree(tree_root.duplicate)
     for node in nodes:
         if node.nodes_from:
             for i in range(len(node.nodes_from)):
                 node.nodes_from[i] = node.nodes_from[i].chain_node
         chain.add_node(node.chain_node)
+
+    assert validate(chain)
     return chain
 
 

--- a/core/composer/gp_composer/gp_node.py
+++ b/core/composer/gp_composer/gp_node.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from typing import (Optional, List, Any)
+from core.composer.node import node_duplicate
 
 
 class GPNode:
@@ -14,6 +15,14 @@ class GPNode:
     @nodes_from.setter
     def nodes_from(self, nodes):
         self.chain_node.nodes_from = nodes
+
+    @property
+    def node_id(self):
+        return self.chain_node.node_id
+
+    @node_id.setter
+    def node_id(self, id):
+        self.chain_node.node_id = id
 
     @property
     def eval_strategy(self):
@@ -42,6 +51,10 @@ class GPNode:
         else:
             return 1 + max([next_node.depth for next_node in self.nodes_from])
 
+    @property
+    def duplicate(self) -> 'GPNode':
+        return node_duplicate(self)
+
     def nodes_from_height(self, selected_height) -> List[Any]:
         nodes = []
         if self.nodes_from:
@@ -54,7 +67,7 @@ class GPNode:
 
 
 def swap_nodes(node_first, node_second):
-    new_node = deepcopy(node_second)
+    new_node = node_second.duplicate
     new_node.node_to = node_first.node_to
     node_first.node_to.nodes_from[node_first.node_to.nodes_from.index(node_first)] = new_node
     node_first = new_node

--- a/core/composer/node.py
+++ b/core/composer/node.py
@@ -7,6 +7,7 @@ from core.models.data import Data, InputData, OutputData
 from core.models.model import Model
 from core.models.model import sklearn_model_by_type
 from core.repository.model_types_repository import ModelTypesIdsEnum
+from copy import deepcopy, copy
 
 
 class Node(ABC):
@@ -52,6 +53,9 @@ class Node(ABC):
                 nodes += parent.subtree_nodes
         return nodes
 
+    @property
+    def duplicate(self)-> 'Node':
+        return node_duplicate(self)
 
 class CachedNodeResult:
     def __init__(self, node: Node, fitted_model):
@@ -186,3 +190,16 @@ def equivalent_subtree(root_of_tree_first: Node, root_of_tree_second: Node) -> L
     pairs_set = structural_equivalent_nodes(root_of_tree_first, root_of_tree_second)
     assert isinstance(pairs_set, list)
     return pairs_set
+
+
+def node_duplicate(any_node: Any) -> Any:
+    duplicate_node = deepcopy(any_node)
+
+    def update_node_id(node):
+        node.node_id = str(uuid.uuid4())
+        if isinstance(node, SecondaryNode):
+            [update_node_id(node_from) for node_from in node.nodes_from]
+
+    update_node_id(duplicate_node)
+
+    return duplicate_node

--- a/core/composer/optimisers/crossover.py
+++ b/core/composer/optimisers/crossover.py
@@ -1,5 +1,4 @@
 import random
-from copy import deepcopy
 from random import randint, choice
 from typing import (
     Any
@@ -10,12 +9,12 @@ from core.composer.gp_composer.gp_node import swap_nodes
 
 def standard_crossover(tree1: Any, tree2: Any, max_depth: int, crossover_prob: float = 0.8) -> Any:
     if tree1 is tree2 or random.random() > crossover_prob:
-        return deepcopy(tree1)
-    tree1_copy = deepcopy(tree1)
+        return tree1.duplicate
+    tree1_copy = tree1.duplicate
     random_layer_in_tree1 = randint(0, tree1_copy.depth - 1)
     random_layer_in_tree2 = randint(0, tree2.depth - 1)
     if random_layer_in_tree1 == 0 and random_layer_in_tree2 == 0:
-        return deepcopy(tree2)
+        return tree2.duplicate
 
     node_from_tree1 = choice(tree1_copy.nodes_from_height(random_layer_in_tree1))
     node_from_tree2 = choice(tree2.nodes_from_height(random_layer_in_tree2))

--- a/core/composer/optimisers/gp_optimiser.py
+++ b/core/composer/optimisers/gp_optimiser.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from random import choice, randint
 from typing import (
     List,
@@ -41,14 +40,14 @@ class GPChainOptimiser:
             for generation_num in range(self.requirements.num_of_generations-1):
                 print(f'GP generation num: {generation_num}')
                 best_ind_num = np.argmin(self.fitness)
-                self.best_individual = deepcopy(self.population[best_ind_num])
+                self.best_individual = self.population[best_ind_num].duplicate
                 self.best_fitness = self.fitness[best_ind_num]
                 selected_individuals = tournament_selection(self.fitness, self.population)
 
                 for ind_num in range(self.requirements.pop_size):
 
                     if ind_num == self.requirements.pop_size - 1:
-                        self.population[ind_num] = deepcopy(self.best_individual)
+                        self.population[ind_num] = self.best_individual.duplicate
                         self.fitness[ind_num] = self.best_fitness
                         history.append((self.population[ind_num], self.fitness[ind_num]))
                         break

--- a/core/composer/optimisers/mutation.py
+++ b/core/composer/optimisers/mutation.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from enum import Enum
 from random import random, choice
 from typing import Any
@@ -26,7 +25,7 @@ def standard_mutation(root_node: Any, secondary: Any, primary: Any,
                       node_mutate_type=MutationPowerEnum.mean) -> Any:
     if mutation_prob:
         if random() > mutation_prob:
-            return deepcopy(root_node)
+            return root_node.duplicate
 
     probability = get_mutation_prob(mut_id=node_mutate_type.value, root_node=root_node)
 
@@ -58,6 +57,6 @@ def random_mutation(root_node, probability, primary_node_func, secondary_node_fu
                         node.nodes_from[i].node_to = node
         return node
 
-    root_node_copy = deepcopy(root_node)
+    root_node_copy = root_node.duplicate
     root_node_copy = replace_node_to_random_recursive(node=root_node_copy)
     return root_node_copy

--- a/core/composer/optimisers/selection.py
+++ b/core/composer/optimisers/selection.py
@@ -6,7 +6,6 @@ from typing import (
 )
 
 import numpy as np
-from copy import deepcopy
 
 
 def random_selection(pop_size: int, group_size: int) -> List[int]:
@@ -23,6 +22,6 @@ def tournament_selection(fitness: List[float], population: List[Any], group_size
         for _ in range(num_of_parents):
             group = random_selection(len(fitness), group_size)
             num_of_chosen_ind = group[np.argmin([fitness[ind_num] for ind_num in group])]
-            choice_item.append(deepcopy(population[num_of_chosen_ind]))
+            choice_item.append(population[num_of_chosen_ind].duplicate)
         chosen.append(tuple(parent for parent in choice_item))
     return chosen

--- a/core/composer/visualisation.py
+++ b/core/composer/visualisation.py
@@ -37,7 +37,7 @@ class ComposerVisualiser:
         prev_fit = fitnesses[0]
 
         for ch_id, chain in enumerate(chains):
-            graph, node_labels = as_nx_graph(chain=deepcopy(chain))
+            graph, node_labels = as_nx_graph(chain=chain.duplicate)
             pos = node_positions(graph.to_undirected())
             plt.rcParams['axes.titlesize'] = 20
             plt.rcParams['axes.labelsize'] = 20
@@ -63,7 +63,7 @@ class ComposerVisualiser:
                 last_best_chain = chain
             prev_fit = fitnesses[ch_id]
 
-            best_graph, best_node_labels = as_nx_graph(chain=deepcopy(last_best_chain))
+            best_graph, best_node_labels = as_nx_graph(chain=last_best_chain.duplicate)
             pos = node_positions(best_graph.to_undirected())
             plt.rcParams['axes.titlesize'] = 20
             plt.rcParams['axes.labelsize'] = 20

--- a/test/test_chain_comparison.py
+++ b/test/test_chain_comparison.py
@@ -1,5 +1,4 @@
 import itertools
-from copy import deepcopy
 
 import pytest
 
@@ -91,7 +90,7 @@ def equality_cases():
 
     for node_num in ((2, 1), (1, 2)):
         old_node = pairs[2][1].root_node.nodes_from[node_num[0]]
-        new_node = deepcopy(pairs[2][0].root_node.nodes_from[node_num[1]])
+        new_node = pairs[2][0].root_node.nodes_from[node_num[1]].duplicate
         pairs[2][1].replace_node(old_node, new_node)
 
     return pairs

--- a/test/test_gp_node.py
+++ b/test/test_gp_node.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from core.composer.chain import Chain
 from core.composer.gp_composer.gp_node import GPNode
 from core.composer.gp_composer.gp_node import swap_nodes
@@ -9,7 +7,7 @@ from core.repository.model_types_repository import ModelTypesIdsEnum
 
 def tree_to_chain(tree_root: GPNode) -> Chain:
     chain = Chain()
-    nodes = flat_nodes_tree(deepcopy(tree_root))
+    nodes = flat_nodes_tree(tree_root.duplicate)
     for node in nodes:
         if node.nodes_from:
             for i in range(len(node.nodes_from)):


### PR DESCRIPTION
Была исправлена ошибка дублирования node_id  при создании копий деревьев при помощи deepcopy. 
Поскольку каждый объект Node имеет свой уникальный node_id, при использовании deepcopy для копирования узла, необходимо заменять node_id в узле который непосредственно копируется, а так же рекурсивно заменять node_id всех узлов в стоящем ниже поддереве. Если этого не делать, при копировании поддеревьев, например в скрещивании может произойти ситуация, что в каком-то из поколений, в популяции может попасться дерево с нодами, имеющими разные ссылки в памяти, но одинаковые id.
В связи с этим в такие классы как Node, GPNode и Сhain была добавлена функция duplicate, которую необходимо использовать всякий раз, когда нужно скопировать объекты этих типов.