### PR TITLE
Refactored preprocessing and PCA model

### DIFF
--- a/benchmark/test_cases/scoring/scoring_case.py
+++ b/benchmark/test_cases/scoring/scoring_case.py
@@ -12,7 +12,8 @@ if __name__ == '__main__':
                                                          task=TaskTypesEnum.classification,
                                                          target_name='default',
                                                          case_label='scoring'),
-                                  models=[BenchmarkModelTypesEnum.tpot,
+                                  models=[BenchmarkModelTypesEnum.baseline,
+                                          BenchmarkModelTypesEnum.tpot,
                                           BenchmarkModelTypesEnum.fedot],
                                   metric_list=['roc_auc', 'f1']).execute()
 

--- a/core/composer/node.py
+++ b/core/composer/node.py
@@ -1,10 +1,10 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections import namedtuple
 from copy import copy
 from datetime import timedelta
 from typing import (List, Optional)
 
-from core.models.data import Data, InputData, OutputData
+from core.models.data import InputData, OutputData
 from core.models.model import Model
 from core.models.preprocessing import *
 from core.models.transformation import transformation_function_for_data
@@ -15,11 +15,12 @@ CachedState = namedtuple('CachedState', 'preprocessor model')
 
 class Node(ABC):
 
-    def __init__(self, nodes_from: Optional[List['Node']], model: Model):
+    def __init__(self, nodes_from: Optional[List['Node']], model_type: str,
+                 with_preprocessing):
         self.nodes_from = nodes_from
-        self.model = model
+        self.model = Model(model_type=model_type)
         self.cache = FittedModelCache(self)
-        self.label = []
+        self.with_preprocessing = with_preprocessing
 
     @property
     def descriptive_id(self):
@@ -46,49 +47,87 @@ class Node(ABC):
     def model_tags(self) -> List[str]:
         return self.model.metadata.tags
 
-    @abstractmethod
-    def fit(self, input_data: InputData, verbose=False) -> OutputData:
-        raise NotImplementedError()
+    def output_from_prediction(self, input_data, prediction):
+        return OutputData(idx=input_data.idx,
+                          features=input_data.features,
+                          predict=prediction, task=input_data.task,
+                          data_type=self.model.output_datatype(input_data.data_type))
 
-    @abstractmethod
-    def predict(self, input_data: InputData, verbose=False) -> OutputData:
-        raise NotImplementedError()
-
-    def __str__(self):
-        model = f'{self.model}'
-        return model
-
-    def _fit_using_cache(self, input_data, with_preprocessing=True, verbose=False):
-
-        preprocessed_data = transformation_function_for_data(
+    def _transform(self, input_data: InputData):
+        transformed_data = transformation_function_for_data(
             input_data_type=input_data.data_type,
             required_data_types=self.model.metadata.input_types)(input_data)
+        return transformed_data
+
+    def _preprocess(self, data: InputData):
+        _preprocessing_for_types = {
+            DataTypesEnum.ts: DefaultStrategy,
+            DataTypesEnum.table: Scaling,
+            DataTypesEnum.ts_lagged_table: Scaling,
+            DataTypesEnum.ts_lagged_3d: LaggedTimeSeriesFeature3dStrategy,
+        }
+        strategy = _preprocessing_for_types[data.data_type]
+        if 'without_preprocessing' in self.model.metadata.tags:
+            strategy = DefaultStrategy
+
+        if not self.cache.actual_cached_state:
+            preprocessing_strategy = \
+                strategy().fit(data.features)
+            data.features = preprocessing_strategy.apply(data.features)
+        else:
+            preprocessing_strategy = self.cache.actual_cached_state.preprocessor
+            data.features = preprocessing_strategy.apply(data.features)
+
+        return data, preprocessing_strategy
+
+    def fit(self, input_data: InputData, verbose=False) -> OutputData:
+        transformed = self._transform(input_data)
+        preprocessed_data, preproc_strategy = self._preprocess(transformed)
 
         if not self.cache.actual_cached_state:
             if verbose:
                 print('Cache is not actual')
 
-            if with_preprocessing:
-                preprocessing_strategy = _preprocessing_strategy(preprocessed_data.data_type, self.model)().fit(
-                    preprocessed_data.features)
-                preprocessed_data.features = preprocessing_strategy.apply(preprocessed_data.features)
-            else:
-                preprocessing_strategy = None
-
             cached_model, model_predict = self.model.fit(data=preprocessed_data)
-            self.cache.append(CachedState(preprocessor=copy(preprocessing_strategy),
+            self.cache.append(CachedState(preprocessor=copy(preproc_strategy),
                                           model=cached_model))
         else:
             if verbose:
                 print('Model were obtained from cache')
 
-            if with_preprocessing:
-                preprocessing_strategy = self.cache.actual_cached_state.preprocessor
-                preprocessed_data.features = preprocessing_strategy.apply(preprocessed_data.features)
-
             model_predict = self.model.predict(fitted_model=self.cache.actual_cached_state.model,
                                                data=preprocessed_data)
-        return model_predict
+
+        return self.output_from_prediction(input_data, model_predict)
+
+    def predict(self, input_data: InputData, verbose=False) -> OutputData:
+        transformed = self._transform(input_data)
+        preprocessed_data, _ = self._preprocess(transformed)
+
+        if not self.cache:
+            raise ValueError('Model must be fitted before predict')
+
+        model_predict = self.model.predict(fitted_model=self.cache.actual_cached_state.model,
+                                           data=preprocessed_data)
+
+        return self.output_from_prediction(input_data, model_predict)
+
+    def fine_tune(self, input_data: InputData,
+                  max_lead_time: timedelta = timedelta(minutes=5), iterations: int = 30):
+
+        transformed = self._transform(input_data)
+        preprocessed_data, preproc_strategy = self._preprocess(transformed)
+
+        fitted_model, _ = self.model.fine_tune(preprocessed_data,
+                                               max_lead_time=max_lead_time,
+                                               iterations=iterations)
+
+        self.cache.append(CachedState(preprocessor=copy(preproc_strategy),
+                                      model=fitted_model))
+
+    def __str__(self):
+        model = f'{self.model}'
+        return model
 
     @property
     def ordered_subnodes_hierarchy(self) -> List['Node']:
@@ -97,9 +136,6 @@ class Node(ABC):
             for parent in self.nodes_from:
                 nodes += parent.ordered_subnodes_hierarchy
         return nodes
-
-    def fine_tune(self, input_data: InputData, max_lead_time: timedelta = timedelta(minutes=5), iterations: int = 30):
-        raise NotImplementedError()
 
     @property
     def custom_params(self) -> dict:
@@ -150,82 +186,39 @@ class SharedCache(FittedModelCache):
         return found_model
 
 
-def _preprocessing_strategy(dataset_type: DataTypesEnum, model: Model):
-    _preprocessing_for_tasks = {
-        DataTypesEnum.ts: DefaultStrategy,
-        DataTypesEnum.table: Scaling,
-        DataTypesEnum.ts_lagged_table: Scaling,
-        DataTypesEnum.ts_lagged_3d: LaggedTimeSeriesFeature3dStrategy,
-    }
-    if 'without_preprocessing' not in model.metadata.tags:
-        return _preprocessing_for_tasks[dataset_type]
-    else:
-        return DefaultStrategy
-
-
 class PrimaryNode(Node):
     def __init__(self, model_type: str):
-        model = Model(model_type=model_type)
-        super().__init__(nodes_from=None, model=model)
+        super().__init__(nodes_from=None, model_type=model_type, with_preprocessing=True)
 
     def fit(self, input_data: InputData, verbose=False) -> OutputData:
         if verbose:
             print(f'Trying to fit primary node with model: {self.model}')
 
-        model_predict = self._fit_using_cache(input_data=input_data, verbose=verbose)
-
-        return OutputData(idx=input_data.idx,
-                          features=input_data.features,
-                          predict=model_predict, task=input_data.task,
-                          data_type=self.model.output_datatype(input_data.data_type))
+        return super().fit(input_data, verbose)
 
     def predict(self, input_data: InputData, verbose=False) -> OutputData:
         if verbose:
             print(f'Predict in primary node by model: {self.model}')
-        if not self.cache:
-            raise ValueError('Model must be fitted before predict')
 
-        preprocessed_data = transformation_function_for_data(input_data.data_type,
-                                                             self.model.metadata.input_types)(input_data)
-
-        preprocessed_data.features = self.cache.actual_cached_state.preprocessor.apply(preprocessed_data.features)
-
-        predict_train = self.model.predict(fitted_model=self.cache.actual_cached_state.model,
-                                           data=preprocessed_data)
-        return OutputData(idx=input_data.idx,
-                          features=input_data.features,
-                          predict=predict_train, task=input_data.task,
-                          data_type=self.model.output_datatype(input_data.data_type))
-
-    def fine_tune(self, input_data: InputData,
-                  max_lead_time: timedelta = timedelta(minutes=5), iterations: int = 30):
-        preprocessed_data = transformation_function_for_data(input_data.data_type,
-                                                             self.model.metadata.input_types)(input_data)
-
-        preprocessing_strategy = _preprocessing_strategy(preprocessed_data.data_type, self.model)().fit(
-            preprocessed_data.features)
-        preprocessed_data.features = preprocessing_strategy.apply(preprocessed_data.features)
-
-        fitted_model, predict_train = self.model.fine_tune(preprocessed_data,
-                                                           max_lead_time=max_lead_time,
-                                                           iterations=iterations)
-        self.cache.append(CachedState(preprocessor=copy(preprocessing_strategy),
-                                      model=fitted_model))
+        return super().predict(input_data, verbose)
 
 
 class SecondaryNode(Node):
     def __init__(self, model_type: str, nodes_from: Optional[List['Node']] = None):
-        model = Model(model_type=model_type)
         nodes_from = [] if nodes_from is None else nodes_from
-        super().__init__(nodes_from=nodes_from, model=model)
+        super().__init__(nodes_from=nodes_from, model_type=model_type, with_preprocessing=False)
 
     def _nodes_from_with_fixed_order(self):
         if self.nodes_from is not None:
             return sorted(self.nodes_from, key=lambda node: node.descriptive_id)
 
-    def fit(self, input_data: InputData, verbose=False) -> OutputData:
+    def _input_from_parents(self, input_data: InputData,
+                            parent_operation: str,
+                            max_tune_time: Optional[timedelta] = None,
+                            verbose=False) -> InputData:
         if len(self.nodes_from) == 0:
             raise ValueError()
+
         parent_results = []
 
         if verbose:
@@ -234,11 +227,16 @@ class SecondaryNode(Node):
         target = input_data.target
         parent_nodes = self._nodes_from_with_fixed_order()
 
-        are_nodes_affect_target = ['affects_target' in parent_node.model_tags for parent_node in parent_nodes]
-        if any(are_nodes_affect_target):
+        are_prev_nodes_affect_target = ['affects_target' in parent_node.model_tags for parent_node in parent_nodes]
+        if any(are_prev_nodes_affect_target):
             if len(parent_nodes) == 1:
                 # is the previous model is the model that changes target
-                parent_result = parent_nodes[0].fit(input_data=input_data)
+                if parent_operation == 'predict':
+                    parent_result = parent_nodes[0].predict(input_data=input_data)
+                elif parent_operation == 'fit' or parent_operation == 'fine_tune':
+                    parent_result = parent_nodes[0].fit(input_data=input_data)
+                else:
+                    raise NotImplementedError()
                 target = parent_result.predict
 
                 parent_results.append(parent_result)
@@ -247,81 +245,49 @@ class SecondaryNode(Node):
 
         else:
             for parent in parent_nodes:
-                parent_results.append(parent.fit(input_data=input_data))
+                if parent_operation == 'predict':
+                    parent_results.append(parent.predict(input_data=input_data))
+                elif parent_operation == 'fit':
+                    parent_results.append(parent.fit(input_data=input_data))
+                elif parent_operation == 'fine_tune':
+                    parent.fine_tune(input_data=input_data, max_lead_time=max_tune_time)
+                    parent_results.append(parent.predict(input_data=input_data))
+                else:
+                    raise NotImplementedError()
+        secondary_input = InputData.from_predictions(outputs=parent_results,
+                                                     target=target)
 
-        secondary_input = Data.from_predictions(outputs=parent_results,
-                                                target=target)
+        return secondary_input
+
+    def fit(self, input_data: InputData, verbose=False) -> OutputData:
         if verbose:
             print(f'Trying to fit secondary node with model: {self.model}')
 
-        model_predict = self._fit_using_cache(input_data=secondary_input, with_preprocessing=False)
-
-        return OutputData(idx=input_data.idx,
-                          features=input_data.features,
-                          predict=model_predict,
-                          task=input_data.task,
-                          data_type=self.model.output_datatype(input_data.data_type))
+        secondary_input = self._input_from_parents(input_data=input_data,
+                                                   parent_operation='fit',
+                                                   verbose=verbose)
+        return super().fit(input_data=secondary_input)
 
     def predict(self, input_data: InputData, verbose=False) -> OutputData:
-        if len(self.nodes_from) == 0:
-            raise ValueError('')
-        parent_results = []
-        if verbose:
-            print(f'Obtain predictions from all parent nodes: {self.model}')
-        parent_nodes = self._nodes_from_with_fixed_order()
-        target = input_data.target
-
-        # TODO refactor
-        if any(['affects_target' in parent_node.model_tags for parent_node in parent_nodes]):
-            if len(parent_nodes) == 1:
-                # is the previous model is the model that changes target
-                parent_result = parent_nodes[0].predict(input_data=input_data)
-                target = parent_result.predict
-
-                parent_results.append(parent_result)
-            else:
-                raise NotImplementedError()
-
-        else:
-            for parent in parent_nodes:
-                parent_results.append(parent.predict(input_data=input_data))
-
-        secondary_input = Data.from_predictions(outputs=parent_results,
-                                                target=target)
         if verbose:
             print(f'Obtain prediction in secondary node with model: {self.model}')
 
-        preprocessed_data = transformation_function_for_data(input_data.data_type,
-                                                             self.model.metadata.input_types)(secondary_input)
+        secondary_input = self._input_from_parents(input_data=input_data,
+                                                   parent_operation='predict',
+                                                   verbose=verbose)
 
-        evaluation_result = self.model.predict(fitted_model=self.cache.actual_cached_state.model,
-                                               data=preprocessed_data)
-        return OutputData(idx=input_data.idx,
-                          features=input_data.features,
-                          predict=evaluation_result,
-                          data_type=self.model.output_datatype(input_data.data_type),
-                          task=input_data.task)
+        return super().predict(input_data=secondary_input)
 
     def fine_tune(self, input_data: InputData,
                   max_lead_time: timedelta = timedelta(minutes=5), iterations: int = 30,
                   verbose: bool = False):
-        parent_results = []
-
         if verbose:
             print(f'Tune all parent nodes in secondary node with model: {self.model}')
 
-        target = input_data.target
-        for parent in self._nodes_from_with_fixed_order():
-            parent.fine_tune(input_data=input_data, max_lead_time=max_lead_time)
-            parent_results.append(parent.predict(input_data=input_data))
+        secondary_input = self._input_from_parents(input_data=input_data,
+                                                   parent_operation='fine_tune',
+                                                   max_tune_time=max_lead_time, verbose=verbose)
 
-        secondary_input = Data.from_predictions(outputs=parent_results,
-                                                target=target)
+        return super().fine_tune(input_data=secondary_input)
 
-        preprocessed_data = transformation_function_for_data(input_data.data_type,
-                                                             self.model.metadata.input_types)(secondary_input)
-
-        fitted_model, predict_train = self.model.fine_tune(preprocessed_data, iterations=iterations,
-                                                           max_lead_time=max_lead_time)
-        self.cache.append(CachedState(preprocessor=None,
-                                      model=fitted_model))
+# class DataNode(PrimaryNode):

--- a/core/models/data.py
+++ b/core/models/data.py
@@ -33,6 +33,18 @@ class Data:
             target = None
         return InputData(idx=idx, features=features, target=target, task=task, data_type=data_type)
 
+
+@dataclass
+class InputData(Data):
+    target: np.array = None
+
+    @property
+    def num_classes(self):
+        if self.task.task_type == TaskTypesEnum.classification:
+            return len(np.unique(self.target))
+        else:
+            return None
+
     @staticmethod
     def from_predictions(outputs: List['OutputData'], target: np.array):
         if len(set([output.data_type for output in outputs])) > 1:
@@ -57,21 +69,8 @@ class Data:
 
 
 @dataclass
-class InputData(Data):
-    target: np.array = None
-
-    @property
-    def num_classes(self):
-        if self.task.task_type == TaskTypesEnum.classification:
-            return len(np.unique(self.target))
-        else:
-            return None
-
-
-@dataclass
 class OutputData(Data):
     predict: np.array = None
-
 
 def split_train_test(data, split_ratio=0.8, with_shuffle=False):
     if with_shuffle:

--- a/core/models/data.py
+++ b/core/models/data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -39,7 +39,7 @@ class InputData(Data):
     target: np.array = None
 
     @property
-    def num_classes(self):
+    def num_classes(self) -> Optional[int]:
         if self.task.task_type == TaskTypesEnum.classification:
             return len(np.unique(self.target))
         else:
@@ -71,6 +71,7 @@ class InputData(Data):
 @dataclass
 class OutputData(Data):
     predict: np.array = None
+
 
 def split_train_test(data, split_ratio=0.8, with_shuffle=False):
     if with_shuffle:

--- a/core/models/evaluation/automl_eval.py
+++ b/core/models/evaluation/automl_eval.py
@@ -1,4 +1,6 @@
 import gc
+from datetime import timedelta
+from typing import Optional
 
 import h2o
 import numpy as np
@@ -9,7 +11,6 @@ from tpot import TPOTClassifier, TPOTRegressor
 from core.models.data import InputData
 from core.models.evaluation.evaluation import EvaluationStrategy
 from core.repository.tasks import TaskTypesEnum
-from datetime import timedelta
 
 
 def fit_tpot(data: InputData, max_run_time_min: int):
@@ -137,10 +138,15 @@ class AutoMLEvaluationStrategy(EvaluationStrategy):
         'h2o': (fit_h2o, predict_h2o)
     }
 
-    def __init__(self, model_type: 'str'):
+    def __init__(self, model_type: str, params: Optional[dict] = None):
         self._model_specific_fit, self._model_specific_predict = \
             self._init_benchmark_model_functions(model_type)
+
         self.max_time_min = 5
+        if params:
+            self.max_time_min = params.get('max_run_time_sec', self.max_time_min * 60) / 60
+
+        super().__init__(model_type, params)
 
     def _init_benchmark_model_functions(self, model_type):
         if model_type in self._model_functions_by_type.keys():

--- a/core/models/evaluation/data_evaluation.py
+++ b/core/models/evaluation/data_evaluation.py
@@ -8,8 +8,8 @@ from statsmodels.tsa.seasonal import seasonal_decompose
 from core.models.data import InputData
 from core.models.evaluation.evaluation import EvaluationStrategy
 
-DEFAULT_DIM_REDUCTION_EXPLAINED_VARIANCE_THR = 0.9
-DEFAULT_DIM_REDUCTION_MIN_EXPLAINED_VARIANCE = 0.01
+DEFAULT_EXPLAINED_VARIANCE_THR = 0.9
+DEFAULT_MIN_EXPLAINED_VARIANCE = 0.01
 
 
 def _estimate_period(variable):
@@ -72,21 +72,19 @@ def fit_pca(train_data: InputData, params: Optional[dict]):
 
     cum_variance = np.cumsum(pca.explained_variance_ratio_)
 
-    dim_reduction_explained_variance_thr = DEFAULT_DIM_REDUCTION_EXPLAINED_VARIANCE_THR
-    dim_reduction_min_explained_variance = DEFAULT_DIM_REDUCTION_MIN_EXPLAINED_VARIANCE
+    explained_variance_thr = DEFAULT_EXPLAINED_VARIANCE_THR
+    min_explained_variance = DEFAULT_MIN_EXPLAINED_VARIANCE
 
     if params:
-        dim_reduction_explained_variance_thr = params.get('dim_reduction_expl_thr',
-                                                          dim_reduction_explained_variance_thr)
-        dim_reduction_min_explained_variance = params.get('dim_reduction_min_expl',
-                                                          dim_reduction_min_explained_variance)
+        explained_variance_thr = params.get('dim_reduction_expl_thr', explained_variance_thr)
+        min_explained_variance = params.get('dim_reduction_min_expl', min_explained_variance)
 
-    components_before_thr = np.where(cum_variance > dim_reduction_explained_variance_thr)[0]
+    components_before_thr = np.where(cum_variance > explained_variance_thr)[0]
 
     last_ind_cum = min(components_before_thr) if len(components_before_thr) > 0 else 1
 
     significant_components = \
-        np.where(pca.explained_variance_ratio_ < dim_reduction_min_explained_variance)[0]
+        np.where(pca.explained_variance_ratio_ < min_explained_variance)[0]
 
     last_ind = min(significant_components) if len(significant_components) > 0 else 1
 

--- a/core/models/evaluation/data_evaluation.py
+++ b/core/models/evaluation/data_evaluation.py
@@ -1,23 +1,26 @@
+from copy import copy
+
 import numpy as np
 from scipy import signal
+from sklearn.decomposition import PCA
 from statsmodels.tsa.seasonal import seasonal_decompose
 
 from core.models.data import InputData
 from core.models.evaluation.evaluation import EvaluationStrategy
 
 
-def get_data(predict_data: InputData):
+def get_data(trained_model, predict_data: InputData):
     return predict_data.features
 
 
-def get_difference(predict_data: InputData):
+def get_difference(trained_model, predict_data: InputData):
     number_of_inputs = predict_data.features.shape[1]
     if number_of_inputs != 1:
         raise ValueError('Too many inputs for the differential model')
     return predict_data.features[:, 0] - predict_data.target
 
 
-def get_sum(predict_data: InputData):
+def get_sum(trained_model, predict_data: InputData):
     if predict_data.features.shape[1] != 2:
         raise ValueError('Wrong number of inputs for the additive model')
     return np.sum(predict_data.features, axis=1)
@@ -32,37 +35,58 @@ def _estimate_period(variable):
     return period
 
 
-def get_trend(predict_data: InputData):
+def get_trend(trained_model, predict_data: InputData):
     target = predict_data.target
     period = _estimate_period(target)
     decomposed_target = seasonal_decompose(target, period=period, extrapolate_trend='freq')
     return decomposed_target.trend
 
 
-def get_residual(predict_data: InputData):
-    target_trend = get_trend(predict_data)
+def get_residual(trained_model, predict_data: InputData):
+    target_trend = get_trend(trained_model, predict_data)
     target_residual = predict_data.target - target_trend
     return target_residual
 
 
+def fit_pca(predict_data: InputData):
+    pca = PCA(svd_solver='randomized', iterated_power='auto')
+    pca.fit(predict_data.features)
+    return pca
+
+
+def predict_pca(pca_model, predict_data: InputData):
+    variance_cum_thr = 0.7
+    variance_ind_thr = 0.01
+
+    cum_variance = np.cumsum(pca_model.explained_variance_ratio_)
+    last_ind_cum = min(np.where(cum_variance > variance_cum_thr)[0])
+    last_ind = min(np.where(pca_model.explained_variance_ratio_ < variance_ind_thr)[0])
+
+    return pca_model.transform(predict_data.features)[:, :min(last_ind, last_ind_cum)]
+
+
 class DataModellingStrategy(EvaluationStrategy):
     _model_functions_by_type = {
-        'direct_data_model': get_data,
-        'diff_data_model': get_difference,
-        'additive_data_model': get_sum,
-        'trend_data_model': get_trend,
-        'residual_data_model': get_residual
+        'direct_data_model': (None, get_data),
+        'diff_data_model': (None, get_difference),
+        'additive_data_model': (None, get_sum),
+        'trend_data_model': (None, get_trend),
+        'residual_data_model': (None, get_residual),
+        'pca_data_model': (fit_pca, predict_pca)
     }
 
     def __init__(self, model_type: str):
-        self._model_specific_predict = self._model_functions_by_type[model_type]
+        self._model_specific_fit = self._model_functions_by_type[model_type][0]
+        self._model_specific_predict = self._model_functions_by_type[model_type][1]
 
     def fit(self, train_data: InputData):
-        # fit is not necessary for data models
-        return None
+        if not self._model_specific_fit:
+            return None
+        else:
+            return self._model_specific_fit(train_data)
 
     def predict(self, trained_model, predict_data: InputData):
-        return self._model_specific_predict(predict_data)
+        return self._model_specific_predict(trained_model, predict_data)
 
-    def fit_tuned(self, train_data: InputData, iterations: int = 30):
+    def fit_tuned(self, **args):
         return None, None

--- a/core/models/evaluation/evaluation.py
+++ b/core/models/evaluation/evaluation.py
@@ -34,6 +34,10 @@ warnings.filterwarnings("ignore", category=UserWarning)
 
 
 class EvaluationStrategy:
+    def __init__(self, model_type: str, params: Optional[dict] = None):
+        self.params_for_fit = params
+        self.model_type = model_type
+
     @abstractmethod
     def fit(self, train_data: InputData):
         raise NotImplementedError()
@@ -83,11 +87,10 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
         'regression': make_scorer(mean_squared_error, greater_is_better=False),
     }
 
-    def __init__(self, model_type: str):
+    def __init__(self, model_type: str, params: Optional[dict] = None):
         self._sklearn_model_impl = self._convert_to_sklearn(model_type)
         self._tune_strategy: SklearnTuner = Optional[SklearnTuner]
-        self.params_for_fit = None
-        self.model_type = model_type
+        super().__init__(model_type, params)
 
     def fit(self, train_data: InputData):
         warnings.filterwarnings("ignore", category=RuntimeWarning)

--- a/core/models/evaluation/hyperparams.py
+++ b/core/models/evaluation/hyperparams.py
@@ -78,5 +78,4 @@ params_range_by_model = {
         'min_samples_leaf': range(1, 21),
         'bootstrap': [True, False]
     }
-
 }

--- a/core/models/evaluation/keras_eval.py
+++ b/core/models/evaluation/keras_eval.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Optional
 
 import numpy as np
 import tensorflow as tf
@@ -12,9 +13,14 @@ forecast_length = 1
 
 # TODO inherit this and similar from custom strategy
 class KerasForecastingStrategy(EvaluationStrategy):
-    def __init__(self, model_type: str):
+    def __init__(self, model_type: str, params: Optional[dict] = None):
         self._init_lstm_model_functions(model_type)
+
         self.epochs = 10
+        if params:
+            self.epochs = params.get('epochs', self.epochs)
+
+        super().__init__(model_type, params)
 
     def _init_lstm_model_functions(self, model_type):
         if model_type != 'lstm':

--- a/core/models/evaluation/keras_eval.py
+++ b/core/models/evaluation/keras_eval.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import numpy as np
 import tensorflow as tf
 
@@ -10,7 +12,6 @@ forecast_length = 1
 
 # TODO inherit this and similar from custom strategy
 class KerasForecastingStrategy(EvaluationStrategy):
-
     def __init__(self, model_type: str):
         self._init_lstm_model_functions(model_type)
         self.epochs = 10
@@ -26,7 +27,8 @@ class KerasForecastingStrategy(EvaluationStrategy):
     def predict(self, trained_model, predict_data: InputData):
         return predict_lstm(trained_model, predict_data)
 
-    def fit_tuned(self, train_data: InputData, iterations: int = 30):
+    def fit_tuned(self, train_data: InputData, iterations: int,
+                  max_lead_time: timedelta = timedelta(minutes=5)):
         raise NotImplementedError()
 
 

--- a/core/models/evaluation/stats_models_eval.py
+++ b/core/models/evaluation/stats_models_eval.py
@@ -1,3 +1,6 @@
+from datetime import timedelta
+from typing import Optional
+
 import numpy as np
 from statsmodels.tsa.ar_model import AutoReg
 from statsmodels.tsa.arima_model import ARIMA
@@ -5,7 +8,7 @@ from statsmodels.tsa.arima_model import ARIMA
 from core.models.data import InputData, OutputData
 from core.models.evaluation.evaluation import EvaluationStrategy
 from core.models.tuners import ForecastingCustomRandomTuner
-from datetime import timedelta
+
 
 def fit_ar(train_data: InputData, params):
     return AutoReg(train_data.target, **params,
@@ -73,12 +76,12 @@ class StatsModelsForecastingStrategy(EvaluationStrategy):
         'ar': {'lags': (range(1, 6), range(6, 96, 6))}
     }
 
-    def __init__(self, model_type: str):
+    def __init__(self, model_type: str, params: Optional[dict] = None):
         self._model_specific_fit, self._model_specific_predict = self._init_stats_model_functions(model_type)
         self._params_range = self.__params_range_by_model[model_type]
         self._default_params = self.__default_params_by_model[model_type]
 
-        self.params_for_fit = None
+        super().__init__(model_type, params)
 
     def _init_stats_model_functions(self, model_type: str):
         if model_type in self.__model_functions_by_types.keys():

--- a/core/repository/data/model_repository.json
+++ b/core/repository/data/model_repository.json
@@ -67,6 +67,14 @@
 	  "tags": ["without_preprocessing"],
 	  "description": "Implementations of the models for the data modification during time series forecasting"
 	},
+	"dim_red_data_model": {
+	  "tasks": "[TaskTypesEnum.classification, TaskTypesEnum.regression]",
+	  "input_type": "[DataTypesEnum.table]",
+	  "output_type": "[DataTypesEnum.table]",
+	  "strategies": ["core.models.evaluation.data_evaluation", "DataModellingStrategy"],
+	  "tags": ["without_preprocessing", "data_model"],
+	  "description": "Implementations of the models for the feature preprocessing (dimensionality reduction, etc)"
+	},
 	"keras_forecasting": {
 	  "tasks": "[TaskTypesEnum.ts_forecasting]",
 	  "input_type": "[DataTypesEnum.ts_lagged_3d]",
@@ -193,6 +201,10 @@
 	"residual_data_model": {
 	  "meta": "ts_data_model",
 	  "tags": ["affects_target", "decomposition"]
+	},
+	"pca_data_model": {
+	  "meta": "dim_red_data_model",
+	  "tags": ["linear"]
 	},
 	"lstm": {
 	  "meta": "keras_forecasting",

--- a/examples/chain_from_automl.py
+++ b/examples/chain_from_automl.py
@@ -17,7 +17,7 @@ def run_chain_from_automl(train_file_path: str, test_file_path: str,
 
     chain = Chain()
     node_tpot = PrimaryNode('tpot')
-    node_tpot.model.external_params = {'max_run_time_sec': max_run_time.seconds}
+    node_tpot.model.params = {'max_run_time_sec': max_run_time.seconds}
 
     node_lda = PrimaryNode('lda')
     node_rf = SecondaryNode('rf')

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ scikit_learn==0.22.1
 matplotlib==3.0.2
 networkx==2.4
 xgboost==1.0.1
-Pillow==7.0.0
+Pillow==7.1.0
 imageio==2.8.0
 pydot==1.4.1
 pmlb==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tpot==0.11.1
 h2o==3.28.1.2
 statsmodels==0.11.1
 pandas==1.0.1
-dataclasses==0.7
+dataclasses==0.7; python_version < '3.7'
 ete3==3.1.1
 numpy==1.18.0
 pytest==5.2.0

--- a/test/test_classification.py
+++ b/test/test_classification.py
@@ -10,7 +10,7 @@ from core.repository.tasks import Task, TaskTypesEnum
 from test.test_model import classification_dataset_with_redunant_features
 
 
-def compose_chain() -> Chain:
+def chain_simple() -> Chain:
     node_first = PrimaryNode('svc')
     node_second = PrimaryNode('lda')
     node_final = SecondaryNode('rf', nodes_from=[node_first, node_second])
@@ -20,7 +20,7 @@ def compose_chain() -> Chain:
     return chain
 
 
-def compose_chain_pca() -> Chain:
+def chain_with_pca() -> Chain:
     node_first = PrimaryNode('pca_data_model')
     node_second = PrimaryNode('lda')
     node_final = SecondaryNode('rf', nodes_from=[node_first, node_second])
@@ -42,7 +42,7 @@ def get_iris_data() -> InputData:
 
 def test_multiclassification_chain_fit_correct():
     data = get_iris_data()
-    chain = compose_chain()
+    chain = chain_simple()
     train_data, test_data = train_test_data_setup(data, shuffle_flag=True)
 
     chain.fit(input_data=train_data)
@@ -58,8 +58,8 @@ def test_multiclassification_chain_fit_correct():
 
 def test_classification_with_pca_chain_fit_correct():
     data = classification_dataset_with_redunant_features()
-    chain_pca = compose_chain_pca()
-    chain = compose_chain()
+    chain_pca = chain_with_pca()
+    chain = chain_simple()
 
     train_data, test_data = train_test_data_setup(data, shuffle_flag=True)
 

--- a/test/test_classification.py
+++ b/test/test_classification.py
@@ -7,18 +7,25 @@ from core.composer.node import PrimaryNode, SecondaryNode
 from core.models.data import InputData, train_test_data_setup
 from core.repository.dataset_types import DataTypesEnum
 from core.repository.tasks import Task, TaskTypesEnum
+from test.test_model import classification_dataset_with_redunant_features
 
 
 def compose_chain() -> Chain:
-    chain = Chain()
     node_first = PrimaryNode('svc')
     node_second = PrimaryNode('lda')
-    node_third = SecondaryNode('rf')
+    node_final = SecondaryNode('rf', nodes_from=[node_first, node_second])
 
-    node_third.nodes_from.append(node_first)
-    node_third.nodes_from.append(node_second)
+    chain = Chain(node_final)
 
-    chain.add_node(node_third)
+    return chain
+
+
+def compose_chain_pca() -> Chain:
+    node_first = PrimaryNode('pca_data_model')
+    node_second = PrimaryNode('lda')
+    node_final = SecondaryNode('rf', nodes_from=[node_first, node_second])
+
+    chain = Chain(node_final)
 
     return chain
 
@@ -47,3 +54,29 @@ def test_multiclassification_chain_fit_correct():
                               average='macro')
 
     assert roc_auc_on_test > 0.95
+
+
+def test_classification_with_pca_chain_fit_correct():
+    data = classification_dataset_with_redunant_features()
+    chain_pca = compose_chain_pca()
+    chain = compose_chain()
+
+    train_data, test_data = train_test_data_setup(data, shuffle_flag=True)
+
+    chain.fit(input_data=train_data)
+    chain_pca.fit(input_data=train_data)
+
+    results = chain.predict(input_data=test_data)
+    results_pca = chain_pca.predict(input_data=test_data)
+
+    roc_auc_on_test = roc_auc(y_true=test_data.target,
+                              y_score=results.predict,
+                              multi_class='ovo',
+                              average='macro')
+
+    roc_auc_on_test_pca = roc_auc(y_true=test_data.target,
+                                  y_score=results_pca.predict,
+                                  multi_class='ovo',
+                                  average='macro')
+
+    assert roc_auc_on_test_pca > roc_auc_on_test > 0.5

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from core.models.data import Data, InputData, OutputData
+from core.models.data import InputData, OutputData
 from core.repository.dataset_types import DataTypesEnum
 from core.repository.tasks import Task, TaskTypesEnum
 
@@ -49,8 +49,8 @@ def test_data_from_predictions(output_dataset):
     data_2 = output_dataset
     data_3 = output_dataset
     target = output_dataset.predict
-    new_input_data = Data.from_predictions(outputs=[data_1, data_2, data_3],
-                                           target=target)
+    new_input_data = InputData.from_predictions(outputs=[data_1, data_2, data_3],
+                                                target=target)
     assert new_input_data.features.all() == np.array(
         [data_1.predict, data_2.predict, data_3.predict]).all()
 

--- a/test/test_forecasting.py
+++ b/test/test_forecasting.py
@@ -43,7 +43,7 @@ def get_decomposed_chain(model_trend='lstm', model_residual='ridge'):
 
     if model_trend == 'lstm':
         # decrease the number of epochs to fit
-        node_first_trend.model.external_params = {model_trend: 1}
+        node_first_trend.model.params = {'epochs': 1}
 
     node_residual = PrimaryNode('residual_data_model')
     node_model_residual = SecondaryNode(model_residual,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from sklearn.datasets import make_classification
 from sklearn.metrics import roc_auc_score as roc_auc
 
 from core.models.data import InputData, train_test_data_setup
@@ -41,6 +42,20 @@ def classification_dataset():
                      data_type=DataTypesEnum.table)
 
     return data
+
+
+def classification_dataset_with_redunant_features(
+        n_samples=1000, n_features=100, n_informative=5) -> InputData:
+    synthetic_data = make_classification(n_samples=n_samples,
+                                         n_features=n_features,
+                                         n_informative=n_informative)
+
+    input_data = InputData(idx=np.arange(0, len(synthetic_data[1])),
+                           features=synthetic_data[0],
+                           target=synthetic_data[1],
+                           task=Task(TaskTypesEnum.classification),
+                           data_type=DataTypesEnum.table)
+    return input_data
 
 
 def test_log_regression_fit_correct(classification_dataset):
@@ -144,3 +159,15 @@ def test_svc_fit_correct(data_fixture, request):
     roc_on_train = get_roc_auc(train_data, train_predicted)
     roc_threshold = 0.95
     assert roc_on_train >= roc_threshold
+
+
+def test_pca_datamodel():
+    n_informative = 5
+    data = classification_dataset_with_redunant_features(n_samples=1000, n_features=100,
+                                                         n_informative=n_informative)
+    train_data, test_data = train_test_data_setup(data=data)
+
+    pca = Model(model_type='pca_data_model')
+    _, train_predicted = pca.fit(data=train_data)
+
+    assert train_predicted.shape[1] < data.features.shape[1]

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -161,7 +161,7 @@ def test_svc_fit_correct(data_fixture, request):
     assert roc_on_train >= roc_threshold
 
 
-def test_pca_datamodel():
+def test_pca_model_removes_redunant_features_correct():
     n_informative = 5
     data = classification_dataset_with_redunant_features(n_samples=1000, n_features=100,
                                                          n_informative=n_informative)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -5,8 +5,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, classification_report
 
 from core.composer.node import PrimaryNode
-from core.models.data import (
-    InputData, train_test_data_setup)
+from core.models.data import InputData, train_test_data_setup
 from core.models.model import Model
 from core.repository.dataset_types import DataTypesEnum
 from core.repository.tasks import Task, TaskTypesEnum

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+from sklearn.datasets import load_iris
+
+from core.composer.node import PrimaryNode
+from core.models.data import InputData
+from core.models.preprocessing import Normalization
+from core.repository.dataset_types import DataTypesEnum
+from core.repository.tasks import Task, TaskTypesEnum
+
+
+@pytest.fixture()
+def data_setup() -> InputData:
+    predictors, response = load_iris(return_X_y=True)
+    np.random.seed(1)
+    np.random.shuffle(predictors)
+    np.random.shuffle(response)
+    predictors = predictors[:100]
+    response = response[:100]
+    data = InputData(features=predictors, target=response, idx=np.arange(0, 100),
+                     task=Task(TaskTypesEnum.classification),
+                     data_type=DataTypesEnum.table)
+    return data
+
+
+def test_node_with_manual_preprocessing_has_correct_behaviour_and_attributes(data_setup):
+    model_type = 'logit'
+
+    node_default = PrimaryNode(model_type=model_type)
+    node_manual = PrimaryNode(model_type=model_type, manual_preprocessing_func=Normalization)
+
+    default_node_prediction = node_default.fit(data_setup)
+    manual_node_prediction = node_manual.fit(data_setup)
+
+    assert node_manual.manual_preprocessing_func is not None
+    assert node_default.manual_preprocessing_func != node_manual.manual_preprocessing_func
+
+    assert not np.array_equal(default_node_prediction.predict, manual_node_prediction.predict)
+
+    assert node_manual.descriptive_id == '/n_logit_default_params_custom_preprocessing=Normalization'


### PR DESCRIPTION
Накидал небольшие изменения по преобразованию features.

1. Сократил число дублирующегося кода в nodes. Кмк стало компактнее и удобнее, вроде ничего в процессе не сломалось. Порядок блоков остался прежний:

![image](https://user-images.githubusercontent.com/5711814/87851540-5fa52f00-c902-11ea-9457-c73c303869f8.png)

Transformer осуществляет преобразование форматов данных, preprocess - изменяет их "масштаб" через скейлинг/нормализацию и т.п.

2. Сделал возможность задавать тип препроцессинга в ноде "снаружи" - через поле manual_preprocessing_func.
Как минимум, пригодится для генерации бенчмарков, там с этим были проблемы.

3. Добавил реализацию модели-PCA, которая снижает размерность данных. Обильно не тестировал, но на примере в test_classifications.py внедрение PCA в цепочку даёт повышение качества.
Предлагаю пока использовать эту реализацию (добавив ещё несколько подобных моделей) для экспериментального определения необходимости такого рода подходов (снижения размерности и т.д.)

Алсо, посмотрел как это сделано в TPOT-е:
https://github.com/EpistasisLab/tpot/blob/master/tpot/builtins/feature_transformers.py
Там для непрерывных величин возможно PCA преобразование, для категориальных - onehot. Других опций вроде не вижу, мб в других файлах что-то есть.