### PR TITLE
Fix Pillow security issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ scikit_learn==0.22.1
 matplotlib==3.0.2
 networkx==2.4
 xgboost==1.0.1
-Pillow>=7.1.0
+Pillow==7.1.0
 imageio==2.8.0
 pydot==1.4.1
 pmlb==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ scikit_learn==0.22.1
 matplotlib==3.0.2
 networkx==2.4
 xgboost==1.0.1
-Pillow==7.0.0
+Pillow>=7.1.0
 imageio==2.8.0
 pydot==1.4.1
 pmlb==0.3


### PR DESCRIPTION
Гитхаб ругается, что в pillow версии < 7.1.0 есть проблемы с безопасностью.
Поправил версию в requirements.txt