### PR TITLE
Enum comparison bug fixed

### DIFF
--- a/core/composer/composer.py
+++ b/core/composer/composer.py
@@ -1,13 +1,14 @@
 import datetime
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from enum import Enum
 from typing import (Any, Callable, List, Optional)
+
+from dataclasses import dataclass
 
 from core.composer.chain import Chain
 from core.composer.node import PrimaryNode, SecondaryNode
-from core.log import default_log, Log
+from core.log import Log, default_log
 from core.models.data import InputData
+from core.utils import ComparableEnum as Enum
 
 
 @dataclass
@@ -18,10 +19,10 @@ class ComposerRequirements:
     :param primary: List of model types (str) for Primary Nodes
     :param secondary: List of model types (str) for Secondary Nodes
     :param max_lead_time: max time in minutes available for composition process
-    :param max_depth: desiderabile max depth of the result chain
-    :param max_arity:
-    :param min_arity:
-    :param add_single_model_chains:
+    :param max_depth: max depth of the result chain
+    :param max_arity: maximal number of parent for node
+    :param min_arity: minimal number of parent for node
+    :param add_single_model_chains: allow to have chain with only one node
     """
     primary: List[str]
     secondary: List[str]
@@ -46,6 +47,7 @@ class Composer(ABC):
 
     :param log: optional parameter for log oject
     """
+
     def __init__(self, log: Log = default_log(__name__)):
         self.history = None
         self.log = log

--- a/core/composer/optimisers/crossover.py
+++ b/core/composer/optimisers/crossover.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from enum import Enum
 from random import choice, random
 from typing import Any, List
 
@@ -7,6 +6,7 @@ from core.composer.constraint import constraint_function
 from core.composer.optimisers.gp_operators import \
     (equivalent_subtree, node_depth,
      nodes_from_height, replace_subtrees)
+from core.utils import ComparableEnum as Enum
 
 
 class CrossoverTypesEnum(Enum):

--- a/core/composer/optimisers/inheritance.py
+++ b/core/composer/optimisers/inheritance.py
@@ -1,8 +1,8 @@
 from copy import deepcopy
-from enum import Enum
 from typing import (Any, List)
 
 from core.composer.optimisers.selection import SelectionTypesEnum, individuals_selection
+from core.utils import ComparableEnum as Enum
 
 
 class GeneticSchemeTypesEnum(Enum):

--- a/core/composer/optimisers/mutation.py
+++ b/core/composer/optimisers/mutation.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from enum import Enum
 from functools import partial
 from random import choice, randint, random
 from typing import (Any, Callable)
@@ -7,6 +6,7 @@ from typing import (Any, Callable)
 from core.composer.chain import Chain, List
 from core.composer.constraint import constraint_function
 from core.composer.optimisers.gp_operators import node_depth, nodes_from_height, random_chain
+from core.utils import ComparableEnum as Enum
 
 
 class MutationTypesEnum(Enum):

--- a/core/composer/optimisers/regularization.py
+++ b/core/composer/optimisers/regularization.py
@@ -1,8 +1,8 @@
 from copy import deepcopy
-from enum import Enum
 from typing import (Any, Callable, List, Optional)
 
 from core.composer.constraint import constraint_function
+from core.utils import ComparableEnum as Enum
 
 
 class RegularizationTypesEnum(Enum):

--- a/core/composer/optimisers/selection.py
+++ b/core/composer/optimisers/selection.py
@@ -1,7 +1,8 @@
 import math
-from enum import Enum
 from random import choice, randint
 from typing import (Any, List)
+
+from core.utils import ComparableEnum as Enum
 
 
 class SelectionTypesEnum(Enum):

--- a/core/models/evaluation/automl_eval.py
+++ b/core/models/evaluation/automl_eval.py
@@ -16,9 +16,9 @@ from core.repository.tasks import TaskTypesEnum
 def fit_tpot(data: InputData, max_run_time_min: int):
     models_hyperparameters = _get_models_hyperparameters(max_run_time_min)['TPOT']
     estimator = None
-    if data.task.task_type is TaskTypesEnum.classification:
+    if data.task.task_type == TaskTypesEnum.classification:
         estimator = TPOTClassifier
-    elif data.task.task_type is TaskTypesEnum.regression:
+    elif data.task.task_type == TaskTypesEnum.regression:
         estimator = TPOTRegressor
 
     model = estimator(generations=models_hyperparameters['GENERATIONS'],

--- a/core/repository/dataset_types.py
+++ b/core/repository/dataset_types.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from core.utils import ComparableEnum as Enum
 
 
 class DataTypesEnum(Enum):

--- a/core/repository/quality_metrics_repository.py
+++ b/core/repository/quality_metrics_repository.py
@@ -1,7 +1,7 @@
-from enum import Enum
 from typing import Callable
 
 from core.composer.metrics import F1Metric, MaeMetric, RmseMetric, RocAucMetric, StructuralComplexityMetric
+from core.utils import ComparableEnum as Enum
 
 
 class MetricsEnum(Enum):

--- a/core/repository/tasks.py
+++ b/core/repository/tasks.py
@@ -1,6 +1,8 @@
-from dataclasses import dataclass
-from enum import Enum
 from typing import Any, List, Optional
+
+from dataclasses import dataclass
+
+from core.utils import ComparableEnum as Enum
 
 
 @dataclass

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,4 +1,5 @@
 import os
+from enum import Enum
 from pathlib import Path
 
 import numpy as np
@@ -60,3 +61,16 @@ def ensure_directory_exists(dir_names: list):
         os.mkdir(main_dir)
     if not os.path.exists(dataset_dir):
         os.mkdir(dataset_dir)
+
+
+class ComparableEnum(Enum):
+    """
+    The Enum implementation that allows to avoid the multi-module enum comparison problem
+    (https://stackoverflow.com/questions/26589805/python-enums-across-modules)
+    """
+
+    def eq(self, other):
+        return str(self) == str(other)
+
+    def hash(self):
+        return hash(str(self))

--- a/core/utils.py
+++ b/core/utils.py
@@ -69,8 +69,8 @@ class ComparableEnum(Enum):
     (https://stackoverflow.com/questions/26589805/python-enums-across-modules)
     """
 
-    def eq(self, other):
+    def __eq__(self, other):
         return str(self) == str(other)
 
-    def hash(self):
+    def __hash__(self):
         return hash(str(self))


### PR DESCRIPTION
Был найден баг - при подключении федот-а как внешней либы возникает проблема со сравнением енумов, торчащих из пользовательского интерфейса наружу.

Сценарий такой. 

В своем стороннем проекте делается

from FEDOT.core.repository.tasks import TaskTypesEnum

и передаешь внутрь fedot переменную class_task =TaskTypesEnum.classification, то внутри fedot

где скрипт начинается с

from core.repository.tasks import TaskTypesEnum

и имеет сравнение енумов, то class_task не будет равно TaskTypesEnum.classification

(сравнение возвращает false, см. https://stackoverflow.com/questions/26589805/python-enums-across-modules).

Сделал в рамках этого PR фикс, но не знаю - можно ли его протестировать автоматически?