### PR TITLE
Error with tuning the non-tunable models (e.g. PCA) fixed

### DIFF
--- a/fedot/core/models/evaluation/evaluation.py
+++ b/fedot/core/models/evaluation/evaluation.py
@@ -24,7 +24,7 @@ from sklearn.svm import LinearSVR as SklearnSVR
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from xgboost import XGBClassifier, XGBRegressor
 
-from fedot.core.log import default_log, Log
+from fedot.core.log import Log, default_log
 from fedot.core.models.data import InputData, OutputData
 from fedot.core.models.evaluation.custom_models.models import CustomSVC
 from fedot.core.models.tuning.hyperparams import params_range_by_model
@@ -74,6 +74,7 @@ class EvaluationStrategy:
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def fit_tuned(self, train_data: InputData, iterations: int,
                   max_lead_time: timedelta = timedelta(minutes=5)):
         """

--- a/fedot/core/models/model.py
+++ b/fedot/core/models/model.py
@@ -124,6 +124,9 @@ class Model:
             fitted_model, tuned_params = self._eval_strategy.fit_tuned(train_data=prepared_data,
                                                                        iterations=iterations,
                                                                        max_lead_time=max_lead_time)
+            if fitted_model is None:
+                raise ValueError(f'{self.model_type} can not be fitted')
+
             self.params = tuned_params
             if not self.params:
                 self.params = DEFAULT_PARAMS_STUB

--- a/fedot/core/models/tuning/tuners.py
+++ b/fedot/core/models/tuning/tuners.py
@@ -3,13 +3,12 @@ from datetime import timedelta
 from typing import Callable, Tuple, Union
 
 from numpy.random import choice as nprand_choice, randint
-from sklearn.metrics import make_scorer, mean_squared_error, roc_auc_score
-from sklearn.metrics import mean_squared_error as mse
+from sklearn.metrics import make_scorer, mean_squared_error, mean_squared_error as mse, roc_auc_score
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, cross_val_score
 from skopt import BayesSearchCV
 
 from fedot.core.composer.timer import TunerTimer
-from fedot.core.log import default_log, Log
+from fedot.core.log import Log, default_log
 from fedot.core.models.data import InputData, train_test_data_setup
 from fedot.core.models.tuning.tuner_adapter import HyperoptAdapter
 from fedot.core.repository.tasks import TaskTypesEnum
@@ -70,7 +69,7 @@ class Tuner:
     def _is_score_better(self, previous, current):
         __compare = {
             TaskTypesEnum.classification: operator.gt,
-            TaskTypesEnum.regression: operator.lt
+            TaskTypesEnum.regression: operator.gt
         }
         comparison = __compare.get(self.tune_data.task.task_type)
         try:
@@ -171,8 +170,8 @@ class SklearnCustomRandomTuner(Tuner):
         try:
             with TunerTimer() as timer:
                 best_model = self.trained_model
-                best_score, best_params = self.get_cross_val_score_and_params(best_model)
-                for iteration in range(self.max_iterations):
+                best_score, best_params = self.default_score, self.default_params
+                for _ in range(self.max_iterations):
                     params = {k: nprand_choice(v) for k, v in self.params_range.items()}
                     self.trained_model.set_params(**params)
                     score, _ = self.get_cross_val_score_and_params(self.trained_model)

--- a/test/chain/test_chain_tuning.py
+++ b/test/chain/test_chain_tuning.py
@@ -32,7 +32,7 @@ def classification_dataset():
 
 
 def get_regr_chain():
-    final = PrimaryNode(model_type='knnreg')
+    final = PrimaryNode(model_type='xgbreg')
     chain = Chain(final)
 
     return chain
@@ -54,7 +54,7 @@ def get_class_chain():
 def test_fine_tune_primary_nodes(data_fixture, request):
     # TODO still stochastic
     result_list = []
-    for _ in range(3):
+    for _ in range(5):
         data = request.getfixturevalue(data_fixture)
         train_data, test_data = train_test_data_setup(data=data)
 

--- a/test/chain/test_chain_tuning.py
+++ b/test/chain/test_chain_tuning.py
@@ -81,29 +81,28 @@ def test_fine_tune_primary_nodes(data_fixture, request):
 
 @pytest.mark.parametrize('data_fixture', ['classification_dataset'])
 def test_fine_tune_all_nodes(data_fixture, request):
-    for _ in range(10):
-        data = request.getfixturevalue(data_fixture)
-        train_data, test_data = train_test_data_setup(data=data)
+    data = request.getfixturevalue(data_fixture)
+    train_data, test_data = train_test_data_setup(data=data)
 
-        # Chain composition
-        chain = get_class_chain()
+    # Chain composition
+    chain = get_class_chain()
 
-        # Before tuning prediction
-        chain.fit(train_data, use_cache=False)
-        before_tuning_predicted = chain.predict(test_data)
+    # Before tuning prediction
+    chain.fit(train_data, use_cache=False)
+    before_tuning_predicted = chain.predict(test_data)
 
-        # root node tuning
-        chain.fine_tune_all_nodes(train_data, max_lead_time=timedelta(minutes=1), iterations=30)
-        chain.fit_from_scratch(train_data)
-        after_tun_root_node_predicted = chain.predict(test_data)
+    # root node tuning
+    chain.fine_tune_all_nodes(train_data, max_lead_time=timedelta(minutes=1), iterations=30)
+    chain.fit_from_scratch(train_data)
+    after_tun_root_node_predicted = chain.predict(test_data)
 
-        bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
-        aft_tun_roc_auc = round(roc(y_true=test_data.target, y_score=after_tun_root_node_predicted.predict), 2)
+    bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
+    aft_tun_roc_auc = round(roc(y_true=test_data.target, y_score=after_tun_root_node_predicted.predict), 2)
 
-        print(f'Before tune test {bfr_tun_roc_auc}')
-        print(f'After tune test {aft_tun_roc_auc}', '\n')
+    print(f'Before tune test {bfr_tun_roc_auc}')
+    print(f'After tune test {aft_tun_roc_auc}', '\n')
 
-        assert aft_tun_roc_auc >= bfr_tun_roc_auc
+    assert aft_tun_roc_auc >= bfr_tun_roc_auc
 
 
 @pytest.mark.parametrize('data_fixture', ['classification_dataset'])

--- a/test/chain/test_chain_tuning.py
+++ b/test/chain/test_chain_tuning.py
@@ -40,10 +40,9 @@ def get_regr_chain():
 
 def get_class_chain():
     first = PrimaryNode(model_type='xgboost')
-    second = PrimaryNode(model_type='knn')
-    third = PrimaryNode(model_type='pca_data_model')
-    final = SecondaryNode(model_type='xgboost',
-                          nodes_from=[first, second, third])
+    second = PrimaryNode(model_type='pca_data_model')
+    final = SecondaryNode(model_type='logit',
+                          nodes_from=[first, second])
 
     chain = Chain(final)
 

--- a/test/chain/test_chain_tuning.py
+++ b/test/chain/test_chain_tuning.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from random import seed
 
+import numpy as np
 import pytest
 from sklearn.metrics import mean_squared_error as mse, roc_auc_score as roc
 
@@ -13,6 +14,7 @@ from fedot.core.repository.tasks import Task, TaskTypesEnum
 from test.test_chain_import_export import create_four_depth_chain
 
 seed(1)
+np.random.seed(1)
 
 
 @pytest.fixture()
@@ -30,33 +32,27 @@ def classification_dataset():
 
 
 def get_regr_chain():
-    # Chain composition
-    first = PrimaryNode(model_type='xgbreg')
-    second = PrimaryNode(model_type='knnreg')
-    final = SecondaryNode(model_type='linear',
-                          nodes_from=[first, second])
-    chain = Chain()
-    chain.add_node(final)
+    final = PrimaryNode(model_type='knnreg')
+    chain = Chain(final)
 
     return chain
 
 
 def get_class_chain():
-    # Chain composition
     first = PrimaryNode(model_type='xgboost')
     second = PrimaryNode(model_type='knn')
+    third = PrimaryNode(model_type='pca_data_model')
     final = SecondaryNode(model_type='xgboost',
-                          nodes_from=[first, second])
+                          nodes_from=[first, second, third])
 
-    chain = Chain()
-    chain.add_node(final)
+    chain = Chain(final)
 
     return chain
 
 
 @pytest.mark.parametrize('data_fixture', ['regression_dataset'])
 def test_fine_tune_primary_nodes(data_fixture, request):
-    # TODO still stochatic
+    # TODO still stochastic
     result_list = []
     for _ in range(3):
         data = request.getfixturevalue(data_fixture)

--- a/test/chain/test_chain_tuning.py
+++ b/test/chain/test_chain_tuning.py
@@ -52,60 +52,58 @@ def get_class_chain():
 
 @pytest.mark.parametrize('data_fixture', ['regression_dataset'])
 def test_fine_tune_primary_nodes(data_fixture, request):
-    # TODO still stochastic
-    result_list = []
-    for _ in range(5):
-        data = request.getfixturevalue(data_fixture)
-        train_data, test_data = train_test_data_setup(data=data)
-
-        # Chain composition
-        chain = get_regr_chain()
-
-        # Before tuning prediction
-        chain.fit(train_data, use_cache=False)
-        before_tuning_predicted = chain.predict(test_data)
-
-        # Chain tuning
-        chain.fine_tune_primary_nodes(train_data, max_lead_time=timedelta(minutes=1), iterations=10)
-
-        # After tuning prediction
-        chain.fit(train_data)
-        after_tuning_predicted = chain.predict(test_data)
-
-        # Metrics
-        bfr_tun_mse = mse(y_true=test_data.target, y_pred=before_tuning_predicted.predict)
-        aft_tun_mse = mse(y_true=test_data.target, y_pred=after_tuning_predicted.predict)
-
-        print(f'Before tune test {bfr_tun_mse}')
-        print(f'After tune test {aft_tun_mse}', '\n')
-        result_list.append(aft_tun_mse <= bfr_tun_mse)
-
-    assert any(result_list)
-
-
-@pytest.mark.parametrize('data_fixture', ['classification_dataset'])
-def test_fine_tune_all_nodes(data_fixture, request):
     data = request.getfixturevalue(data_fixture)
     train_data, test_data = train_test_data_setup(data=data)
 
     # Chain composition
-    chain = get_class_chain()
+    chain = get_regr_chain()
 
     # Before tuning prediction
     chain.fit(train_data, use_cache=False)
     before_tuning_predicted = chain.predict(test_data)
 
-    # root node tuning
-    chain.fine_tune_all_nodes(train_data, max_lead_time=timedelta(minutes=1), iterations=30)
-    after_tun_root_node_predicted = chain.predict(test_data)
+    # Chain tuning
+    chain.fine_tune_primary_nodes(train_data, max_lead_time=timedelta(minutes=1), iterations=10)
 
-    bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
-    aft_tun_roc_auc = round(roc(y_true=test_data.target, y_score=after_tun_root_node_predicted.predict), 2)
+    # After tuning prediction
+    chain.fit_from_scratch(train_data)
+    after_tuning_predicted = chain.predict(test_data)
 
-    print(f'Before tune test {bfr_tun_roc_auc}')
-    print(f'After tune test {aft_tun_roc_auc}', '\n')
+    # Metrics
+    bfr_tun_mse = mse(y_true=test_data.target, y_pred=before_tuning_predicted.predict)
+    aft_tun_mse = mse(y_true=test_data.target, y_pred=after_tuning_predicted.predict)
 
-    assert aft_tun_roc_auc >= bfr_tun_roc_auc
+    print(f'Before tune test {bfr_tun_mse}')
+    print(f'After tune test {aft_tun_mse}', '\n')
+
+    assert aft_tun_mse <= bfr_tun_mse
+
+
+@pytest.mark.parametrize('data_fixture', ['classification_dataset'])
+def test_fine_tune_all_nodes(data_fixture, request):
+    for _ in range(10):
+        data = request.getfixturevalue(data_fixture)
+        train_data, test_data = train_test_data_setup(data=data)
+
+        # Chain composition
+        chain = get_class_chain()
+
+        # Before tuning prediction
+        chain.fit(train_data, use_cache=False)
+        before_tuning_predicted = chain.predict(test_data)
+
+        # root node tuning
+        chain.fine_tune_all_nodes(train_data, max_lead_time=timedelta(minutes=1), iterations=30)
+        chain.fit_from_scratch(train_data)
+        after_tun_root_node_predicted = chain.predict(test_data)
+
+        bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
+        aft_tun_roc_auc = round(roc(y_true=test_data.target, y_score=after_tun_root_node_predicted.predict), 2)
+
+        print(f'Before tune test {bfr_tun_roc_auc}')
+        print(f'After tune test {aft_tun_roc_auc}', '\n')
+
+        assert aft_tun_roc_auc >= bfr_tun_roc_auc
 
 
 @pytest.mark.parametrize('data_fixture', ['classification_dataset'])
@@ -136,7 +134,7 @@ def test_tune_primary_with_tune_class_correctly(data_fixture, request):
                        verbose=True).fine_tune_primary_nodes(input_data=train_data,
                                                              max_lead_time=timedelta(minutes=1),
                                                              iterations=30)
-    tuned_chain.fit(train_data)
+    tuned_chain.fit_from_scratch(train_data)
     after_tun_root_node_predicted = tuned_chain.predict(test_data)
 
     bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
@@ -161,7 +159,7 @@ def test_tune_all_with_tune_class_correctly(data_fixture, request):
                                                                 max_lead_time=timedelta(minutes=1),
                                                                 iterations=30)
 
-    tuned_chain.fit(train_data)
+    tuned_chain.fit_from_scratch(train_data)
     after_tun_root_node_predicted = tuned_chain.predict(test_data)
 
     bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
@@ -186,7 +184,7 @@ def test_tune_root_with_tune_class_correctly(data_fixture, request):
                                                                 max_lead_time=timedelta(minutes=1),
                                                                 iterations=30)
 
-    tuned_chain.fit(train_data)
+    tuned_chain.fit_from_scratch(train_data)
     after_tun_root_node_predicted = tuned_chain.predict(test_data)
 
     bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 2)
@@ -214,7 +212,7 @@ def test_tune_certain_node_with_tune_class_correctly(data_fixture, request):
                                                      max_lead_time=timedelta(minutes=1),
                                                      iterations=30)
 
-    tuned_chain.fit(train_data)
+    tuned_chain.fit_from_scratch(train_data)
     after_tun_root_node_predicted = tuned_chain.predict(test_data)
 
     bfr_tun_roc_auc = round(roc(y_true=test_data.target, y_score=before_tuning_predicted.predict), 1)


### PR DESCRIPTION
Now, if the fine_tune method of the model in node returns None (e.g PCA, it means that the model can not be tuned), the whole chain tuning fails.

Example:

Traceback (most recent call last):
  File "C:\Program Files\JetBrains\PyCharm 2019.3.1\plugins\python\helpers\pydev\pydevd.py", line 1434, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "C:\Program Files\JetBrains\PyCharm 2019.3.1\plugins\python\helpers\pydev\_pydev_imps\_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "D:\PycharmProjects\new fed\FEDOT\cases\credit_scoring_problem_multiobj.py", line 102, in <module>
    run_credit_scoring_problem(full_path_train, full_path_test, is_visualise=True)
  File "D:\PycharmProjects\new fed\FEDOT\cases\credit_scoring_problem_multiobj.py", line 74, in run_credit_scoring_problem
    iterations=50)
  File "D:\PycharmProjects\new fed\FEDOT\fedot\core\composer\chain.py", line 122, in fine_tune_primary_nodes
    node.fine_tune(input_data, max_lead_time=max_lead_time, iterations=iterations)
  File "D:\PycharmProjects\new fed\FEDOT\fedot\core\composer\node.py", line 157, in fine_tune
    iterations=iterations)
  File "D:\PycharmProjects\new fed\FEDOT\fedot\core\models\model.py", line 135, in fine_tune
    predict_train = self.predict(fitted_model, data)
  File "D:\PycharmProjects\new fed\FEDOT\fedot\core\models\model.py", line 104, in predict
    predict_data=prepared_data)
  File "D:\PycharmProjects\new fed\FEDOT\fedot\core\models\evaluation\data_evaluation.py", line 97, in predict
    return self._model_specific_predict(trained_model, predict_data)
  File "D:\PycharmProjects\new fed\FEDOT\fedot\core\models\evaluation\data_evaluation.py", line 74, in predict_pca
    return pca_model.transform(predict_data.features)[:, :(pca_model.last_component_ind + 1)]
AttributeError: 'NoneType' object has no attribute 'transform'

Fixed by raising of intermediate exception. Also, the stability of the tuning test is improved.