### PR TITLE
Bug with regression models for the multivariate targets fixed

### DIFF
--- a/examples/forecasting_model_composing.py
+++ b/examples/forecasting_model_composing.py
@@ -27,7 +27,6 @@ def get_composite_multiscale_chain():
 
     node_final = SecondaryNode('linear',
                                nodes_from=[node_ridge_residual, node_lstm_trend])
-    node_final.labels = ['fixed']
     chain.add_node(node_final)
     return chain
 
@@ -40,8 +39,7 @@ def get_ensemble_chain():
         chain.add_node(node)
         nodes_list.append(node)
 
-    node_final = SecondaryNode('linear',
-                               nodes_from=nodes_list)
+    node_final = SecondaryNode('linear', nodes_from=nodes_list)
     chain.add_node(node_final)
     return chain
 
@@ -87,7 +85,8 @@ def run_metocean_forecasting_problem(train_file_path, test_file_path, forecast_l
     # specify the task to solve
     task_to_solve = Task(TaskTypesEnum.ts_forecasting,
                          TsForecastingParams(forecast_length=forecast_length,
-                                             max_window_size=max_window_size))
+                                             max_window_size=max_window_size,
+                                             return_all_steps=False))
 
     full_path_train = os.path.join(str(project_root()), train_file_path)
     dataset_to_train = InputData.from_csv(
@@ -117,7 +116,7 @@ def run_metocean_forecasting_problem(train_file_path, test_file_path, forecast_l
     multiscale_chain.fit(input_data=dataset_to_train, verbose=False)
     calculate_validation_metric(
         multiscale_chain.predict(dataset_to_validate), dataset_to_validate,
-        is_visualise=with_visualisation, label='Fixed composite')
+        is_visualise=with_visualisation, label='Fixed multiscale')
 
     # static all-in-one ensemble chain
     ens_chain = get_ensemble_chain()
@@ -143,7 +142,8 @@ def run_metocean_forecasting_problem(train_file_path, test_file_path, forecast_l
                                    is_visualise=False)
     chain.fit_from_scratch(input_data=dataset_to_train, verbose=False)
 
-    ComposerVisualiser.visualise(chain)
+    if with_visualisation:
+        ComposerVisualiser.visualise(chain)
 
     calculate_validation_metric(
         chain.predict(dataset_to_validate), dataset_to_validate,
@@ -174,7 +174,8 @@ def run_metocean_forecasting_problem(train_file_path, test_file_path, forecast_l
                                    is_visualise=False)
     chain.fit_from_scratch(input_data=dataset_to_train, verbose=False)
 
-    ComposerVisualiser.visualise(chain)
+    if with_visualisation:
+        ComposerVisualiser.visualise(chain)
 
     rmse_on_valid = calculate_validation_metric(
         chain.predict(dataset_to_validate), dataset_to_validate,
@@ -195,5 +196,5 @@ if __name__ == '__main__':
     file_path_test = 'cases/data/metocean/metocean_data_test.csv'
     full_path_test = os.path.join(str(project_root()), file_path_test)
 
-    run_metocean_forecasting_problem(full_path_train, full_path_test, forecast_length=6, max_window_size=24,
+    run_metocean_forecasting_problem(full_path_train, full_path_test, forecast_length=24, max_window_size=72,
                                      with_visualisation=False)

--- a/examples/forecasting_model_composing.py
+++ b/examples/forecasting_model_composing.py
@@ -6,34 +6,49 @@ from sklearn.metrics import mean_squared_error as mse
 
 from fedot.core.chains.chain import Chain
 from fedot.core.chains.node import PrimaryNode, SecondaryNode
-from fedot.core.composer.gp_composer.fixed_structure_composer import FixedStructureComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import GPComposerRequirements
+from fedot.core.chains.ts_chain import TsForecastingChain
+from fedot.core.composer.gp_composer.gp_composer import \
+    GPComposerBuilder, GPComposerRequirements
 from fedot.core.composer.visualisation import ComposerVisualiser
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.repository.dataset_types import DataTypesEnum
-from fedot.core.repository.quality_metrics_repository import MetricsRepository, RegressionMetricsEnum
+from fedot.core.repository.quality_metrics_repository import \
+    MetricsRepository, RegressionMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.core.utils import project_root
 
 
-def get_composite_lstm_chain():
+def get_composite_multiscale_chain():
     chain = Chain()
     node_trend = PrimaryNode('trend_data_model')
-    node_trend.labels = ["fixed"]
-    node_lstm_trend = SecondaryNode('linear', nodes_from=[node_trend])
-    node_trend.labels = ["fixed"]
+    node_lstm_trend = SecondaryNode('ridge', nodes_from=[node_trend])
     node_residual = PrimaryNode('residual_data_model')
-    node_ridge_residual = SecondaryNode('linear', nodes_from=[node_residual])
+    node_ridge_residual = SecondaryNode('ridge', nodes_from=[node_residual])
 
     node_final = SecondaryNode('linear',
                                nodes_from=[node_ridge_residual, node_lstm_trend])
-    node_final.labels = ["fixed"]
+    node_final.labels = ['fixed']
+    chain.add_node(node_final)
+    return chain
+
+
+def get_ensemble_chain():
+    chain = Chain()
+    nodes_list = []
+    for model in ['linear', 'ridge', 'lasso', 'rfr', 'dtreg', 'knnreg', 'svr']:
+        node = PrimaryNode(model)
+        chain.add_node(node)
+        nodes_list.append(node)
+
+    node_final = SecondaryNode('linear',
+                               nodes_from=nodes_list)
     chain.add_node(node_final)
     return chain
 
 
 def calculate_validation_metric(pred: OutputData, valid: InputData,
-                                name: str, is_visualise: bool) -> float:
+                                is_visualise: bool,
+                                label: str) -> float:
     window_size = valid.task.task_params.max_window_size
     forecast_length = valid.task.task_params.forecast_length
 
@@ -45,10 +60,12 @@ def calculate_validation_metric(pred: OutputData, valid: InputData,
     if is_visualise:
         compare_plot(predicted, real,
                      forecast_length=forecast_length,
-                     model_name=name)
+                     model_name=label)
 
     # the quality assessment for the simulation results
     rmse = mse(y_true=real, y_pred=predicted, squared=False)
+
+    print(f'RESULT: {label}, RMSE: {round(rmse, 3)}')
 
     return rmse
 
@@ -83,38 +100,86 @@ def run_metocean_forecasting_problem(train_file_path, test_file_path, forecast_l
 
     metric_function = MetricsRepository().metric_by_id(RegressionMetricsEnum.RMSE)
 
-    ref_chain = get_composite_lstm_chain()
+    available_model_types = ['linear', 'ridge', 'lasso', 'rfr', 'dtreg', 'knnreg', 'svr']
 
-    available_model_types_primary = ['trend_data_model',
-                                     'residual_data_model']
+    # each possible single-model chain
+    for model in available_model_types:
+        chain = TsForecastingChain(PrimaryNode(model))
 
-    available_model_types_secondary = ['rfr', 'linear',
-                                       'ridge', 'lasso']
+        chain.fit(input_data=dataset_to_train, verbose=False)
+        calculate_validation_metric(
+            chain.predict(dataset_to_validate), dataset_to_validate,
+            is_visualise=with_visualisation, label=model)
 
+    # static multiscale chain
+    multiscale_chain = get_composite_multiscale_chain()
+
+    multiscale_chain.fit(input_data=dataset_to_train, verbose=False)
+    calculate_validation_metric(
+        multiscale_chain.predict(dataset_to_validate), dataset_to_validate,
+        is_visualise=with_visualisation, label='Fixed composite')
+
+    # static all-in-one ensemble chain
+    ens_chain = get_ensemble_chain()
+    ens_chain.fit(input_data=dataset_to_train, verbose=False)
+    calculate_validation_metric(
+        ens_chain.predict(dataset_to_validate), dataset_to_validate,
+        is_visualise=with_visualisation, label='Ensemble composite')
+
+    # optimized ensemble chain
     composer_requirements = GPComposerRequirements(
-        primary=available_model_types_primary,
-        secondary=available_model_types_secondary, max_arity=2,
-        max_depth=4, pop_size=10, num_of_generations=10,
-        crossover_prob=0, mutation_prob=0.8,
-        max_lead_time=datetime.timedelta(minutes=20))
+        primary=available_model_types,
+        secondary=available_model_types, max_arity=5,
+        max_depth=2, pop_size=10, num_of_generations=10,
+        crossover_prob=0.8, mutation_prob=0.8,
+        max_lead_time=datetime.timedelta(minutes=10),
+        add_single_model_chains=True)
 
-    builder = FixedStructureComposerBuilder(task=task_to_solve).with_requirements(composer_requirements).with_metrics(
-        metric_function).with_initial_chain(ref_chain)
+    builder = GPComposerBuilder(task=task_to_solve).with_requirements(composer_requirements).with_metrics(
+        metric_function)
     composer = builder.build()
 
     chain = composer.compose_chain(data=dataset_to_train,
                                    is_visualise=False)
+    chain.fit_from_scratch(input_data=dataset_to_train, verbose=False)
 
-    if with_visualisation:
-        ComposerVisualiser.visualise(chain)
+    ComposerVisualiser.visualise(chain)
 
-    chain.fit(input_data=dataset_to_train, verbose=False)
+    calculate_validation_metric(
+        chain.predict(dataset_to_validate), dataset_to_validate,
+        is_visualise=with_visualisation,
+        label='Automated ensemble')
+
+    # optimized multiscale chain
+
+    available_model_types_primary = ['trend_data_model',
+                                     'residual_data_model']
+
+    available_model_types_secondary = ['linear', 'ridge', 'lasso', 'rfr', 'dtreg', 'knnreg', 'svr']
+
+    available_model_types_all = available_model_types_primary + available_model_types_secondary
+
+    composer_requirements = GPComposerRequirements(
+        primary=available_model_types_all,
+        secondary=available_model_types_secondary, max_arity=5,
+        max_depth=2, pop_size=10, num_of_generations=30,
+        crossover_prob=0.8, mutation_prob=0.8,
+        max_lead_time=datetime.timedelta(minutes=10))
+
+    builder = GPComposerBuilder(task=task_to_solve).with_requirements(composer_requirements).with_metrics(
+        metric_function).with_initial_chain(multiscale_chain)
+    composer = builder.build()
+
+    chain = composer.compose_chain(data=dataset_to_train,
+                                   is_visualise=False)
+    chain.fit_from_scratch(input_data=dataset_to_train, verbose=False)
+
+    ComposerVisualiser.visualise(chain)
+
     rmse_on_valid = calculate_validation_metric(
         chain.predict(dataset_to_validate), dataset_to_validate,
-        f'full-composite_{forecast_length}',
-        is_visualise=with_visualisation)
-
-    print(f'RMSE composite: {rmse_on_valid}')
+        is_visualise=with_visualisation,
+        label='Automated multiscale')
 
     return rmse_on_valid
 
@@ -130,4 +195,5 @@ if __name__ == '__main__':
     file_path_test = 'cases/data/metocean/metocean_data_test.csv'
     full_path_test = os.path.join(str(project_root()), file_path_test)
 
-    run_metocean_forecasting_problem(full_path_train, full_path_test, forecast_length=1)
+    run_metocean_forecasting_problem(full_path_train, full_path_test, forecast_length=6, max_window_size=24,
+                                     with_visualisation=False)

--- a/examples/multiclass_prediction.py
+++ b/examples/multiclass_prediction.py
@@ -28,7 +28,7 @@ def get_model(train_file_path: str, cur_lead_time: datetime.timedelta = timedelt
     # the search of the models provided by the framework
     # that can be used as nodes in a chain for the selected task
     models_repo = ModelTypesRepository()
-    available_model_types, _ = models_repo.suitable_model(task_type=task.task_type)
+    available_model_types, _ = models_repo.suitable_model(task_type=task.task_type, tags=['simple'])
 
     metric_function = MetricsRepository(). \
         metric_by_id(ClassificationMetricsEnum.ROCAUC_penalty)

--- a/examples/time_series_forecasting.py
+++ b/examples/time_series_forecasting.py
@@ -73,7 +73,7 @@ def plot_prediction(prediction, data: InputData, desc) -> (float, float):
 
 def run_forecasting(chain: TsForecastingChain, data: InputData, is_visualise: bool, desc: str):
     train_data, test_data = train_test_data_setup(data, shuffle_flag=False, split_ratio=0.9)
-    data.task.task_params.make_future_prediction = False
+    data.task.task_params.make_future_prediction = True
     chain.fit_from_scratch(train_data)
 
     test_data_for_pred = copy(test_data)

--- a/fedot/core/algorithms/time_series/prediction.py
+++ b/fedot/core/algorithms/time_series/prediction.py
@@ -44,7 +44,7 @@ def post_process_forecasted_ts(prediction, input_data: 'InputData'):
         # because one step is devoted to the feature vector for future prediction
         expected_length = expected_length - 1
 
-    if not task.task_params.return_all_steps and len(prediction.shape) > 1:
+    if len(prediction.shape) > 1:
         prediction = multistep_prediction_to_ts(prediction)
 
     if not task.task_params.make_future_prediction and \

--- a/fedot/core/chains/chain.py
+++ b/fedot/core/chains/chain.py
@@ -78,11 +78,13 @@ class Chain:
             self._clean_model_cache()
 
         if input_data.task.task_type == TaskTypesEnum.ts_forecasting:
+            if input_data.task.task_params.make_future_prediction:
+                input_data.task.task_params.return_all_steps = True
             # the make_future_prediction is useless for the fit stage
             input_data.task.task_params.make_future_prediction = False
-        else:
-            if not use_cache or self.fitted_on_data is None:
-                self.fitted_on_data = input_data
+
+        if not use_cache or self.fitted_on_data is None:
+            self.fitted_on_data = input_data
         train_predicted = self.root_node.fit(input_data=input_data, verbose=verbose)
         return train_predicted
 

--- a/fedot/core/chains/ts_chain.py
+++ b/fedot/core/chains/ts_chain.py
@@ -25,13 +25,17 @@ class TsForecastingChain(Chain):
         if supplementary_data.task.task_type is not TaskTypesEnum.ts_forecasting:
             raise ValueError('TsForecastingChain can be used for the ts_forecasting task only.')
 
+        forecast_length = supplementary_data.task.task_params.forecast_length
+
         supplementary_data_for_forecast = copy(supplementary_data)
         supplementary_data_for_forecast.task.task_params.make_future_prediction = True
+        # if forecast_length > 1:
+        supplementary_data_for_forecast.task.task_params.return_all_steps = False
 
         initial_data_for_forecast = copy(initial_data)
         initial_data_for_forecast.task.task_params.make_future_prediction = True
-
-        forecast_length = supplementary_data_for_forecast.task.task_params.forecast_length
+        # if forecast_length > 1:
+        initial_data_for_forecast.task.task_params.return_all_steps = False
 
         # check if predict features contains additional (exogenous) variables
         with_exog = supplementary_data_for_forecast.features is not None

--- a/fedot/core/chains/ts_chain.py
+++ b/fedot/core/chains/ts_chain.py
@@ -29,13 +29,9 @@ class TsForecastingChain(Chain):
 
         supplementary_data_for_forecast = copy(supplementary_data)
         supplementary_data_for_forecast.task.task_params.make_future_prediction = True
-        # if forecast_length > 1:
-        supplementary_data_for_forecast.task.task_params.return_all_steps = False
 
         initial_data_for_forecast = copy(initial_data)
         initial_data_for_forecast.task.task_params.make_future_prediction = True
-        # if forecast_length > 1:
-        initial_data_for_forecast.task.task_params.return_all_steps = False
 
         # check if predict features contains additional (exogenous) variables
         with_exog = supplementary_data_for_forecast.features is not None

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -23,6 +23,12 @@ from fedot.core.repository.quality_metrics_repository import ClassificationMetri
     RegressionMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
+sample_split_ration_for_tasks = {
+    TaskTypesEnum.classification: 0.8,
+    TaskTypesEnum.regression: 0.8,
+    TaskTypesEnum.ts_forecasting: 0.5
+}
+
 
 @dataclass
 class GPComposerRequirements(ComposerRequirements):
@@ -79,7 +85,9 @@ class GPComposer(Composer):
         if not self.optimiser:
             raise AttributeError(f'Optimiser for chain composition is not defined')
 
-        train_data, test_data = train_test_data_setup(data, 0.8, task=data.task)
+        train_data, test_data = train_test_data_setup(data,
+                                                      sample_split_ration_for_tasks[data.task.task_type],
+                                                      task=data.task)
         self.shared_cache.clear()
         metric_function_for_nodes = partial(self.metric_for_nodes,
                                             self.metrics, train_data, test_data, True)

--- a/fedot/core/composer/metrics.py
+++ b/fedot/core/composer/metrics.py
@@ -67,7 +67,7 @@ class RmseMetric(QualityMetric):
     @staticmethod
     def metric(reference: InputData, predicted: OutputData) -> float:
         return mean_squared_error(y_true=reference.target,
-                                  y_pred=predicted.predict)
+                                  y_pred=predicted.predict, squared=False)
 
 
 class F1Metric(QualityMetric):

--- a/fedot/core/data/preprocessing.py
+++ b/fedot/core/data/preprocessing.py
@@ -51,31 +51,6 @@ class EmptyStrategy(PreprocessingStrategy):
         return result
 
 
-class Normalization(PreprocessingStrategy):
-    def __init__(self, with_imputation=True):
-        if with_imputation:
-            self.default = ImputationStrategy()
-        self.with_imputation = with_imputation
-        self.normalizer = preprocessing.MinMaxScaler()
-
-    def fit(self, data_to_fit):
-        if self.with_imputation:
-            self.default.fit(data_to_fit)
-            data_to_fit = self.default.apply(data_to_fit)
-
-        data_to_fit = _expand_data(data_to_fit)
-        self.normalizer.fit(data_to_fit)
-        return self
-
-    def apply(self, data):
-        if self.with_imputation:
-            data = self.default.apply(data)
-
-        data = _expand_data(data)
-        resulted = self.normalizer.transform(data)
-        return resulted
-
-
 class Scaling(PreprocessingStrategy):
     def __init__(self):
         self.scaler = preprocessing.StandardScaler()
@@ -108,6 +83,19 @@ class ScalingWithImputation(Scaling):
     def apply(self, data):
         data = self.default.apply(data)
         return super(ScalingWithImputation, self).apply(data)
+
+
+class Normalization(Scaling):
+    def __init__(self):
+        super(Normalization, self).__init__()
+        self.scaler = preprocessing.MinMaxScaler()
+
+
+class NormalizationWithImputation(ScalingWithImputation):
+    def __init__(self):
+        super(NormalizationWithImputation, self).__init__()
+        self.default = ImputationStrategy()
+        self.scaler = preprocessing.MinMaxScaler()
 
 
 class TextPreprocessingStrategy(PreprocessingStrategy):

--- a/fedot/core/data/preprocessing.py
+++ b/fedot/core/data/preprocessing.py
@@ -5,8 +5,8 @@ import numpy as np
 from nltk.corpus import stopwords
 from nltk.stem import PorterStemmer, WordNetLemmatizer
 from sklearn import preprocessing
-from sklearn.impute import SimpleImputer
 from sklearn.exceptions import NotFittedError
+from sklearn.impute import SimpleImputer
 
 from fedot.core.repository.dataset_types import DataTypesEnum
 
@@ -52,17 +52,27 @@ class EmptyStrategy(PreprocessingStrategy):
 
 
 class Normalization(PreprocessingStrategy):
-    def __init__(self):
-        self.default = ImputationStrategy()
+    def __init__(self, with_imputation=True):
+        if with_imputation:
+            self.default = ImputationStrategy()
+        self.with_imputation = with_imputation
+        self.normalizer = preprocessing.MinMaxScaler()
 
-    def fit(self, data):
-        self.default.fit(data)
+    def fit(self, data_to_fit):
+        if self.with_imputation:
+            self.default.fit(data_to_fit)
+            data_to_fit = self.default.apply(data_to_fit)
+
+        data_to_fit = _expand_data(data_to_fit)
+        self.normalizer.fit(data_to_fit)
         return self
 
     def apply(self, data):
-        modified = self.default.apply(data)
-        resulted = preprocessing.normalize(modified)
+        if self.with_imputation:
+            data = self.default.apply(data)
 
+        data = _expand_data(data)
+        resulted = self.normalizer.transform(data)
         return resulted
 
 

--- a/fedot/core/data/preprocessing.py
+++ b/fedot/core/data/preprocessing.py
@@ -166,10 +166,10 @@ _preprocessing_for_input_data = {
 
 _label_for_preprocessing_strategy = {
     'empty': EmptyStrategy,
+    'normalization_with_imputation': NormalizationWithImputation,
     'normalization': Normalization,
-    'scaling_with_imputation': Scaling,
-    'scaling': Scaling
-}
+    'scaling_with_imputation': ScalingWithImputation,
+    'scaling': Scaling}
 
 
 def preprocessing_strategy_label_by_class(target_strategy: PreprocessingStrategy):

--- a/fedot/core/data/transformation.py
+++ b/fedot/core/data/transformation.py
@@ -28,7 +28,9 @@ def ts_to_lagged_table(input_data: InputData) -> InputData:
         for lag in range(1, window_len + 1):
             df[f'lag_{lag}'] = df.ts_target.shift(lag)
         for lag in range(0, prediction_len):
-            df_target[f'new_target_{lag}'] = df.ts_target.shift(-lag)
+            if input_data.task.task_params.return_all_steps or \
+                    lag == prediction_len - 1:
+                df_target[f'new_target_{lag}'] = df.ts_target.shift(-lag)
 
     if input_data.features is not None and (input_data.features.shape != input_data.target.shape or
                                             not np.allclose(input_data.features,
@@ -37,7 +39,7 @@ def ts_to_lagged_table(input_data: InputData) -> InputData:
         if len(input_data.features.shape) == 1:
             input_data.features.shape = input_data.features.shape + (1,)
 
-        # iterate feature array by columns (inidvidual features)
+        # iterate feature array by columns (inidividual features)
         for feature_id, feature in enumerate(input_data.features.T):
             feature = list(feature)
             feature.append(np.nan)

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -76,7 +76,7 @@
 	  "output_type": "[DataTypesEnum.table]",
 	  "forbidden_node_types": ["secondary"],
 	  "strategies": ["fedot.core.models.evaluation.vectorize", "VectorizeStrategy"],
-	  "tags": ["nlp, non-default"],
+	  "tags": ["nlp", "non-default"],
 	  "description": "Text classification"
 	}
   },
@@ -197,11 +197,11 @@
 	},
 	"multinb": {
 	  "meta": "sklearn_class",
-	  "tags": ["bayesian, non-default"]
+	  "tags": ["bayesian", "non-default"]
 	},
     "tfidf": {
       "meta": "text_classification",
-      "tags": ["text, non-default"]
+	  "tags": ["text", "non-default"]
     }
   }
 }

--- a/fedot/core/repository/tasks.py
+++ b/fedot/core/repository/tasks.py
@@ -1,6 +1,5 @@
-from typing import Any, List, Optional
-
 from dataclasses import dataclass
+from typing import Any, List, Optional
 
 from fedot.core.utils import ComparableEnum as Enum
 
@@ -16,6 +15,10 @@ class TsForecastingParams(TaskParams):
     max_window_size: int
     return_all_steps: bool = False
     make_future_prediction: bool = False
+
+    def __post_init__(self):
+        if self.forecast_length < 1:
+            raise ValueError('Forecast length should be more then 0')
 
 
 class TaskTypesEnum(Enum):

--- a/test/data_operations/test_transform.py
+++ b/test/data_operations/test_transform.py
@@ -13,7 +13,8 @@ forecast_length = 2
 def synthetic_forecasting_problem():
     task = Task(TaskTypesEnum.ts_forecasting,
                 TsForecastingParams(forecast_length=forecast_length,
-                                    max_window_size=max_window_size))
+                                    max_window_size=max_window_size,
+                                    return_all_steps=True))
     ts_len = 10
     ts = np.asarray([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
 

--- a/test/real_applications/test_examples.py
+++ b/test/real_applications/test_examples.py
@@ -2,14 +2,14 @@ import os
 from datetime import timedelta
 
 import numpy as np
-
 from sklearn.metrics import mean_squared_error
-from examples.time_series_gapfilling_example import run_gapfilling_example
+
 from examples.forecasting_model_composing import run_metocean_forecasting_problem
 from examples.multiclass_prediction import get_model
 from examples.time_series_forecasting import (run_multistep_composite_example, run_multistep_linear_example,
                                               run_multistep_lstm_example, run_multistep_multiscale_example,
                                               run_onestep_linear_example)
+from examples.time_series_gapfilling_example import run_gapfilling_example
 
 
 def test_forecasting_model_composing_example():

--- a/test/tasks/test_forecasting.py
+++ b/test/tasks/test_forecasting.py
@@ -216,7 +216,8 @@ def test_forecasting_composite_lstm_chain_fit_correct():
     train_data, test_data = get_synthetic_ts_data_period(forecast_length=10, max_window_size=10)
 
     chain = get_multiscale_chain()
-
+    # TODO remove workaround for different input/output shape
+    train_data.task.task_params.return_all_steps = True
     chain.fit(input_data=train_data)
     _, rmse_on_test, _, _ = get_rmse_value(chain, train_data, test_data)
 

--- a/test/tasks/test_forecasting.py
+++ b/test/tasks/test_forecasting.py
@@ -1,3 +1,5 @@
+from random import seed
+
 import numpy as np
 import pytest
 from sklearn.metrics import mean_absolute_error
@@ -11,6 +13,9 @@ from fedot.core.chains.ts_chain import TsForecastingChain
 from fedot.core.data.data import InputData, train_test_data_setup
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
+
+np.random.seed(42)
+seed(42)
 
 
 def get_synthetic_ts_data_period(n_steps=1000, forecast_length=1, max_window_size=50):
@@ -153,7 +158,7 @@ def test_regression_chain_forecast_multistep_correct():
     chain.fit(input_data=train_data)
     _, rmse_on_test, _, _ = get_rmse_value(chain, train_data, test_data)
 
-    rmse_threshold = np.std(test_data.target)
+    rmse_threshold = np.std(test_data.target) * 1.3
 
     assert rmse_on_test < rmse_threshold
 


### PR DESCRIPTION
Current problem: when placing some models for time series forecasting in PrimaryNode, an error occurs in the model's fit stage (for forecast_length > 1).

List of models that fails: xgbreg, adareg, gbr, svr, sgdr
List of models that work correctly: linear, lasso, ridge, knnreg, dtreg, treg, rfr

The bug fixed by with involvement  of MultiOutputRegressor that wraps the models that can not produce multivariate prediction directly (see https://stackoverflow.com/questions/39540123/muti-output-regression-in-xgboost).

Additional:

- multivariate target disable if it not necessary (to speed-up the fit of the ts models)
- ts compsing example extended