### PR TITLE
HOT FIX widows error

### DIFF
--- a/fedot/core/chains/chain_template.py
+++ b/fedot/core/chains/chain_template.py
@@ -114,7 +114,7 @@ class ChainTemplate:
             raise FileNotFoundError(message)
 
         self.unique_chain_id = folder_name
-        folder_name = f"{datetime.now().strftime('%B:%d:%Y, %H:%M:%S %p')} {folder_name}"
+        folder_name = f"{datetime.now().strftime('%B-%d-%Y,%H-%M-%S,%p')} {folder_name}"
         path_to_save = os.path.join(path, folder_name)
 
         return path_to_save


### PR DESCRIPTION
Появилась ошибка после переноса двух PR [first](https://github.com/nccr-itmo/FEDOT/pull/217) and [second]https://github.com/nccr-itmo/FEDOT/pull/210):

>           mkdir(name, mode)
E           OSError: [WinError 123] Синтаксическая ошибка в имени файла, имени папки или метке тома: 'D:\\THEODOR\\test\\January:12:2021, 13:41:40 PM test_chain_convert_to_json'

C:\Python37\lib\os.py:223: OSError

Исправлено на формат: 'January-12-2021,15-59-58,PM'.