### PR TITLE
Notify action

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,34 @@
+name: telegram notify
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+
+  merge_job:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: send custom message with args
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          args: "The ${{github.event_name}} '${{github.event.pull_request.title}}' (#${{github.event.number}}) was merged.
+          \nLink: ${{github.event.pull_request.html_url}}
+          \nDescription: ${{github.event.pull_request.body}}
+          \nCheck it out to keep your local repository updated."
+
+
+  close_job:
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: send custom message with args
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          args: The ${{github.event_name}} ${{github.event.pull_request.title}} (${{github.event.number}}) was closed.


### PR DESCRIPTION
The telegram notifications about merges were added.

New Action is triggered by 'closed' status of pull requests. If the PR is merged the Action will send the PR information with link and description to chat. If the PR is closed manually the Action will send the information that this PR was just closed.