### PR TITLE
Update pytest version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ statsmodels==0.12.0
 dataclasses==0.7; python_version < '3.7'
 ete3==3.1.1
 numpy==1.19.2
-pytest==5.2.0
+pytest==6.2.3
 anytree==2.8.0
 typing==3.7.4.1
 scikit_learn==0.24.1


### PR DESCRIPTION
Pytest version in requirements was updated to the latest 6.2.3.
It allow one to reduce the dublicated logs during pytest run. 
![image](https://user-images.githubusercontent.com/7864250/115014068-89ec4300-9eba-11eb-9ba7-0d1d0d91a3ad.png)
