### PR TITLE
Correct RANSAC operation parameters

### DIFF
--- a/fedot/core/repository/data/default_model_params.json
+++ b/fedot/core/repository/data/default_model_params.json
@@ -42,5 +42,17 @@
     "p": 2,
     "d": 0,
     "q": 2
+  },
+  "ransac_lin_reg": {
+    "min_samples": 0.4,
+    "residual_threshold": 10,
+    "max_trials": 100,
+    "max_skips": 1000
+  },
+  "ransac_non_lin_reg": {
+    "min_samples": 0.4,
+    "residual_threshold": 10,
+    "max_trials": 100,
+    "max_skips": 1000
   }
 }

--- a/test/unit/data_operations/test_data_operation_params.py
+++ b/test/unit/data_operations/test_data_operation_params.py
@@ -9,6 +9,7 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.core.utils import fedot_project_root
+from test.unit.tasks.test_regression import get_synthetic_regression_data
 
 
 def get_ts_pipeline(window_size):
@@ -17,6 +18,14 @@ def get_ts_pipeline(window_size):
     node_lagged.custom_params = {'window_size': window_size}
 
     node_final = SecondaryNode('ridge', nodes_from=[node_lagged])
+    pipeline = Pipeline(node_final)
+    return pipeline
+
+
+def get_ransac_pipeline():
+    """ Function return pipeline with lagged transformation in it """
+    node_ransac = PrimaryNode('ransac_lin_reg')
+    node_final = SecondaryNode('linear', nodes_from=[node_ransac])
     pipeline = Pipeline(node_final)
     return pipeline
 
@@ -49,6 +58,26 @@ def test_lagged_with_invalid_params_fit_correctly():
 
     # Fit it
     pipeline.fit(train_input)
+
+    is_pipeline_was_fitted = True
+    assert is_pipeline_was_fitted
+
+
+def test_ransac_with_invalid_params_fit_correctly():
+    """ Check that on a small dataset the RANSAC anomaly search algorithm can
+    adjust the values of hyperparameters
+
+    As stated in the sklearn documentation, min_samples is determined by default
+    based on how many features are in the dataset
+    Therefore, problems can arise when there are more attributes in a dataset
+    than the number of objects
+    """
+
+    input_regression = get_synthetic_regression_data(n_samples=20, n_features=23)
+
+    ransac_pipeline = get_ransac_pipeline()
+    ransac_pipeline.fit(input_regression)
+    predicted = ransac_pipeline.predict(input_regression)
 
     is_pipeline_was_fitted = True
     assert is_pipeline_was_fitted

--- a/test/unit/data_operations/test_data_operation_params.py
+++ b/test/unit/data_operations/test_data_operation_params.py
@@ -59,8 +59,7 @@ def test_lagged_with_invalid_params_fit_correctly():
     # Fit it
     pipeline.fit(train_input)
 
-    is_pipeline_was_fitted = True
-    assert is_pipeline_was_fitted
+    assert pipeline.is_fitted
 
 
 def test_ransac_with_invalid_params_fit_correctly():
@@ -79,5 +78,5 @@ def test_ransac_with_invalid_params_fit_correctly():
     ransac_pipeline.fit(input_regression)
     predicted = ransac_pipeline.predict(input_regression)
 
-    is_pipeline_was_fitted = True
-    assert is_pipeline_was_fitted
+    assert ransac_pipeline.is_fitted
+    assert predicted is not None


### PR DESCRIPTION
A bug that appeared when running on medical data has been fixed. 

Data feature: there are more features in dataset than objects. 

When initializing ransac_lin_reg, hyperparameter min_samples was defined by integer value. Now it is a real number (from 0.1 to 0.9, default value is 0.4).