### PR TITLE
Change logging when default tuner metric is set

### DIFF
--- a/fedot/api/api_utils.py
+++ b/fedot/api/api_utils.py
@@ -205,10 +205,11 @@ def compose_fedot_model(train_data: [InputData, MultiModalData],
         logger.message('Hyperparameters tuning started')
 
         if tuner_metric is None:
-            logger.message('Default loss function was set')
             # Default metric for tuner
             tune_metrics = TunerMetricByTask(task.task_type)
             tuner_loss, loss_params = tune_metrics.get_metric_and_params(train_data)
+            logger.message(f'Tuner metric is None, '
+                           f'{tuner_loss.__name__} was set as default')
         else:
             # Get metric and parameters by name
             tuner_loss, loss_params = tuner_metric_by_name(metric_name=tuner_metric,

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ SALib==1.3.11
 deap==1.3.1
 lightgbm==2.3.1
 catboost==0.25.1
+testfixtures==6.18.0

--- a/test/unit/api/test_api_utils.py
+++ b/test/unit/api/test_api_utils.py
@@ -1,0 +1,17 @@
+from fedot.api.api_utils import compose_fedot_model
+from ..api.test_main_api import get_dataset
+from fedot.core.repository.tasks import Task, TaskTypesEnum
+from fedot.core.log import default_log
+
+
+def test_compose_fedot_model_with_tuning():
+    train, test, _ = get_dataset(task_type='classification')
+    generations = 1
+    _, _, history = compose_fedot_model(train_data=train,
+                                        task=Task(
+                                            task_type=TaskTypesEnum.classification),
+                                        logger=default_log('test_log'),
+                                        max_depth=1, max_arity=1,
+                                        pop_size=2, num_of_generations=generations,
+                                        with_tuning=True)
+    assert len(history.individuals) == generations

--- a/test/unit/api/test_api_utils.py
+++ b/test/unit/api/test_api_utils.py
@@ -3,15 +3,21 @@ from ..api.test_main_api import get_dataset
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 from fedot.core.log import default_log
 
+from testfixtures import LogCapture
+
 
 def test_compose_fedot_model_with_tuning():
     train, test, _ = get_dataset(task_type='classification')
     generations = 1
-    _, _, history = compose_fedot_model(train_data=train,
-                                        task=Task(
-                                            task_type=TaskTypesEnum.classification),
-                                        logger=default_log('test_log'),
-                                        max_depth=1, max_arity=1,
-                                        pop_size=2, num_of_generations=generations,
-                                        with_tuning=True)
-    assert len(history.individuals) == generations
+
+    with LogCapture() as logs:
+        _, _, history = compose_fedot_model(train_data=train,
+                                            task=Task(
+                                                task_type=TaskTypesEnum.classification),
+                                            logger=default_log('test_log'),
+                                            max_depth=1, max_arity=1,
+                                            pop_size=2, num_of_generations=generations,
+                                            timeout=0.1,
+                                            with_tuning=True)
+    expected = ('test_log', 'INFO', 'Tuner metric is None, roc_auc_score was set as default')
+    logs.check_present(expected, order_matters=False)


### PR DESCRIPTION
Based on this issue: https://github.com/ITMO-NSS-team/fedot_electro_ts_case/issues/1

Previously, if `tuner_metric=None` in compose_fedot_model, a message in log is given: 'Default loss function was set'.
Now it is more user-friendly: 
![image](https://user-images.githubusercontent.com/7864250/128852041-3b6e1227-0f49-4527-9325-7b5e4626247f.png)
