### PR TITLE
Improving binary feature processing

### DIFF
--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -113,13 +113,14 @@ class Fedot:
         if predefined_model is not None:
             # Fit predefined model and return it without composing
             self.current_pipeline = self._process_predefined_model(predefined_model)
+            self.current_pipeline.preprocessor = self.data_processor.preprocessor
             return self.current_pipeline
 
         self.api_params['train_data'] = self.train_data
         self.current_pipeline, self.best_models, self.history = self.api_composer.obtain_model(**self.api_params)
 
         # Store data encoder in the pipeline if it is required
-        self.current_pipeline.preprocessor.target_encoder = self.data_processor.preprocessor.target_encoder
+        self.current_pipeline.preprocessor = self.data_processor.preprocessor
         return self.current_pipeline
 
     def predict(self,

--- a/fedot/core/data/data_preprocessing.py
+++ b/fedot/core/data/data_preprocessing.py
@@ -13,7 +13,9 @@ def has_data_categorical(data: InputData) -> bool:
     :param data: InputData
     :return data_has_categorical_columns: bool, whether data has categorical columns or not
     """
-    if isinstance(data.features.dtype, int) or isinstance(data.features.dtype, float):
+    is_float_dtype = data.features.dtype is np.array([1]).dtype
+    is_int_dtype = data.features.dtype is np.array([1.5]).dtype
+    if is_float_dtype or is_int_dtype:
         return False
     else:
         return True

--- a/fedot/core/data/data_preprocessing.py
+++ b/fedot/core/data/data_preprocessing.py
@@ -6,6 +6,9 @@ import pandas as pd
 from fedot.core.data.data import InputData, data_type_is_table
 from fedot.core.repository.dataset_types import DataTypesEnum
 
+NUMPY_TYPE_INT = np.array([1]).dtype
+NUMPY_TYPE_FLOAT = np.array([1.5]).dtype
+
 
 def has_data_categorical(data: InputData) -> bool:
     """ Whether data categorical columns or not.
@@ -13,12 +16,10 @@ def has_data_categorical(data: InputData) -> bool:
     :param data: InputData
     :return data_has_categorical_columns: bool, whether data has categorical columns or not
     """
-    is_float_dtype = data.features.dtype is np.array([1]).dtype
-    is_int_dtype = data.features.dtype is np.array([1.5]).dtype
-    if is_float_dtype or is_int_dtype:
-        return False
-    else:
-        return True
+    is_float_dtype = data.features.dtype is NUMPY_TYPE_INT
+    is_int_dtype = data.features.dtype is NUMPY_TYPE_FLOAT
+    is_contain_categorical = not (is_float_dtype or is_int_dtype)
+    return is_contain_categorical
 
 
 def data_type_is_suitable_preprocessing(data: InputData) -> bool:

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -253,8 +253,5 @@ def convert_to_multivariate_model(sklearn_model, train_data: InputData):
 
 def is_multi_output_task(train_data):
     target_shape = train_data.target.shape
-    if len(target_shape) > 1 and target_shape[1] > 1:
-        is_multi_target = True
-    else:
-        is_multi_target = False
+    is_multi_target = len(target_shape) > 1 and target_shape[1] > 1
     return is_multi_target

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -176,8 +176,8 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
                                                              tags=['non_multi'])
         is_model_not_support_multi = self.operation_type in non_multi_models
 
-        # Multi-output task
-        is_multi_target = len(train_data.target.shape) > 1
+        # Multi-output task or not
+        is_multi_target = is_multi_output_task(train_data)
         if is_model_not_support_multi and is_multi_target:
             # Manually wrap the regressor into multi-output model
             operation_implementation = convert_to_multivariate_model(operation_implementation,
@@ -249,3 +249,12 @@ def convert_to_multivariate_model(sklearn_model, train_data: InputData):
     sklearn_model = multiout_func(sklearn_model)
     sklearn_model.fit(train_data.features, train_data.target)
     return sklearn_model
+
+
+def is_multi_output_task(train_data):
+    target_shape = train_data.target.shape
+    if len(target_shape) > 1 and target_shape[1] > 1:
+        is_multi_target = True
+    else:
+        is_multi_target = False
+    return is_multi_target

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
@@ -392,11 +392,10 @@ class ImputationImplementation(DataOperationImplementation):
         All features in table are numerical.
         """
         df = pd.DataFrame(numerical_features)
-        df = df.dropna()
 
-        # Calculate unique values per column
+        # Calculate unique values per column (excluding nans)
         for column_id, col in enumerate(df):
-            unique_values = df[col].unique()
+            unique_values = df[col].dropna().unique()
             if len(unique_values) <= 2:
                 # Current numerical column has only two values
                 column_info = {column_id: {'min': min(unique_values),

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -299,8 +299,8 @@ def test_inf_and_nan_absence_after_pipeline_fitting_from_scratch():
 
     model_names, _ = OperationTypesRepository().suitable_operation(task_type=TaskTypesEnum.regression)
 
-    for data_operation in model_names:
-        node_data_operation = PrimaryNode(data_operation)
+    for model_name in model_names:
+        node_data_operation = PrimaryNode(model_name)
         node_final = SecondaryNode('linear', nodes_from=[node_data_operation])
         pipeline = Pipeline(node_final)
 

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -161,18 +161,40 @@ def get_mixed_data(task=None, extended=False):
 def get_nan_binary_data(task=None):
     """ Generate table with two numerical and one categorical features.
     Both them contain nans, which need to be filled in.
+
+    Binary int columns must be processed as "almost categorical". Current dataset
+    For example, nan object in [1, nan, 0, 0] must be filled as 0, not as 0.33
     """
     features = np.array([[1, '0', 0],
                          [np.nan, np.nan, np.nan],
                          [0, '2', 1],
                          [1, '1', 1],
-                         [5, '1', 0]], dtype=object)
+                         [5, '1', 1]], dtype=object)
 
     input_data = InputData(idx=[0, 1, 2, 3], features=features,
                            target=np.array([[0], [0], [1], [1]]),
                            task=task, data_type=DataTypesEnum.table)
 
     return input_data
+
+
+def data_with_binary_int_features_and_equal_categories():
+    """
+    Generate table with binary integer features and nans there. Such a columns
+    must be processed as "almost categorical". Current dataset
+    For example, nan object in [1, nan, 0, 0] must be filled as 0, not as 0.33
+    """
+    task = Task(TaskTypesEnum.classification)
+    features = np.array([[1, 10],
+                         [np.nan, np.nan],
+                         [np.nan, np.nan],
+                         [0, 0]])
+    target = np.array([['not-nan'], ['nan'], ['nan'], ['not-nan']])
+    train_input = InputData(idx=[0, 1, 2, 3], features=features, target=target,
+                            task=task, data_type=DataTypesEnum.table,
+                            supplementary_data=SupplementaryData(was_preprocessed=False))
+
+    return train_input
 
 
 def test_regression_data_operations():
@@ -368,11 +390,28 @@ def test_imputation_with_binary_correct():
     """
     nan_data = get_nan_binary_data(task=Task(TaskTypesEnum.classification))
 
-    # Create pipeline with imputation operation
+    # Create node with imputation operation
     imputation_node = PrimaryNode('simple_imputation')
     imputation_node.fit(nan_data)
     predicted = imputation_node.predict(nan_data)
 
     assert np.isclose(predicted.predict[1, 0], 1.75)
     assert predicted.predict[1, 1] == '1'
-    assert np.isclose(predicted.predict[1, 2], 0.5)
+    assert np.isclose(predicted.predict[1, 2], 1)
+
+
+def test_imputation_binary_features_with_equal_categories_correct():
+    """
+    The correctness of the gap-filling algorithm is checked on data with binary
+    features. The number of known categories in each column is equal. Consequently,
+    there is no possibility to insert the majority class label into the gaps.
+    Instead of that the mean value is inserted.
+    """
+    nan_data = data_with_binary_int_features_and_equal_categories()
+
+    imputation_node = PrimaryNode('simple_imputation')
+    imputation_node.fit(nan_data)
+    predicted = imputation_node.predict(nan_data)
+
+    assert np.isclose(predicted.predict[1, 0], 0.5)
+    assert np.isclose(predicted.predict[1, 1], 5.0)

--- a/test/unit/test_data_preprocessing.py
+++ b/test/unit/test_data_preprocessing.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.data.supplementary_data import SupplementaryData
@@ -8,7 +7,6 @@ from fedot.api.main import Fedot
 from fedot.core.data.data import InputData
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
-from test.unit.api.test_main_api import composer_params
 
 
 def data_with_only_categorical_features():
@@ -117,8 +115,8 @@ def data_with_categorical_target(with_nan: bool = False):
     task = Task(TaskTypesEnum.classification)
     features = np.array([[0, 0],
                          [0, 1],
-                         [9, 9],
-                         [9, 9]])
+                         [8, 8],
+                         [8, 9]])
     if with_nan:
         target = np.array(['blue', np.nan, np.nan, 'di'], dtype=object)
     else:

--- a/test/unit/test_data_preprocessing.py
+++ b/test/unit/test_data_preprocessing.py
@@ -116,9 +116,9 @@ def data_with_categorical_target(with_nan: bool = False):
     """
     task = Task(TaskTypesEnum.classification)
     features = np.array([[0, 1],
-                         [1, 2],
-                         [0, 3],
-                         [1, 4]])
+                         [1, 3],
+                         [2, 5],
+                         [3, 7]])
     if with_nan:
         target = np.array(['blue', np.nan, np.nan, 'di'], dtype=object)
     else:

--- a/test/unit/test_data_preprocessing.py
+++ b/test/unit/test_data_preprocessing.py
@@ -116,9 +116,9 @@ def data_with_categorical_target(with_nan: bool = False):
     """
     task = Task(TaskTypesEnum.classification)
     features = np.array([[0, 1],
-                         [1, 3],
-                         [2, 5],
-                         [3, 7]])
+                         [1, 0],
+                         [8, 9],
+                         [9, 8]])
     if with_nan:
         target = np.array(['blue', np.nan, np.nan, 'di'], dtype=object)
     else:

--- a/test/unit/test_data_preprocessing.py
+++ b/test/unit/test_data_preprocessing.py
@@ -115,10 +115,10 @@ def data_with_categorical_target(with_nan: bool = False):
     :param with_nan: is there a need to generate target column with np.nan
     """
     task = Task(TaskTypesEnum.classification)
-    features = np.array([[0, 1],
-                         [1, 0],
-                         [8, 9],
-                         [9, 8]])
+    features = np.array([[0, 0],
+                         [0, 1],
+                         [9, 9],
+                         [9, 9]])
     if with_nan:
         target = np.array(['blue', np.nan, np.nan, 'di'], dtype=object)
     else:
@@ -149,12 +149,11 @@ def test_categorical_target_processed_correctly():
     into integer values and then perform inverse operation. API tested in this
     test.
     """
-
     classification_data = data_with_categorical_target()
     train_data, test_data = train_test_data_setup(classification_data)
 
-    fedot_model = Fedot(problem='classification', composer_params=composer_params)
-    fedot_model.fit(train_data)
+    fedot_model = Fedot(problem='classification')
+    fedot_model.fit(train_data, predefined_model='auto')
     predicted = fedot_model.predict(test_data)
 
     # Predicted label must be close to 'di' label (so, right prediction is 'ba')


### PR DESCRIPTION
Modified the Imputer so that it can correctly handle integer features with unique values of 2 or less. 
For example, now `[1, 1, nan, 0]` will not be transformed into `[1, 1, 0.75, 0]`, but into `[1, 1, 1, 0]`. 
Another case: `[1, nan, nan, 0]` (the number of known categories is equal to each other). Then it will be converted inro `[1, 0.5, 0.5, 0]` 

Minor issues with preprocessing and processing of multi-output cases have also been corrected