### PR TITLE
Preset refactor & minor fixes

### DIFF
--- a/cases/credit_scoring/credit_scoring_problem.py
+++ b/cases/credit_scoring/credit_scoring_problem.py
@@ -28,7 +28,7 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
                                with_tuning=False,
                                target='target'):
 
-    preset = 'light_tun' if with_tuning else 'light'
+    preset = 'best_quality_tun' if with_tuning else 'best_quality'
     automl = Fedot(problem='classification', timeout=timeout, verbose_level=4,
                    preset=preset)
     automl.fit(train_file_path, target=target)

--- a/cases/credit_scoring/credit_scoring_problem.py
+++ b/cases/credit_scoring/credit_scoring_problem.py
@@ -28,9 +28,8 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
                                with_tuning=False,
                                target='target'):
 
-    preset = 'best_quality' if with_tuning else 'best_quality'
     automl = Fedot(problem='classification', timeout=timeout, verbose_level=4,
-                   preset=preset)
+                   preset='best_quality', composer_params={'with_tuning': with_tuning})
     automl.fit(train_file_path, target=target)
     predict = automl.predict(test_file_path)
     metrics = automl.get_metrics()

--- a/cases/credit_scoring/credit_scoring_problem.py
+++ b/cases/credit_scoring/credit_scoring_problem.py
@@ -28,7 +28,7 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
                                with_tuning=False,
                                target='target'):
 
-    preset = 'best_quality_tun' if with_tuning else 'best_quality'
+    preset = 'best_quality' if with_tuning else 'best_quality'
     automl = Fedot(problem='classification', timeout=timeout, verbose_level=4,
                    preset=preset)
     automl.fit(train_file_path, target=target)

--- a/cases/industrial/multivariate_forecasting.py
+++ b/cases/industrial/multivariate_forecasting.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
                        'pop_size': 20,
                        'num_of_generations': 20,
                        'timeout': 0.5,
-                       'preset': 'light',
+                       'preset': 'best_quality',
                        'metric': 'rmse',
                        'cv_folds': None,
                        'validation_blocks': None}

--- a/cases/industrial/univariate_forecasting_advanced.py
+++ b/cases/industrial/univariate_forecasting_advanced.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
                        'pop_size': 20,
                        'num_of_generations': 100,
                        'timeout': 2,
-                       'preset': 'best_quality_tun',
+                       'preset': 'best_quality',
                        'metric': 'rmse',
                        'cv_folds': 2,
                        'validation_blocks': 2}

--- a/cases/industrial/univariate_forecasting_advanced.py
+++ b/cases/industrial/univariate_forecasting_advanced.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
                        'pop_size': 20,
                        'num_of_generations': 100,
                        'timeout': 2,
-                       'preset': 'light_tun',
+                       'preset': 'best_quality_tun',
                        'metric': 'rmse',
                        'cv_folds': 2,
                        'validation_blocks': 2}

--- a/cases/industrial/univariate_forecasting_simple.py
+++ b/cases/industrial/univariate_forecasting_simple.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
                        'num_of_generations': 20,
                        'timeout': 2,
                        'with_tuning': True,
-                       'preset': 'light',
+                       'preset': 'best_quality',
                        'genetic_scheme': None,
                        'history_folder': None}
     forecast, obtained_pipeline = automl_fit_forecast(train_input, predict_input, composer_params,

--- a/examples/advanced/additional_learning.py
+++ b/examples/advanced/additional_learning.py
@@ -20,7 +20,7 @@ def run_additional_learning_example():
 
     problem = 'classification'
 
-    auto_model = Fedot(problem=problem, seed=42, preset='light', timeout=5,
+    auto_model = Fedot(problem=problem, seed=42, preset='best_quality', timeout=5,
                        composer_params={'initial_pipeline': Pipeline(
                            SecondaryNode('logit',
                                          nodes_from=[
@@ -41,14 +41,14 @@ def run_additional_learning_example():
     train_data = train_data.head(5000)
     timeout = 1
 
-    auto_model_from_atomized = Fedot(problem=problem, seed=42, preset='light', timeout=timeout,
+    auto_model_from_atomized = Fedot(problem=problem, seed=42, preset='best_quality', timeout=timeout,
                                      composer_params={'initial_pipeline': atomized_model}, verbose_level=2)
     auto_model_from_atomized.fit(features=deepcopy(train_data), target='target')
     auto_model_from_atomized.predict_proba(features=deepcopy(test_data))
     auto_model_from_atomized.current_pipeline.show()
     print('auto_model_from_atomized', auto_model_from_atomized.get_metrics(deepcopy(test_data_target)))
 
-    auto_model_from_pipeline = Fedot(problem=problem, seed=42, preset='light', timeout=timeout,
+    auto_model_from_pipeline = Fedot(problem=problem, seed=42, preset='best_quality', timeout=timeout,
                                      composer_params={'initial_pipeline': non_atomized_model}, verbose_level=2)
     auto_model_from_pipeline.fit(features=deepcopy(train_data), target='target')
     auto_model_from_pipeline.predict_proba(features=deepcopy(test_data))

--- a/examples/advanced/multiobj_optimisation.py
+++ b/examples/advanced/multiobj_optimisation.py
@@ -10,7 +10,7 @@ def run_classification_multiobj_example(with_plot=True, timeout=None):
     del test_data['class']
     problem = 'classification'
 
-    auto_model = Fedot(problem=problem, timeout=timeout, preset='light',
+    auto_model = Fedot(problem=problem, timeout=timeout, preset='best_quality',
                        composer_params={'metric': ['f1', 'node_num']}, seed=42)
     auto_model.fit(features=train_data, target='class')
     prediction = auto_model.predict_proba(features=test_data)

--- a/examples/advanced/remote_execution/ts_composer_with_integration.py
+++ b/examples/advanced/remote_execution/ts_composer_with_integration.py
@@ -62,7 +62,7 @@ def run_automl(df: pd.DataFrame, features_to_use: list, target_series: str,
                        'pop_size': 20,
                        'num_of_generations': 100,
                        'timeout': timeout,
-                       'preset': 'ultra_light',
+                       'preset': 'fast_train',
                        'metric': 'rmse',
                        'cv_folds': None,
                        'validation_blocks': None}

--- a/examples/simple/classification/api_classification.py
+++ b/examples/simple/classification/api_classification.py
@@ -2,7 +2,7 @@ from fedot.api.main import Fedot
 from fedot.core.utils import fedot_project_root
 
 
-def run_classification_example(timeout=None):
+def run_classification_example(timeout: float = None):
     train_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_train.csv'
     test_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_test.csv'
 
@@ -24,4 +24,4 @@ def run_classification_example(timeout=None):
 
 
 if __name__ == '__main__':
-    run_classification_example()
+    run_classification_example(timeout=2)

--- a/examples/simple/pipeline_log.py
+++ b/examples/simple/pipeline_log.py
@@ -3,8 +3,6 @@ import os
 from examples.simple.classification.classification_pipelines import classification_complex_pipeline
 from examples.simple.pipeline_tune import get_case_train_test_data, get_scoring_case_data_paths
 from fedot.core.log import default_log
-from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
-from fedot.core.pipelines.pipeline import Pipeline
 
 
 def run_log_example(log_file_name):

--- a/examples/simple/pipeline_tune.py
+++ b/examples/simple/pipeline_tune.py
@@ -4,7 +4,6 @@ from sklearn.metrics import roc_auc_score as roc_auc
 from cases.data.data_utils import get_scoring_case_data_paths
 from examples.simple.classification.classification_pipelines import classification_complex_pipeline
 from fedot.core.data.data import InputData
-from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.tuning.unified import PipelineTuner
 

--- a/examples/simple/regression/api_regression.py
+++ b/examples/simple/regression/api_regression.py
@@ -13,9 +13,9 @@ def run_regression_example():
     train, test = train_test_data_setup(data)
     problem = 'regression'
 
-    baseline_model = Fedot(problem=problem, composer_params={
-        'history_folder': 'custom_history_folder'
-    })
+    composer_params = {'history_folder': 'custom_history_folder'}
+    baseline_model = Fedot(problem=problem, composer_params=composer_params,
+                           preset='best_quality')
     baseline_model.fit(features=train)
 
     baseline_model.predict(features=test)

--- a/examples/simple/regression/api_regression.py
+++ b/examples/simple/regression/api_regression.py
@@ -15,7 +15,7 @@ def run_regression_example():
 
     composer_params = {'history_folder': 'custom_history_folder'}
     baseline_model = Fedot(problem=problem, composer_params=composer_params,
-                           preset='steady_state')
+                           preset='stable')
     baseline_model.fit(features=train)
 
     baseline_model.predict(features=test)

--- a/examples/simple/regression/api_regression.py
+++ b/examples/simple/regression/api_regression.py
@@ -15,7 +15,7 @@ def run_regression_example():
 
     composer_params = {'history_folder': 'custom_history_folder'}
     baseline_model = Fedot(problem=problem, composer_params=composer_params,
-                           preset='best_quality')
+                           preset='steady_state_tun')
     baseline_model.fit(features=train)
 
     baseline_model.predict(features=test)

--- a/examples/simple/regression/api_regression.py
+++ b/examples/simple/regression/api_regression.py
@@ -15,7 +15,7 @@ def run_regression_example():
 
     composer_params = {'history_folder': 'custom_history_folder'}
     baseline_model = Fedot(problem=problem, composer_params=composer_params,
-                           preset='steady_state_tun')
+                           preset='steady_state')
     baseline_model.fit(features=train)
 
     baseline_model.predict(features=test)

--- a/examples/simple/time_series_forecasting/api_foresacting.py
+++ b/examples/simple/time_series_forecasting/api_foresacting.py
@@ -5,7 +5,7 @@ from fedot.core.repository.tasks import TsForecastingParams
 from fedot.core.utils import fedot_project_root
 
 
-def run_ts_forecasting_example(with_plot=True, with_pipeline_vis=True, timeout: float=None):
+def run_ts_forecasting_example(with_plot=True, with_pipeline_vis=True, timeout: float = None):
     train_data_path = f'{fedot_project_root()}/examples/data/ts/salaries.csv'
 
     target = pd.read_csv(train_data_path)['value']

--- a/examples/simple/time_series_forecasting/api_foresacting.py
+++ b/examples/simple/time_series_forecasting/api_foresacting.py
@@ -5,7 +5,7 @@ from fedot.core.repository.tasks import TsForecastingParams
 from fedot.core.utils import fedot_project_root
 
 
-def run_ts_forecasting_example(with_plot=True, with_pipeline_vis=True, timeout=None):
+def run_ts_forecasting_example(with_plot=True, with_pipeline_vis=True, timeout: float=None):
     train_data_path = f'{fedot_project_root()}/examples/data/ts/salaries.csv'
 
     target = pd.read_csv(train_data_path)['value']
@@ -16,7 +16,7 @@ def run_ts_forecasting_example(with_plot=True, with_pipeline_vis=True, timeout=N
 
     # init model for the time series forecasting
     model = Fedot(problem='ts_forecasting', task_params=task_parameters, timeout=timeout,
-                  preset='ts_tun')
+                  preset='fast_train')
 
     # run AutoML model design in the same way
     pipeline = model.fit(features=train_data_path, target='value')
@@ -36,4 +36,4 @@ def run_ts_forecasting_example(with_plot=True, with_pipeline_vis=True, timeout=N
 
 
 if __name__ == '__main__':
-    run_ts_forecasting_example()
+    run_ts_forecasting_example(timeout=0.5)

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -138,11 +138,7 @@ class ApiComposer:
             secondary_operations = available_operations
         return primary_operations, secondary_operations
 
-    def compose_fedot_model(self,
-                            api_params: dict,
-                            composer_params: dict,
-                            tuning_params: dict
-                            ):
+    def compose_fedot_model(self, api_params: dict, composer_params: dict, tuning_params: dict):
         """ Function for composing FEDOT pipeline model """
 
         metric_function = self.obtain_metric(api_params['task'], composer_params['composer_metric'])
@@ -191,10 +187,7 @@ class ApiComposer:
         optimizer_parameters = GPGraphOptimiserParameters(
             genetic_scheme_type=genetic_scheme_type,
             mutation_types=mutations,
-            crossover_types=[
-                CrossoverTypesEnum.one_point,
-                CrossoverTypesEnum.subtree
-            ],
+            crossover_types=[CrossoverTypesEnum.one_point, CrossoverTypesEnum.subtree],
             history_folder=composer_params.get('history_folder'),
             stopping_after_n_generation=composer_params.get('stopping_after_n_generation')
         )

--- a/fedot/api/api_utils/api_data.py
+++ b/fedot/api/api_utils/api_data.py
@@ -1,5 +1,5 @@
-from copy import deepcopy, copy
-from typing import Union, List, Dict
+from copy import deepcopy
+from typing import Union, Dict
 
 import numpy as np
 import pandas as pd

--- a/fedot/api/api_utils/params.py
+++ b/fedot/api/api_utils/params.py
@@ -98,7 +98,10 @@ class ApiParams:
 
     def change_preset_for_label_encoded_data(self, task: Task):
         """ Change preset on tree like preset, if data had been label encoded """
-        preset_name = '*tree'
+        if self.api_params.get('preset') is not None:
+            preset_name = ''.join((self.api_params['preset'], '*tree'))
+        else:
+            preset_name = '*tree'
         preset_operations = OperationsPreset(task=task, preset_name=preset_name)
         del self.api_params['available_operations']
         self.api_params = preset_operations.composer_params_based_on_preset(composer_params=self.api_params)

--- a/fedot/api/api_utils/params.py
+++ b/fedot/api/api_utils/params.py
@@ -59,8 +59,6 @@ class ApiParams:
                                          input_params['task_params'])
         self.metric_name = self.get_default_metric(input_params['problem'])
 
-        return
-
     def initialize_params(self, **input_params):
         self.get_initial_params(**input_params)
         preset_operations = OperationsPreset(task=self.task, preset_name=input_params['preset'])
@@ -100,7 +98,7 @@ class ApiParams:
 
     def change_preset_for_label_encoded_data(self, task: Task):
         """ Change preset on tree like preset, if data had been label encoded """
-        preset_name = 'tree_reg' if task.task_type == 'regression' else 'tree_class'
+        preset_name = '*tree'
         preset_operations = OperationsPreset(task=task, preset_name=preset_name)
         del self.api_params['available_operations']
         self.api_params = preset_operations.composer_params_based_on_preset(composer_params=self.api_params)

--- a/fedot/api/api_utils/params.py
+++ b/fedot/api/api_utils/params.py
@@ -118,7 +118,7 @@ class ApiParams:
                   'pop_size': 20,
                   'num_of_generations': 20,
                   'timeout': 2,
-                  'with_tuning': False,
+                  'with_tuning': True,
                   'preset': 'best_quality',
                   'genetic_scheme': None,
                   'history_folder': None,

--- a/fedot/api/api_utils/params.py
+++ b/fedot/api/api_utils/params.py
@@ -119,7 +119,7 @@ class ApiParams:
                   'num_of_generations': 20,
                   'timeout': 2,
                   'with_tuning': False,
-                  'preset': 'light',
+                  'preset': 'best_quality',
                   'genetic_scheme': None,
                   'history_folder': None,
                   'stopping_after_n_generation': 10}

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -25,9 +25,6 @@ class OperationsPreset:
         if self.preset_name is None and 'preset' in updated_params:
             self.preset_name = updated_params['preset']
 
-        # if 'preset' in updated_params:
-        #     del updated_params['preset']
-
         if self.preset_name is not None and 'available_operations' not in composer_params:
             available_operations = self._filter_operations_by_preset()
             updated_params['available_operations'] = available_operations

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -41,7 +41,7 @@ class OperationsPreset:
         # TODO remove workaround
         # Use best_quality preset but exclude several operations
         preset_name = self.preset_name
-        if 'steady_state' in self.preset_name:
+        if 'stable' in self.preset_name:
             # Use best_quality preset but exclude several operations
             preset_name = 'best_quality'
         excluded = ['mlp', 'svc', 'svr', 'arima', 'exog_ts', 'text_clean',
@@ -51,7 +51,7 @@ class OperationsPreset:
         available_operations = get_operations_for_task(self.task, mode='all', preset=preset_name)
 
         # Exclude "heavy" operations if necessary
-        if 'steady_state' in self.preset_name:
+        if 'stable' in self.preset_name:
             available_operations = self.new_operations_without_heavy(excluded, available_operations)
 
         if 'gpu' in self.preset_name:

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -38,50 +38,34 @@ class OperationsPreset:
         """ Filter operations by preset, remove "heavy" operations and save
         appropriate ones
         """
-        excluded = ['mlp', 'svc', 'svr', 'arima', 'exog_ts', 'text_clean']
-
         # TODO remove workaround
-        extended_excluded = ['mlp', 'catboost', 'lda', 'qda', 'lgbm',
-                             'svc', 'svr', 'arima', 'exog_ts', 'text_clean',
-                             'one_hot_encoding', 'resample']
-        excluded_models_dict = {'light': excluded,
-                                'light_steady_state': extended_excluded}
+        # Use best_quality preset but exclude several operations
+        preset_name = self.preset_name
+        if 'steady_state' in self.preset_name:
+            # Use best_quality preset but exclude several operations
+            if 'tun' in self.preset_name:
+                preset_name = 'best_quality_tun'
+            else:
+                preset_name = 'best_quality'
+        excluded = ['mlp', 'svc', 'svr', 'arima', 'exog_ts', 'text_clean',
+                    'catboost', 'lda', 'qda', 'lgbm', 'one_hot_encoding',
+                    'resample']
 
-        # Get data operations and models
-        available_operations = get_operations_for_task(self.task, mode='all')
-        available_data_operation = get_operations_for_task(self.task, mode='data_operation')
+        available_operations = get_operations_for_task(self.task, mode='all', preset=preset_name)
 
         # Exclude "heavy" operations if necessary
-        available_operations = self._new_operations_without_heavy(excluded_models_dict, available_operations)
+        if 'steady_state' in self.preset_name:
+            available_operations = self.new_operations_without_heavy(excluded, available_operations)
 
-        # Save only "light" operations
-        if self.preset_name in ['ultra_light', 'ultra_steady_state']:
-            light_models = ['dt', 'dtreg', 'logit', 'linear', 'lasso', 'ridge', 'knn', 'ar']
-            included_operations = light_models + available_data_operation
-            available_operations = [_ for _ in available_operations if _ in included_operations]
-        elif self.preset_name in ['ts']:
-            # Presets for time series forecasting
-            available_operations = ['lagged', 'sparse_lagged', 'ar', 'gaussian_filter', 'smoothing',
-                                    'ridge', 'linear', 'lasso', 'dtreg', 'scaling', 'normalization',
-                                    'pca', 'cut', 'polyfit', 'ets', 'glm']
-        elif self.preset_name == 'tree_reg':
-            tree_reg = ['dtreg', 'rfr', 'treg', 'adareg', 'catboostreg', 'gbr', 'lgbmreg', 'xgbreg']
-            included_operations = tree_reg + available_data_operation
-            available_operations = [_ for _ in available_operations if _ in included_operations]
-        elif self.preset_name == 'tree_class':
-            tree_class = ['dt', 'rf', 'catboost', 'lgbm', 'xgboost']
-            included_operations = tree_class + available_data_operation
-            available_operations = [_ for _ in available_operations if _ in included_operations]
-        if self.preset_name == 'gpu':
+        if 'gpu' in self.preset_name:
             repository = OperationTypesRepository().assign_repo('model', 'gpu_models_repository.json')
             available_operations = repository.suitable_operation(task_type=self.task.task_type)
 
         return available_operations
 
-    def _new_operations_without_heavy(self, excluded_models_dict, available_operations) -> list:
+    @staticmethod
+    def new_operations_without_heavy(excluded_operations, available_operations) -> list:
         """ Create new list without heavy operations """
-        if self.preset_name in excluded_models_dict.keys():
-            excluded_operations = excluded_models_dict[self.preset_name]
-            available_operations = [_ for _ in available_operations if _ not in excluded_operations]
+        available_operations = [_ for _ in available_operations if _ not in excluded_operations]
 
         return available_operations

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -43,10 +43,7 @@ class OperationsPreset:
         preset_name = self.preset_name
         if 'steady_state' in self.preset_name:
             # Use best_quality preset but exclude several operations
-            if 'tun' in self.preset_name:
-                preset_name = 'best_quality_tun'
-            else:
-                preset_name = 'best_quality'
+            preset_name = 'best_quality'
         excluded = ['mlp', 'svc', 'svr', 'arima', 'exog_ts', 'text_clean',
                     'catboost', 'lda', 'qda', 'lgbm', 'one_hot_encoding',
                     'resample']

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -33,7 +33,15 @@ class Fedot:
         - regression
         - ts_forecasting
         - clustering
-    :param preset: name of preset for model building (e.g. 'light', 'ultra-light')
+    :param preset: name of preset for model building (e.g. 'best_quality', 'fast_train', 'gpu')
+        - 'best_quality' - All models that are available for this data type and task are used
+        - 'fast_train' - Models that learn quickly. This includes preprocessing operations that
+            only reduce the dimensionality of the data, but cannot increase it. For example,
+            there are no polynomial features and one-hot encoding operations
+        - 'gpu' - Models that use GPU resources for computation.
+        - '*tree_reg' - A special preset that allows only tree-based algorithms for regression case.
+        - '*tree_class' - A special preset that allows only tree-based algorithms for classification case.
+        - '*ts' - A special preset with models for time series forecasting task.
     :param timeout: time for model design (in minutes)
     :param composer_params: parameters of pipeline optimisation
         The possible parameters are:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -82,6 +82,7 @@ class Fedot:
         self.metrics = ApiMetrics(problem)
         self.api_composer = ApiComposer(problem)
         self.composer_params = ApiParams()
+        self.timeout_set_in_init = timeout
 
         input_params = {'problem': problem, 'preset': preset, 'timeout': timeout,
                         'composer_params': composer_params, 'task_params': task_params,
@@ -138,6 +139,8 @@ class Fedot:
             # Fit predefined model and return it without composing
             self.current_pipeline = self._process_predefined_model(predefined_model)
         else:
+            if self.timeout_set_in_init is not None:
+                self.api_params['timeout'] = self.timeout_set_in_init
             self.current_pipeline, self.best_models, self.history = self.api_composer.obtain_model(**self.api_params)
 
         self._train_pipeline_on_full_dataset(recommendations, full_train_not_preprocessed)

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -39,9 +39,9 @@ class Fedot:
             only reduce the dimensionality of the data, but cannot increase it. For example,
             there are no polynomial features and one-hot encoding operations
         - 'gpu' - Models that use GPU resources for computation.
-        - '*tree_reg' - A special preset that allows only tree-based algorithms for regression case.
-        - '*tree_class' - A special preset that allows only tree-based algorithms for classification case.
+        - '*tree' - A special preset that allows only tree-based algorithms
         - '*ts' - A special preset with models for time series forecasting task.
+        - '*automl' - A special preset with only AutoML libraries such as TPOT and H2O as operations
     :param timeout: time for model design (in minutes)
     :param composer_params: parameters of pipeline optimisation
         The possible parameters are:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -40,9 +40,9 @@ class Fedot:
              it. For example, there are no polynomial features and one-hot encoding operations
         - 'stable' - The most reliable preset in which the most stable operations are included.
         - 'gpu' - Models that use GPU resources for computation.
+        - 'ts' - A special preset with models for time series forecasting task.
+        - 'automl' - A special preset with only AutoML libraries such as TPOT and H2O as operations.
         - '*tree' - A special preset that allows only tree-based algorithms
-        - '*ts' - A special preset with models for time series forecasting task.
-        - '*automl' - A special preset with only AutoML libraries such as TPOT and H2O as operations
     :param timeout: time for model design (in minutes)
     :param composer_params: parameters of pipeline optimisation
         The possible parameters are:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -38,7 +38,7 @@ class Fedot:
         - 'fast_train' - Models that learn quickly. This includes preprocessing operations
             (data operations) that only reduce the dimensionality of the data, but cannot increase
              it. For example, there are no polynomial features and one-hot encoding operations
-        - 'steady_state' - The most reliable preset in which the most stable operations are included.
+        - 'stable' - The most reliable preset in which the most stable operations are included.
         - 'gpu' - Models that use GPU resources for computation.
         - '*tree' - A special preset that allows only tree-based algorithms
         - '*ts' - A special preset with models for time series forecasting task.

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -35,9 +35,10 @@ class Fedot:
         - clustering
     :param preset: name of preset for model building (e.g. 'best_quality', 'fast_train', 'gpu')
         - 'best_quality' - All models that are available for this data type and task are used
-        - 'fast_train' - Models that learn quickly. This includes preprocessing operations that
-            only reduce the dimensionality of the data, but cannot increase it. For example,
-            there are no polynomial features and one-hot encoding operations
+        - 'fast_train' - Models that learn quickly. This includes preprocessing operations
+            (data operations) that only reduce the dimensionality of the data, but cannot increase
+             it. For example, there are no polynomial features and one-hot encoding operations
+        - 'steady_state' - The most reliable preset in which the most stable operations are included.
         - 'gpu' - Models that use GPU resources for computation.
         - '*tree' - A special preset that allows only tree-based algorithms
         - '*ts' - A special preset with models for time series forecasting task.

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
@@ -49,7 +49,7 @@ class FilterImplementation(DataOperationImplementation):
                 # Update data
                 modified_input_data = self._update_data(input_data, mask)
             else:
-                self.log.info("Filtering Algorithm: didn't fit correctly. Return all features")
+                self.log.info("Filtering Algorithm: didn't fit correctly. Return all objects")
                 inner_features = features
                 modified_input_data = copy(input_data)
 
@@ -103,7 +103,7 @@ class RegRANSACImplementation(FilterImplementation):
                 self.operation.fit(input_data.features, input_data.target)
                 return self.operation
             except ValueError:
-                self.log.info("RASNAC: multiplied residual_threshold on 2")
+                self.log.info("RANSAC: multiplied residual_threshold on 2")
                 self.params["residual_threshold"] *= 2
                 self.parameters_changed = True
                 iter_ += 1

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -407,9 +407,9 @@ class EvoGraphOptimiser(GraphOptimiser):
         return individuals_set
 
     def _is_stopping_criteria_triggered(self):
-        if self.use_stopping_criteria:
-            if self.num_of_gens_without_improvements == self.stopping_after_n_generation:
-                self.log.info(f'GP_Optimiser: Early stopping criteria was triggered and composing finished')
-                return True
+        is_stopping_needed = self.stopping_after_n_generation is not None
+        if is_stopping_needed and self.num_of_gens_without_improvements == self.stopping_after_n_generation:
+            self.log.info(f'GP_Optimiser: Early stopping criteria was triggered and composing finished')
+            return True
         else:
             return False

--- a/fedot/core/optimisers/gp_comp/param_free_gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/param_free_gp_optimiser.py
@@ -48,7 +48,6 @@ class EvoGraphParameterFreeOptimiser(EvoGraphOptimiser):
         self.requirements.pop_size = self.iterator.next()
         self.metrics = metrics
 
-        self.use_stopping_criteria = parameters.use_stopping_criteria
         self.stopping_after_n_generation = parameters.stopping_after_n_generation
 
         self.qual_position = 0

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -39,7 +39,6 @@ class GraphOptimiserParameters:
         self.multi_objective = multi_objective
         self.history_folder = history_folder
         self.stopping_after_n_generation = stopping_after_n_generation
-        self.use_stopping_criteria = self.stopping_after_n_generation is not None
 
 
 class GraphOptimiser:
@@ -79,7 +78,6 @@ class GraphOptimiser:
         self.graph_generation_function = partial(random_graph, params=self.graph_generation_params,
                                                  requirements=self.requirements, max_depth=self.max_depth)
 
-        self.use_stopping_criteria = parameters.use_stopping_criteria
         self.stopping_after_n_generation = parameters.stopping_after_n_generation
 
         self.initial_graph = initial_graph
@@ -134,10 +132,10 @@ class GraphOptimiser:
         return individuals_set
 
     def _is_stopping_criteria_triggered(self):
-        if self.use_stopping_criteria:
-            if self.num_of_gens_without_improvements == self.stopping_after_n_generation:
-                self.log.info(f'GP_Optimiser: Early stopping criteria was triggered and composing finished')
-                return True
+        is_stopping_needed = self.stopping_after_n_generation is not None
+        if is_stopping_needed and self.num_of_gens_without_improvements == self.stopping_after_n_generation:
+            self.log.info(f'GP_Optimiser: Early stopping criteria was triggered and composing finished')
+            return True
         else:
             return False
 

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -196,7 +196,7 @@ class HyperoptTuner(ABC):
             preds, test_target = cv_time_series_predictions(pipeline, data, log=self.log,
                                                             cv_folds=self.cv_folds,
                                                             validation_blocks=self.validation_blocks)
-        return test_target, preds
+        return preds, test_target
 
     @property
     def _default_metric_value(self):

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -144,7 +144,8 @@ class HyperoptTuner(ABC):
 
         if self.is_need_to_maximize is True:
             # Maximization
-            init_metric = self.init_metric - deviation
+            init_metric = -1 * (self.init_metric - deviation)
+            obtained_metric = -1 * obtained_metric
             if obtained_metric >= init_metric:
                 self.log.info(f'{prefix_tuned_phrase} {obtained_metric:.3f} equal or '
                               f'bigger than initial (- 5% deviation) {init_metric:.3f}')

--- a/fedot/core/pipelines/validation_rules.py
+++ b/fedot/core/pipelines/validation_rules.py
@@ -132,7 +132,7 @@ def has_no_data_flow_conflicts_in_ts_pipeline(pipeline: 'Pipeline'):
     # Preprocessing not only for time series
     non_ts_data_operations = get_operations_for_task(task=task,
                                                      mode='data_operation',
-                                                     forbidden_tags=["non_lagged"])
+                                                     tags=["non_applicable_for_ts"])
     ts_data_operations = get_operations_for_task(task=task,
                                                  mode='data_operation',
                                                  tags=["non_lagged"])

--- a/fedot/core/repository/data/automl_repository.json
+++ b/fedot/core/repository/data/automl_repository.json
@@ -77,24 +77,28 @@
   "operations": {
     "h2o_regr": {
       "meta": "h2o_regr",
+      "presets": ["*automl"],
       "tags": [
         "automl"
       ]
     },
     "h2o_class": {
       "meta": "h2o_class",
+      "presets": ["*automl"],
       "tags": [
         "automl"
       ]
     },
     "tpot_regr": {
       "meta": "tpot_regr",
+      "presets": ["*automl"],
       "tags": [
         "automl"
       ]
     },
     "tpot_class": {
       "meta": "tpot_class",
+      "presets": ["*automl"],
       "tags": [
         "automl"
       ]

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -123,18 +123,22 @@
 		},
 		"scaling": {
 			"meta": "custom_preprocessing",
+			"presets": ["fast_train"],
 			"tags": ["simple"]
 		},
 		"normalization": {
 			"meta": "custom_preprocessing",
+			"presets": ["fast_train"],
 			"tags": ["simple"]
 		},
 		"simple_imputation": {
-		  "meta": "custom_preprocessing",
-		  "tags": ["simple", "imputation", "non-default", "categorical-ignore"]
+			"meta": "custom_preprocessing",
+			"presets": ["fast_train"],
+		  	"tags": ["simple", "imputation", "non-default", "categorical-ignore"]
 		},
 		"pca": {
 			"meta": "dimension_transformation",
+			"presets": ["fast_train"],
 			"tags": ["linear", "dimensionality_transforming", "correct_params"]
 		},
 		"kernel_pca": {
@@ -156,14 +160,17 @@
 		},
 		"label_encoding": {
 			"meta": "sklearn_categorical",
+			"presets": ["fast_train"],
 			"tags": ["encoding", "categorical", "non-default"]
 		},
 		"ransac_lin_reg": {
 			"meta": "regression_preprocessing",
+			"presets": ["fast_train"],
 			"tags": ["affects_target", "linear", "filtering", "correct_params"]
 		},
 		"ransac_non_lin_reg": {
 			"meta": "regression_preprocessing",
+			"presets": ["fast_train"],
 			"tags": ["affects_target", "non_linear", "filtering", "correct_params"]
 		},
 		"rfe_lin_reg": {

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -134,7 +134,7 @@
 		"simple_imputation": {
 			"meta": "custom_preprocessing",
 			"presets": ["fast_train", "*tree"],
-		  	"tags": ["simple", "imputation", "non-default", "categorical-ignore"]
+		  	"tags": ["simple", "imputation", "categorical-ignore"]
 		},
 		"pca": {
 			"meta": "dimension_transformation",
@@ -147,7 +147,6 @@
 			"tags": [
 				"non_linear",
 				"dimensionality_transforming",
-				"non-default",
 				"correct_params"
 			]
 		},

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -123,12 +123,12 @@
 		},
 		"scaling": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train", "*ts", "*tree"],
+			"presets": ["fast_train", "ts", "*tree"],
 			"tags": ["simple"]
 		},
 		"normalization": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train", "*ts", "*tree"],
+			"presets": ["fast_train", "ts", "*tree"],
 			"tags": ["simple"]
 		},
 		"simple_imputation": {
@@ -138,12 +138,12 @@
 		},
 		"pca": {
 			"meta": "dimension_transformation",
-			"presets": ["fast_train", "*ts", "*tree"],
+			"presets": ["fast_train", "ts", "*tree"],
 			"tags": ["linear", "dimensionality_transforming", "correct_params", "non_applicable_for_ts"]
 		},
 		"kernel_pca": {
 			"meta": "dimension_transformation",
-			"presets": ["*ts", "*tree"],
+			"presets": ["ts", "*tree"],
 			"tags": [
 				"non_linear",
 				"dimensionality_transforming",
@@ -192,7 +192,7 @@
 		},
 		"lagged": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "ts"],
 			"tags": [
 				"affects_target",
 				"dimensionality_transforming",
@@ -202,7 +202,7 @@
 		},
 		"sparse_lagged": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "ts"],
 			"tags": [
 				"affects_target",
 				"dimensionality_transforming",
@@ -212,7 +212,7 @@
 		},
 		"smoothing": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "ts"],
 			"tags": [
 				"simple",
 				"smoothing",
@@ -221,7 +221,7 @@
 		},
 		"gaussian_filter": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "ts"],
 			"tags": [
 				"simple",
 				"smoothing",
@@ -230,7 +230,7 @@
 		},
 		"diff_filter": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "ts"],
 			"tags": [
 				"differential",
 				"non_lagged",
@@ -239,7 +239,7 @@
 		},
 		"cut": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "ts"],
 			"tags": [
 				"simple",
 				"cutting",
@@ -260,7 +260,7 @@
 		},
 		"decompose": {
 		  "meta": "regression_preprocessing",
-		  "presets": ["fast_train", "*ts", "*tree"],
+		  "presets": ["fast_train", "ts", "*tree"],
 		  "tags": ["non-default", "decompose"]
 		},
 		"class_decompose": {

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -101,19 +101,19 @@
 			"meta": "data_sources",
 			"input_type": "[DataTypesEnum.image]",
 			"output_type": "[DataTypesEnum.image]",
-			"tags": ["nans-ignore", "categorical-ignore"]
+			"tags": ["nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
 		},
 		"data_source_text": {
 			"meta": "data_sources",
 			"input_type": "[DataTypesEnum.text]",
 			"output_type": "[DataTypesEnum.text]",
-			"tags": ["nans-ignore", "categorical-ignore"]
+			"tags": ["nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
 		},
 		"data_source_table": {
 			"meta": "data_sources",
 			"input_type": "[DataTypesEnum.table]",
 			"output_type": "[DataTypesEnum.table]",
-			"tags": ["nans-ignore", "categorical-ignore"]
+			"tags": ["nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
 		},
 		"data_source_ts": {
 		  "meta": "data_sources",
@@ -139,7 +139,7 @@
 		"pca": {
 			"meta": "dimension_transformation",
 			"presets": ["fast_train", "*ts", "*tree"],
-			"tags": ["linear", "dimensionality_transforming", "correct_params"]
+			"tags": ["linear", "dimensionality_transforming", "correct_params", "non_applicable_for_ts"]
 		},
 		"kernel_pca": {
 			"meta": "dimension_transformation",
@@ -147,39 +147,40 @@
 			"tags": [
 				"non_linear",
 				"dimensionality_transforming",
-				"correct_params"
+				"correct_params",
+				"non_applicable_for_ts"
 			]
 		},
 		"poly_features": {
 			"meta": "dimension_transformation",
-			"tags": ["non_linear", "dimensionality_transforming"]
+			"tags": ["non_linear", "dimensionality_transforming", "non_applicable_for_ts"]
 		},
 		"one_hot_encoding": {
 			"meta": "sklearn_categorical",
-			"tags": ["encoding", "categorical", "dimensionality_transforming"]
+			"tags": ["encoding", "categorical", "dimensionality_transforming", "non_applicable_for_ts"]
 		},
 		"label_encoding": {
 			"meta": "sklearn_categorical",
 			"presets": ["fast_train", "*tree"],
-			"tags": ["encoding", "categorical", "non-default"]
+			"tags": ["encoding", "categorical", "non-default", "non_applicable_for_ts"]
 		},
 		"ransac_lin_reg": {
 			"meta": "regression_preprocessing",
 			"presets": ["fast_train", "*tree"],
-			"tags": ["affects_target", "linear", "filtering", "correct_params"]
+			"tags": ["affects_target", "linear", "filtering", "correct_params", "non_applicable_for_ts"]
 		},
 		"ransac_non_lin_reg": {
 			"meta": "regression_preprocessing",
 			"presets": ["fast_train", "*tree"],
-			"tags": ["affects_target", "non_linear", "filtering", "correct_params"]
+			"tags": ["affects_target", "non_linear", "filtering", "correct_params", "non_applicable_for_ts"]
 		},
 		"rfe_lin_reg": {
 			"meta": "regression_preprocessing",
-			"tags": ["linear", "feature_selection"]
+			"tags": ["linear", "feature_selection", "non_applicable_for_ts"]
 		},
 		"rfe_non_lin_reg": {
 			"meta": "regression_preprocessing",
-			"tags": ["non_linear", "feature_selection"]
+			"tags": ["non_linear", "feature_selection", "non_applicable_for_ts"]
 		},
 		"rfe_lin_class": {
 			"meta": "classification_preprocessing",
@@ -255,7 +256,7 @@
 		},
 		"text_clean": {
 			"meta": "text_preprocessing",
-			"tags": []
+			"tags": ["non_applicable_for_ts"]
 		},
 		"decompose": {
 		  "meta": "regression_preprocessing",
@@ -269,9 +270,7 @@
         },
       "resample": {
         "meta": "classification_preprocessing",
-        "tags": [
-          "imbalanced"
-        ]
+        "tags": ["imbalanced"]
 		}
 	}
 }

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -123,12 +123,12 @@
 		},
 		"scaling": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*ts"],
 			"tags": ["simple"]
 		},
 		"normalization": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*ts"],
 			"tags": ["simple"]
 		},
 		"simple_imputation": {
@@ -138,11 +138,12 @@
 		},
 		"pca": {
 			"meta": "dimension_transformation",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*ts"],
 			"tags": ["linear", "dimensionality_transforming", "correct_params"]
 		},
 		"kernel_pca": {
 			"meta": "dimension_transformation",
+			"presets": ["*ts"],
 			"tags": [
 				"non_linear",
 				"dimensionality_transforming",
@@ -191,6 +192,7 @@
 		},
 		"lagged": {
 			"meta": "custom_time_series_transformation",
+			"presets": ["*ts"],
 			"tags": [
 				"affects_target",
 				"dimensionality_transforming",
@@ -200,6 +202,7 @@
 		},
 		"sparse_lagged": {
 			"meta": "custom_time_series_transformation",
+			"presets": ["*ts"],
 			"tags": [
 				"affects_target",
 				"dimensionality_transforming",
@@ -209,6 +212,7 @@
 		},
 		"smoothing": {
 			"meta": "custom_time_series_transformation",
+			"presets": ["fast_train", "*ts"],
 			"tags": [
 				"simple",
 				"smoothing",
@@ -217,6 +221,7 @@
 		},
 		"gaussian_filter": {
 			"meta": "custom_time_series_transformation",
+			"presets": ["fast_train", "*ts"],
 			"tags": [
 				"simple",
 				"smoothing",

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -123,27 +123,27 @@
 		},
 		"scaling": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "*ts", "*tree"],
 			"tags": ["simple"]
 		},
 		"normalization": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "*ts", "*tree"],
 			"tags": ["simple"]
 		},
 		"simple_imputation": {
 			"meta": "custom_preprocessing",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*tree"],
 		  	"tags": ["simple", "imputation", "non-default", "categorical-ignore"]
 		},
 		"pca": {
 			"meta": "dimension_transformation",
-			"presets": ["fast_train", "*ts"],
+			"presets": ["fast_train", "*ts", "*tree"],
 			"tags": ["linear", "dimensionality_transforming", "correct_params"]
 		},
 		"kernel_pca": {
 			"meta": "dimension_transformation",
-			"presets": ["*ts"],
+			"presets": ["*ts", "*tree"],
 			"tags": [
 				"non_linear",
 				"dimensionality_transforming",
@@ -161,17 +161,17 @@
 		},
 		"label_encoding": {
 			"meta": "sklearn_categorical",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*tree"],
 			"tags": ["encoding", "categorical", "non-default"]
 		},
 		"ransac_lin_reg": {
 			"meta": "regression_preprocessing",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*tree"],
 			"tags": ["affects_target", "linear", "filtering", "correct_params"]
 		},
 		"ransac_non_lin_reg": {
 			"meta": "regression_preprocessing",
-			"presets": ["fast_train"],
+			"presets": ["fast_train", "*tree"],
 			"tags": ["affects_target", "non_linear", "filtering", "correct_params"]
 		},
 		"rfe_lin_reg": {
@@ -192,7 +192,7 @@
 		},
 		"lagged": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["*ts"],
+			"presets": ["fast_train", "*ts"],
 			"tags": [
 				"affects_target",
 				"dimensionality_transforming",
@@ -202,7 +202,7 @@
 		},
 		"sparse_lagged": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["*ts"],
+			"presets": ["fast_train", "*ts"],
 			"tags": [
 				"affects_target",
 				"dimensionality_transforming",
@@ -230,6 +230,7 @@
 		},
 		"diff_filter": {
 			"meta": "custom_time_series_transformation",
+			"presets": ["fast_train", "*ts"],
 			"tags": [
 				"differential",
 				"non_lagged",
@@ -238,6 +239,7 @@
 		},
 		"cut": {
 			"meta": "custom_time_series_transformation",
+			"presets": ["fast_train", "*ts"],
 			"tags": [
 				"simple",
 				"cutting",
@@ -258,10 +260,12 @@
 		},
 		"decompose": {
 		  "meta": "regression_preprocessing",
+		  "presets": ["fast_train", "*ts", "*tree"],
 		  "tags": ["non-default", "decompose"]
 		},
 		"class_decompose": {
 		  "meta": "classification_preprocessing",
+		  "presets": ["fast_train", "*tree"],
 		  "tags": ["non-default", "decompose"]
         },
       "resample": {

--- a/fedot/core/repository/data/default_operation_params.json
+++ b/fedot/core/repository/data/default_operation_params.json
@@ -115,5 +115,9 @@
     "balance": "expand_minority",
     "replace": true,
     "n_samples": 0.5
+  },
+  "pca": {
+    "svd_solver": "full",
+    "n_components": "mle"
   }
 }

--- a/fedot/core/repository/data/gpu_models_repository.json
+++ b/fedot/core/repository/data/gpu_models_repository.json
@@ -64,6 +64,7 @@
   "operations": {
     "logit": {
       "meta": "rapids_gpu_class",
+      "presets": ["gpu"],
       "tags": [
         "simple",
         "linear",
@@ -71,53 +72,68 @@
       ]
     },
     "rf": {
-      "meta": "rapids_gpu_class"
+      "meta": "rapids_gpu_class",
+      "presets": ["gpu"]
     },
     "lasso": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "svc": {
       "meta": "rapids_gpu_class",
+      "presets": ["gpu"],
       "tags": [
         "no_prob",
         "expensive"
       ]
     },
     "kmeans": {
-      "meta": "rapids_gpu_clust"
+      "meta": "rapids_gpu_clust",
+      "presets": ["gpu"]
     },
     "linear": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "ridge": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "rfr": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "knn": {
-      "meta": "rapids_gpu_class"
+      "meta": "rapids_gpu_class",
+      "presets": ["gpu"]
     },
     "knnreg": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "sgd": {
-      "meta": "rapids_gpu_class"
+      "meta": "rapids_gpu_class",
+      "presets": ["gpu"]
     },
     "multinb": {
-      "meta": "rapids_gpu_class"
+      "meta": "rapids_gpu_class",
+      "presets": ["gpu"]
     },
     "elasticnet": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "minibatchsgd": {
-      "meta": "rapids_gpu_class"
+      "meta": "rapids_gpu_class",
+      "presets": ["gpu"]
     },
     "mbsgdcregr": {
-      "meta": "rapids_gpu_regr"
+      "meta": "rapids_gpu_regr",
+      "presets": ["gpu"]
     },
     "cd": {
-      "meta": "rapids_gpu_class"
+      "meta": "rapids_gpu_class",
+      "presets": ["gpu"]
     }
   }
 }

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -139,6 +139,7 @@
   "operations": {
     "adareg": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "boosting",
         "non_multi"
@@ -146,6 +147,7 @@
     },
     "ar": {
       "meta": "ts_model",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -154,6 +156,7 @@
     },
     "arima": {
       "meta": "ts_model",
+      "presets": ["*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -168,6 +171,7 @@
     },
     "bernb": {
       "meta": "sklearn_class",
+      "presets": ["fast_train"],
       "tags": [
         "bayesian"
       ]
@@ -187,6 +191,7 @@
     },
     "dt": {
       "meta": "sklearn_class",
+      "presets": ["fast_train"],
       "tags": [
         "tree",
         "interpretable"
@@ -194,6 +199,7 @@
     },
     "dtreg": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "tree",
         "interpretable"
@@ -207,10 +213,12 @@
       ]
     },
     "kmeans": {
-      "meta": "sklearn_clust"
+      "meta": "sklearn_clust",
+      "presets": ["fast_train"]
     },
     "knn": {
       "meta": "custom_class",
+      "presets": ["fast_train"],
       "tags": [
         "simple",
         "correct_params"
@@ -218,6 +226,7 @@
     },
     "knnreg": {
       "meta": "custom_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "correct_params"
@@ -225,6 +234,7 @@
     },
     "lasso": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "linear",
@@ -233,6 +243,7 @@
     },
     "lda": {
       "meta": "custom_class",
+      "presets": ["fast_train"],
       "tags": [
         "discriminant",
         "linear",
@@ -256,6 +267,7 @@
     },
     "linear": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "linear",
@@ -264,6 +276,7 @@
     },
     "logit": {
       "meta": "sklearn_class",
+      "presets": ["fast_train"],
       "tags": [
         "simple",
         "linear",
@@ -278,6 +291,7 @@
     },
     "multinb": {
       "meta": "sklearn_class",
+      "presets": ["fast_train"],
       "tags": [
         "non-default",
         "bayesian"
@@ -285,6 +299,7 @@
     },
     "qda": {
       "meta": "custom_class",
+      "presets": ["fast_train"],
       "tags": [
         "discriminant",
         "quadratic"
@@ -292,14 +307,17 @@
     },
     "rf": {
       "meta": "sklearn_class",
+      "presets": ["fast_train"],
       "tags": ["tree"]
     },
     "rfr": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train"],
       "tags": ["tree"]
     },
     "ridge": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "linear",
@@ -308,6 +326,7 @@
     },
     "polyfit": {
       "meta": "ts_model",
+      "presets": ["*ts"],
       "tags": [
         "simple",
         "non_lagged",
@@ -318,12 +337,14 @@
     },
     "sgdr": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "non_multi"
       ]
     },
     "stl_arima": {
       "meta": "ts_model",
+      "presets": ["*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -332,6 +353,7 @@
     },
     "glm": {
       "meta": "ts_model",
+      "presets": ["*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -341,6 +363,7 @@
     },
     "ets": {
       "meta": "ts_model",
+      "presets": ["*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -369,6 +392,7 @@
     },
     "treg": {
       "meta": "sklearn_regr",
+      "presets": ["fast_train"],
       "tags": [
         "tree"
       ]

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -139,7 +139,7 @@
   "operations": {
     "adareg": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts", "*tree"],
+      "presets": ["fast_train", "ts", "*tree"],
       "tags": [
         "boosting",
         "non_multi"
@@ -147,7 +147,7 @@
     },
     "ar": {
       "meta": "ts_model",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -156,7 +156,7 @@
     },
     "arima": {
       "meta": "ts_model",
-      "presets": ["*ts"],
+      "presets": ["ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -201,7 +201,7 @@
     },
     "dtreg": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts", "*tree"],
+      "presets": ["fast_train", "ts", "*tree"],
       "tags": [
         "tree",
         "interpretable"
@@ -229,7 +229,7 @@
     },
     "knnreg": {
       "meta": "custom_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "correct_params"
@@ -237,7 +237,7 @@
     },
     "lasso": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "linear",
@@ -271,7 +271,7 @@
     },
     "linear": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "linear",
@@ -321,7 +321,7 @@
     },
     "ridge": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "linear",
@@ -330,7 +330,7 @@
     },
     "polyfit": {
       "meta": "ts_model",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "non_lagged",
@@ -341,14 +341,14 @@
     },
     "sgdr": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "non_multi"
       ]
     },
     "stl_arima": {
       "meta": "ts_model",
-      "presets": ["*ts"],
+      "presets": ["ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -357,7 +357,7 @@
     },
     "glm": {
       "meta": "ts_model",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -367,7 +367,7 @@
     },
     "ets": {
       "meta": "ts_model",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "ts"],
       "tags": [
         "simple",
         "interpretable",

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -139,7 +139,7 @@
   "operations": {
     "adareg": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "*ts", "*tree"],
       "tags": [
         "boosting",
         "non_multi"
@@ -184,6 +184,7 @@
     },
     "catboostreg": {
       "meta": "sklearn_regr",
+      "presets": ["*tree"],
       "tags": [
         "boosting",
         "non_multi"
@@ -199,7 +200,7 @@
     },
     "dtreg": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*ts"],
+      "presets": ["fast_train", "*ts", "*tree"],
       "tags": [
         "tree",
         "interpretable"
@@ -207,6 +208,7 @@
     },
     "gbr": {
       "meta": "sklearn_regr",
+      "presets": ["*tree"],
       "tags": [
         "boosting",
         "non_multi"
@@ -259,6 +261,7 @@
     },
     "lgbmreg": {
       "meta": "sklearn_regr",
+      "presets": ["*tree"],
       "tags": [
         "boosting",
         "tree",
@@ -312,7 +315,7 @@
     },
     "rfr": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train"],
+      "presets": ["fast_train", "*tree"],
       "tags": ["tree"]
     },
     "ridge": {
@@ -392,7 +395,7 @@
     },
     "treg": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train"],
+      "presets": ["fast_train", "*tree"],
       "tags": [
         "tree"
       ]
@@ -406,6 +409,7 @@
     },
     "xgbreg": {
       "meta": "sklearn_regr",
+      "presets": ["*tree"],
       "tags": [
         "boosting",
         "tree",

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -178,6 +178,7 @@
     },
     "catboost": {
       "meta": "sklearn_class",
+      "presets": ["*tree"],
       "tags": [
         "boosting"
       ]
@@ -192,7 +193,7 @@
     },
     "dt": {
       "meta": "sklearn_class",
-      "presets": ["fast_train"],
+      "presets": ["fast_train", "*tree"],
       "tags": [
         "tree",
         "interpretable"
@@ -310,7 +311,7 @@
     },
     "rf": {
       "meta": "sklearn_class",
-      "presets": ["fast_train"],
+      "presets": ["fast_train", "*tree"],
       "tags": ["tree"]
     },
     "rfr": {
@@ -329,7 +330,7 @@
     },
     "polyfit": {
       "meta": "ts_model",
-      "presets": ["*ts"],
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "non_lagged",
@@ -356,7 +357,7 @@
     },
     "glm": {
       "meta": "ts_model",
-      "presets": ["*ts"],
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -366,7 +367,7 @@
     },
     "ets": {
       "meta": "ts_model",
-      "presets": ["*ts"],
+      "presets": ["fast_train", "*ts"],
       "tags": [
         "simple",
         "interpretable",
@@ -395,13 +396,14 @@
     },
     "treg": {
       "meta": "sklearn_regr",
-      "presets": ["fast_train", "*tree"],
+      "presets": ["*tree"],
       "tags": [
         "tree"
       ]
     },
     "xgboost": {
       "meta": "sklearn_class",
+      "presets": ["*tree"],
       "tags": [
         "boosting",
         "tree"

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -336,10 +336,6 @@ def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidd
 
     :return : list with operation aliases
     """
-    # Remove 'tun' postfix in preset name
-    if preset is not None:
-        preset = preset.replace('_tun', '')
-
     # Preset None means that all operations will be returned
     if preset is not None and 'best_quality' in preset:
         preset = None

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -320,7 +320,8 @@ def atomized_model_meta_tags():
     return ['random'], ['any'], ['atomized']
 
 
-def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidden_tags=None, ):
+def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidden_tags=None,
+                            preset: str = None):
     """ Function returns aliases of operations.
 
     :param task: task to solve
@@ -331,21 +332,34 @@ def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidd
             'data_operation' - return only list with data_operations
     :param tags: tags for grabbing when filtering
     :param forbidden_tags: tags for skipping when filtering
+    :param preset: operations from this preset will be obtained
 
     :return : list with operation aliases
     """
+    # Remove 'tun' postfix in preset name
+    if preset is not None:
+        preset.replace('_tun', '')
+
+    # Preset None means that all operations will be returned
+    if preset is not None and 'best_quality' in preset:
+        preset = None
+
     task_type = task.task_type if task else None
     if mode != 'all':
         repo = OperationTypesRepository(mode)
-        model_types, _ = repo.suitable_operation(task_type, tags=tags, forbidden_tags=forbidden_tags)
+        model_types, _ = repo.suitable_operation(task_type, tags=tags, forbidden_tags=forbidden_tags,
+                                                 preset=preset)
         return model_types
     elif mode == 'all':
         # Get models from repository
         repo = OperationTypesRepository('model')
-        model_types, _ = repo.suitable_operation(task_type, tags=tags, forbidden_tags=forbidden_tags)
+        model_types, _ = repo.suitable_operation(task_type, tags=tags, forbidden_tags=forbidden_tags,
+                                                 preset=preset)
         # Get data operations
         repo = OperationTypesRepository('data_operation')
-        data_operation_types, _ = repo.suitable_operation(task_type, tags=tags, forbidden_tags=forbidden_tags)
+        data_operation_types, _ = repo.suitable_operation(task_type, tags=tags,
+                                                          forbidden_tags=forbidden_tags,
+                                                          preset=preset)
         return model_types + data_operation_types
     else:
         raise ValueError(f'Such mode "{mode}" is not supported')

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -338,7 +338,7 @@ def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidd
     """
     # Remove 'tun' postfix in preset name
     if preset is not None:
-        preset.replace('_tun', '')
+        preset = preset.replace('_tun', '')
 
     # Preset None means that all operations will be returned
     if preset is not None and 'best_quality' in preset:

--- a/test/integration/quality/test_synthetic_tasks.py
+++ b/test/integration/quality/test_synthetic_tasks.py
@@ -91,7 +91,7 @@ def test_synthetic_regression_automl():
                                                                  'rfe_non_lin_reg',
                                                                  'ridge',
                                                                  'linear']},
-                       preset='light')
+                       preset='best_quality')
     auto_model.fit(features=test_data.features, target=test_data.target)
 
     auto_model.current_pipeline.fit(train_data)

--- a/test/unit/api/test_api_cli_params.py
+++ b/test/unit/api/test_api_cli_params.py
@@ -5,14 +5,14 @@ from fedot.api.fedot_cli import create_parser, separate_argparse_to_fedot, prepr
 
 project_root_path = str(fedot_project_root())
 ts_train_path = os.path.join(project_root_path, 'test/data/simple_time_series.csv')
-ts_call = f'--problem ts_forecasting --preset light --timeout 0.1 --depth 3 --arity 3 \
+ts_call = f'--problem ts_forecasting --preset fast_train --timeout 0.1 --depth 3 --arity 3 \
                                     --popsize 3 --gen_num 5 --c_timeout 0.1 --opers lagged linear ridge --tuning \
                                     0 --cv_folds 2 --val_bl 2 --target sea_height --train {ts_train_path} \
                                     --test {ts_train_path} --for_len 10'.split()
 
 class_train_path = os.path.join(project_root_path, 'test/data/simple_classification.csv')
 class_call = f'--problem classification --train {class_train_path} --test {class_train_path} --target Y \
-                                     --preset light --timeout 0.1 --depth 3 --arity 3 \
+                                     --preset fast_train --timeout 0.1 --depth 3 --arity 3 \
                                      --popsize 3 --gen_num 5 --c_timeout 0.1 --tuning 1'.split()
 
 

--- a/test/unit/api/test_api_safety.py
+++ b/test/unit/api/test_api_safety.py
@@ -78,7 +78,7 @@ def test_api_fit_predict_with_pseudo_large_dataset_with_label_correct():
     model.predict(features=data)
 
     # the should be only tree like models + data operations
-    assert len(model.api_params['available_operations']) == 13
+    assert len(model.api_params['available_operations']) == 9
     assert 'logit' not in model.api_params['available_operations']
 
 

--- a/test/unit/api/test_api_safety.py
+++ b/test/unit/api/test_api_safety.py
@@ -78,7 +78,7 @@ def test_api_fit_predict_with_pseudo_large_dataset_with_label_correct():
     model.predict(features=data)
 
     # the should be only tree like models + data operations
-    assert len(model.api_params['available_operations']) == 9
+    assert len(model.api_params['available_operations']) == 6
     assert 'logit' not in model.api_params['available_operations']
 
 

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -29,7 +29,7 @@ from test.unit.tasks.test_regression import get_synthetic_regression_data
 
 composer_params = {'max_depth': 1,
                    'max_arity': 2,
-                   'timeout': 0.0001,
+                   'timeout': 0.1,
                    'preset': 'fast_train'}
 
 

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -30,7 +30,7 @@ from test.unit.tasks.test_regression import get_synthetic_regression_data
 composer_params = {'max_depth': 1,
                    'max_arity': 2,
                    'timeout': 0.0001,
-                   'preset': 'ultra_light'}
+                   'preset': 'fast_train'}
 
 
 def get_split_data_paths():

--- a/test/unit/api/test_presets.py
+++ b/test/unit/api/test_presets.py
@@ -8,14 +8,14 @@ def test_presets_classification():
     task = Task(TaskTypesEnum.classification)
     class_operations = get_operations_for_task(task=task, mode='all')
 
-    preset_light = OperationsPreset(task=task, preset_name='light')
+    preset_light = OperationsPreset(task=task, preset_name='best_quality')
     operations_for_light_preset = preset_light._filter_operations_by_preset()
 
-    preset_ultra_light = OperationsPreset(task=task, preset_name='ultra_light')
-    operations_for_ultra_light_preset = preset_ultra_light._filter_operations_by_preset()
+    preset_fast_train = OperationsPreset(task=task, preset_name='fast_train')
+    operations_for_fast_train_preset = preset_fast_train._filter_operations_by_preset()
 
-    assert len(operations_for_ultra_light_preset) < len(operations_for_light_preset) < len(class_operations)
-    assert {'dt', 'logit', 'knn'} <= set(operations_for_ultra_light_preset)
+    assert len(operations_for_fast_train_preset) < len(operations_for_light_preset) < len(class_operations)
+    assert {'dt', 'logit', 'knn'} <= set(operations_for_fast_train_preset)
 
 
 def test_presets_regression():
@@ -23,14 +23,14 @@ def test_presets_regression():
 
     regr_operations = get_operations_for_task(task=task, mode='all')
 
-    preset_light = OperationsPreset(task=task, preset_name='light')
+    preset_light = OperationsPreset(task=task, preset_name='best_quality')
     operations_for_light_preset = preset_light._filter_operations_by_preset()
 
-    preset_ultra_light = OperationsPreset(task=task, preset_name='ultra_light')
-    operations_for_ultra_light_preset = preset_ultra_light._filter_operations_by_preset()
+    preset_fast_train = OperationsPreset(task=task, preset_name='fast_train')
+    operations_for_fast_train_preset = preset_fast_train._filter_operations_by_preset()
 
-    assert len(operations_for_ultra_light_preset) < len(operations_for_light_preset) <= len(regr_operations)
-    assert {'dtreg', 'lasso', 'ridge', 'linear'} <= set(operations_for_ultra_light_preset)
+    assert len(operations_for_fast_train_preset) < len(operations_for_light_preset) <= len(regr_operations)
+    assert {'dtreg', 'lasso', 'ridge', 'linear'} <= set(operations_for_fast_train_preset)
 
 
 def test_presets_inserting_in_parms_correct():
@@ -43,7 +43,7 @@ def test_presets_inserting_in_parms_correct():
 
     task = Task(TaskTypesEnum.regression)
 
-    preset_light = OperationsPreset(task=task, preset_name='light')
+    preset_light = OperationsPreset(task=task, preset_name='best_quality')
     updated_params = preset_light.composer_params_based_on_preset(composer_params)
     updated_candidates = updated_params.get('available_operations')
 

--- a/test/unit/api/test_presets.py
+++ b/test/unit/api/test_presets.py
@@ -8,14 +8,14 @@ def test_presets_classification():
     task = Task(TaskTypesEnum.classification)
     class_operations = get_operations_for_task(task=task, mode='all')
 
-    preset_light = OperationsPreset(task=task, preset_name='best_quality')
-    operations_for_light_preset = preset_light._filter_operations_by_preset()
+    preset_best_quality = OperationsPreset(task=task, preset_name='best_quality')
+    operations_for_best_quality = preset_best_quality._filter_operations_by_preset()
 
     preset_fast_train = OperationsPreset(task=task, preset_name='fast_train')
-    operations_for_fast_train_preset = preset_fast_train._filter_operations_by_preset()
+    operations_for_fast_train = preset_fast_train._filter_operations_by_preset()
 
-    assert len(operations_for_fast_train_preset) < len(operations_for_light_preset) < len(class_operations)
-    assert {'dt', 'logit', 'knn'} <= set(operations_for_fast_train_preset)
+    assert len(operations_for_fast_train) < len(operations_for_best_quality) == len(class_operations)
+    assert {'dt', 'logit', 'knn'} <= set(operations_for_fast_train)
 
 
 def test_presets_regression():
@@ -23,14 +23,14 @@ def test_presets_regression():
 
     regr_operations = get_operations_for_task(task=task, mode='all')
 
-    preset_light = OperationsPreset(task=task, preset_name='best_quality')
-    operations_for_light_preset = preset_light._filter_operations_by_preset()
+    preset_best_quality = OperationsPreset(task=task, preset_name='best_quality')
+    operations_for_best_quality = preset_best_quality._filter_operations_by_preset()
 
     preset_fast_train = OperationsPreset(task=task, preset_name='fast_train')
-    operations_for_fast_train_preset = preset_fast_train._filter_operations_by_preset()
+    operations_for_fast_train = preset_fast_train._filter_operations_by_preset()
 
-    assert len(operations_for_fast_train_preset) < len(operations_for_light_preset) <= len(regr_operations)
-    assert {'dtreg', 'lasso', 'ridge', 'linear'} <= set(operations_for_fast_train_preset)
+    assert len(operations_for_fast_train) < len(operations_for_best_quality) <= len(regr_operations)
+    assert {'dtreg', 'lasso', 'ridge', 'linear'} <= set(operations_for_fast_train)
 
 
 def test_presets_inserting_in_parms_correct():
@@ -43,8 +43,8 @@ def test_presets_inserting_in_parms_correct():
 
     task = Task(TaskTypesEnum.regression)
 
-    preset_light = OperationsPreset(task=task, preset_name='best_quality')
-    updated_params = preset_light.composer_params_based_on_preset(composer_params)
+    preset_best_quality = OperationsPreset(task=task, preset_name='best_quality')
+    updated_params = preset_best_quality.composer_params_based_on_preset(composer_params)
     updated_candidates = updated_params.get('available_operations')
 
     assert source_candidates is None

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -354,7 +354,7 @@ def test_gp_composer_early_stopping():
     model = Fedot(problem='classification', timeout=1000,
                   composer_params={'stopping_after_n_generation': 1,
                                    'pop_size': 2},
-                  preset='ultra_light')
+                  preset='fast_train')
     model.fit(train_data)
     spent_time = datetime.datetime.now() - start
 

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -353,7 +353,8 @@ def test_gp_composer_early_stopping():
     start = datetime.datetime.now()
     model = Fedot(problem='classification', timeout=1000,
                   composer_params={'stopping_after_n_generation': 1,
-                                   'pop_size': 2},
+                                   'pop_size': 2,
+                                   'with_tuning': False},
                   preset='fast_train')
     model.fit(train_data)
     spent_time = datetime.datetime.now() - start

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -29,7 +29,7 @@ def test_operators_in_history():
 
     auto_model = Fedot(problem='classification', seed=42,
                        composer_params={'num_of_generations': 3, 'pop_size': 4},
-                       preset='ultra_light')
+                       preset='fast_train')
     auto_model.fit(features=file_path_train, target='Y')
 
     assert auto_model.history is not None

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -28,6 +28,7 @@ def test_operators_in_history():
     file_path_train = os.path.join(project_root_path, 'test/data/simple_classification.csv')
 
     auto_model = Fedot(problem='classification', seed=42,
+                       timeout=0.1,
                        composer_params={'num_of_generations': 3, 'pop_size': 4},
                        preset='fast_train')
     auto_model.fit(features=file_path_train, target='Y')

--- a/test/unit/models/test_custom_model_introduction.py
+++ b/test/unit/models/test_custom_model_introduction.py
@@ -222,8 +222,8 @@ def test_composing_with_custom_model():
 
     automl = Fedot(problem='ts_forecasting', composer_params={'timeout': 0.1,
                                                               'initial_pipeline': initial_pipeline},
-                   preset='ts_tun',
-                   task_params=TsForecastingParams(forecast_length=10), verbose_level=0)
+                   preset='*ts_tun',
+                   task_params=TsForecastingParams(forecast_length=5), verbose_level=0)
     pipeline = automl.fit(train_data)
 
     pipeline.fit_from_scratch(train_data)

--- a/test/unit/models/test_custom_model_introduction.py
+++ b/test/unit/models/test_custom_model_introduction.py
@@ -222,7 +222,7 @@ def test_composing_with_custom_model():
 
     automl = Fedot(problem='ts_forecasting', composer_params={'timeout': 0.1,
                                                               'initial_pipeline': initial_pipeline},
-                   preset='*ts_tun',
+                   preset='*ts',
                    task_params=TsForecastingParams(forecast_length=5), verbose_level=0)
     pipeline = automl.fit(train_data)
 

--- a/test/unit/models/test_custom_model_introduction.py
+++ b/test/unit/models/test_custom_model_introduction.py
@@ -222,7 +222,7 @@ def test_composing_with_custom_model():
 
     automl = Fedot(problem='ts_forecasting', composer_params={'timeout': 0.1,
                                                               'initial_pipeline': initial_pipeline},
-                   preset='*ts',
+                   preset='ts',
                    task_params=TsForecastingParams(forecast_length=5), verbose_level=0)
     pipeline = automl.fit(train_data)
 

--- a/test/unit/optimizer/test_external.py
+++ b/test/unit/optimizer/test_external.py
@@ -40,8 +40,8 @@ def test_external_static_optimizer(data_fixture, request):
     data = request.getfixturevalue(data_fixture)
     train_data, test_data = train_test_data_setup(data=data)
 
-    automl = Fedot(problem='classification', timeout=1, verbose_level=4,
-                   preset='light_notun')
+    automl = Fedot(problem='classification', timeout=0.1, verbose_level=4,
+                   preset='fast_train', composer_params={'with_tuning': False})
     automl.api_composer.optimiser = StaticOptimizer
 
     obtained_pipeline = automl.fit(train_data)

--- a/test/unit/pipelines/test_node.py
+++ b/test/unit/pipelines/test_node.py
@@ -111,5 +111,5 @@ def test_node_return_correct_operation_info():
     node = PrimaryNode('simple_imputation')
     operation_tags = node.tags
 
-    correct_tags = ["simple", "imputation", "non-default"]
+    correct_tags = ["simple", "imputation"]
     assert all(correct_tag in operation_tags for correct_tag in correct_tags)

--- a/test/unit/remote/test_remote_composer.py
+++ b/test/unit/remote/test_remote_composer.py
@@ -44,7 +44,7 @@ def test_pseudo_remote_composer_classification():
 
     composer_params = {
         'pop_size': 3,
-        'timeout': 0.01,
+        'timeout': 0.1,
         'cv_folds': None
     }
 

--- a/test/unit/remote/test_remote_composer.py
+++ b/test/unit/remote/test_remote_composer.py
@@ -48,7 +48,7 @@ def test_pseudo_remote_composer_classification():
         'cv_folds': None
     }
 
-    preset = 'light'
+    preset = 'best_quality'
     automl = Fedot(problem='classification', preset=preset, composer_params=composer_params)
 
     path = os.path.join(fedot_project_root(), 'test', 'data', 'advanced_classification.csv')
@@ -89,7 +89,7 @@ def test_pseudo_remote_composer_ts_forecasting():
         'cv_folds': None
     }
 
-    preset = 'light'
+    preset = 'best_quality'
     automl = Fedot(problem='ts_forecasting', preset=preset, composer_params=composer_params,
                    task_params=TsForecastingParams(forecast_length=1))
 

--- a/test/unit/tasks/test_regression.py
+++ b/test/unit/tasks/test_regression.py
@@ -31,7 +31,7 @@ def get_simple_composer_params() -> dict:
               'pop_size': 2,
               'num_of_generations': 2,
               'timeout': 1,
-              'preset': 'ultra_light'}
+              'preset': 'fast_train'}
     return params
 
 

--- a/test/unit/tasks/test_regression.py
+++ b/test/unit/tasks/test_regression.py
@@ -30,7 +30,8 @@ def get_simple_composer_params() -> dict:
               'max_arity': 3,
               'pop_size': 2,
               'num_of_generations': 2,
-              'timeout': 1,
+              'timeout': 0.1,
+              'with_tuning': True,
               'preset': 'fast_train'}
     return params
 

--- a/test/unit/validation/test_table_cv.py
+++ b/test/unit/validation/test_table_cv.py
@@ -139,7 +139,7 @@ def test_cv_api_correct():
     composer_params = {'max_depth': 1,
                        'max_arity': 2,
                        'timeout': 0.0001,
-                       'preset': 'ultra_light',
+                       'preset': 'fast_train',
                        'cv_folds': 10}
     task = Task(task_type=TaskTypesEnum.classification)
     dataset_to_compose, dataset_to_validate = get_data(task)

--- a/test/unit/validation/test_table_cv.py
+++ b/test/unit/validation/test_table_cv.py
@@ -138,9 +138,9 @@ def test_composer_with_cv_optimization_correct():
 def test_cv_api_correct():
     composer_params = {'max_depth': 1,
                        'max_arity': 2,
-                       'timeout': 0.0001,
+                       'timeout': 0.1,
                        'preset': 'fast_train',
-                       'cv_folds': 10}
+                       'cv_folds': 2}
     task = Task(task_type=TaskTypesEnum.classification)
     dataset_to_compose, dataset_to_validate = get_data(task)
     model = Fedot(problem='classification', composer_params=composer_params, verbose_level=2)

--- a/test/unit/validation/test_table_cv.py
+++ b/test/unit/validation/test_table_cv.py
@@ -118,7 +118,7 @@ def test_composer_with_cv_optimization_correct():
 
     composer_requirements = PipelineComposerRequirements(primary=available_model_types,
                                                          secondary=available_model_types,
-                                                         timeout=timedelta(minutes=1),
+                                                         timeout=timedelta(minutes=0.2),
                                                          num_of_generations=2, cv_folds=3)
 
     builder = ComposerBuilder(task).with_requirements(composer_requirements).with_metrics(metric_function)

--- a/test/unit/validation/test_time_series_cv.py
+++ b/test/unit/validation/test_time_series_cv.py
@@ -145,7 +145,7 @@ def test_api_cv_correct():
     composer_params = {'max_depth': 1,
                        'max_arity': 2,
                        'timeout': 0.05,
-                       'preset': 'ultra_light',
+                       'preset': 'fast_train',
                        'cv_folds': folds,
                        'validation_blocks': validation_blocks}
     task_parameters = TsForecastingParams(forecast_length=forecast_len)


### PR DESCRIPTION
Redesigned preset assignment system. Added additional field "presets" to the json file with operations

The names of the presets have also been changed:
* `light` / `light_tun` - `best_quality`
* `ultra_light` / `ultra_light_tun`  - `fast_train`
* `_steady_state postfix` - `stable`
* `gpu` - `gpu` (stayed the same)
* `tree_regr`, `tree_class` - `*tree`
* `ts` / `ts_tun` - `ts`

Some bugs with hyperparameters in PCA and LDA operation were also fixed. Some bugs with hyperparameters in PCA and LDA operation were also fixed. 