### PR TITLE
Improvement of time series processing

### DIFF
--- a/fedot/core/data/merge.py
+++ b/fedot/core/data/merge.py
@@ -118,8 +118,6 @@ class DataMerger:
         if data_type is not DataTypesEnum.table:
             # Data is not tabular
             return supplementary_data
-        if task.task_type == TaskTypesEnum.ts_forecasting:
-            return supplementary_data
 
         # Types for features columns
         new_features_types = []

--- a/fedot/core/data/merge.py
+++ b/fedot/core/data/merge.py
@@ -5,7 +5,6 @@ import numpy as np
 from fedot.core.log import Log, default_log
 from fedot.core.data.supplementary_data import SupplementaryData
 from fedot.core.repository.dataset_types import DataTypesEnum
-from fedot.core.repository.tasks import TaskTypesEnum
 from fedot.preprocessing.data_types import TableTypesCorrector
 
 
@@ -25,8 +24,9 @@ class DataMerger:
             self.log = log
 
     def merge(self):
-        """ Method automatically determine which merge function should be
-        applied """
+        """
+        Method automatically determine which merge function should be applied
+        """
 
         if len(self.outputs) == 1 and self.outputs[0].data_type in [DataTypesEnum.image, DataTypesEnum.text]:
             # TODO implement correct merge
@@ -69,7 +69,7 @@ class DataMerger:
         if first_data_type == DataTypesEnum.table and len(self.outputs) > 1:
             updated_info.prepare_parent_mask(self.outputs)
 
-        updated_info = self.update_column_types(updated_info, first_data_type, task)
+        updated_info = self.update_column_types(updated_info, first_data_type)
         return idx, features, target, task, first_data_type, updated_info
 
     def combine_datasets_table(self):
@@ -112,8 +112,7 @@ class DataMerger:
             target = np.ravel(np.array(target))
         return idx, features, target, is_main_target, task
 
-    def update_column_types(self, supplementary_data: SupplementaryData, data_type: DataTypesEnum,
-                            task: TaskTypesEnum):
+    def update_column_types(self, supplementary_data: SupplementaryData, data_type: DataTypesEnum):
         """ Store information about column types in tabular data for merged data """
         if data_type is not DataTypesEnum.table:
             # Data is not tabular

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -94,11 +94,18 @@ class LaggedImplementation(DataOperationImplementation):
                                       forecast_length: int, old_idx: np.array):
         """ Apply lagged transformation on each time series in the current dataset """
         # Shape of the time series
-        n_elements, n_time_series = features.shape
+        if len(features.shape) > 1:
+            # Multivariate time series
+            n_elements, n_time_series = features.shape
+        else:
+            n_time_series = 1
         all_transformed_features = None
         for current_ts_id in range(n_time_series):
             # For each time series in the array
-            current_ts = np.ravel(features[:, current_ts_id])
+            if n_time_series == 1:
+                current_ts = features
+            else:
+                current_ts = np.ravel(features[:, current_ts_id])
 
             # Prepare features for training
             new_idx, transformed_cols = ts_to_table(idx=old_idx,
@@ -143,11 +150,19 @@ class LaggedImplementation(DataOperationImplementation):
             self.features_columns = self.features_columns.reshape(1, -1)
             return self.features_columns
 
-        n_elements, n_time_series = input_data.features.shape
+        if len(input_data.features.shape) > 1:
+            # Multivariate time series
+            n_elements, n_time_series = input_data.features.shape
+        else:
+            n_time_series = 1
+
         all_transformed_features = None
         for current_ts_id in range(n_time_series):
             # For each time series
-            current_ts = np.ravel(input_data.features[:, current_ts_id])
+            if n_time_series == 1:
+                current_ts = input_data.features
+            else:
+                current_ts = np.ravel(input_data.features[:, current_ts_id])
 
             # Take last window_size elements for current ts
             last_part_of_ts = current_ts[-self.window_size:]

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -60,38 +60,18 @@ class LaggedImplementation(DataOperationImplementation):
 
         if is_fit_pipeline_stage:
             # Transformation for fit stage of the pipeline
-            target = new_input_data.target
+            target = np.array(new_input_data.target)
             features = np.array(new_input_data.features)
-            # Prepare features for training
-            new_idx, self.features_columns = ts_to_table(idx=old_idx,
-                                                         time_series=features,
-                                                         window_size=self.window_size,
-                                                         is_lag=True)
 
-            # Sparsing matrix of lagged features
-            if self.sparse_transform:
-                self.features_columns = _sparse_matrix(self.log, self.features_columns, self.n_components, self.use_svd)
-            # Transform target
-
-            new_idx, self.features_columns, new_target = prepare_target(all_idx=input_data.idx,
-                                                                        idx=new_idx,
-                                                                        features_columns=self.features_columns,
-                                                                        target=target,
-                                                                        forecast_length=forecast_length)
+            new_target, new_idx = self._apply_transformation_for_fit(new_input_data, features,
+                                                                     target, forecast_length, old_idx)
 
             # Update target for Input Data
             new_input_data.target = new_target
             new_input_data.idx = new_idx
         else:
             # Transformation for predict stage of the pipeline
-            if self.sparse_transform:
-                self.features_columns = self.features_columns[-1]
-
-            if not self.sparse_transform:
-                features = np.array(new_input_data.features)
-                self.features_columns = features[-self.window_size:]
-
-            self.features_columns = self.features_columns.reshape(1, -1)
+            self._apply_transformation_for_predict(new_input_data, forecast_length)
 
         output_data = self._convert_to_output(new_input_data,
                                               self.features_columns,
@@ -109,6 +89,76 @@ class LaggedImplementation(DataOperationImplementation):
             target_n_rows, target_n_cols = output_data.target.shape
             column_types.update({'target': [str(float)] * target_n_cols})
         output_data.supplementary_data.column_types = column_types
+
+    def _apply_transformation_for_fit(self, input_data: InputData, features: np.array, target: np.array,
+                                      forecast_length: int, old_idx: np.array):
+        """ Apply lagged transformation on each time series in the current dataset """
+        # Shape of the time series
+        n_elements, n_time_series = features.shape
+        all_transformed_features = None
+        for current_ts_id in range(n_time_series):
+            # For each time series in the array
+            current_ts = np.ravel(features[:, current_ts_id])
+
+            # Prepare features for training
+            new_idx, transformed_cols = ts_to_table(idx=old_idx,
+                                                    time_series=current_ts,
+                                                    window_size=self.window_size,
+                                                    is_lag=True)
+
+            # Sparsing matrix of lagged features
+            if self.sparse_transform:
+                transformed_cols = _sparse_matrix(self.log,
+                                                  transformed_cols,
+                                                  self.n_components,
+                                                  self.use_svd)
+            # Transform target
+            new_idx, transformed_cols, new_target = prepare_target(all_idx=input_data.idx,
+                                                                   idx=new_idx,
+                                                                   features_columns=transformed_cols,
+                                                                   target=target,
+                                                                   forecast_length=forecast_length)
+            if current_ts_id == 0:
+                # Init full lagged table
+                all_transformed_features = transformed_cols
+            else:
+                all_transformed_features = np.hstack((all_transformed_features, transformed_cols))
+
+        input_data.features = all_transformed_features
+        self.features_columns = all_transformed_features
+        return new_target, new_idx
+
+    def _apply_transformation_for_predict(self, input_data: InputData, forecast_length: int):
+        """ Apply lagged transformation for every column (time series) in the dataset """
+        if self.sparse_transform:
+            # TODO refactor to apply with new unseen data in more flexible way
+            self.log.debug(f'Sparse lagged transformation applied. If new data were used. Call fit method')
+            # Target can be None
+            simple_target = np.arange(0, len(input_data.idx))
+            self._apply_transformation_for_fit(input_data, input_data.features,
+                                               simple_target, forecast_length,
+                                               input_data.idx)
+
+            self.features_columns = self.features_columns[-1]
+            self.features_columns = self.features_columns.reshape(1, -1)
+            return self.features_columns
+
+        n_elements, n_time_series = input_data.features.shape
+        all_transformed_features = None
+        for current_ts_id in range(n_time_series):
+            # For each time series
+            current_ts = np.ravel(input_data.features[:, current_ts_id])
+
+            # Take last window_size elements for current ts
+            last_part_of_ts = current_ts[-self.window_size:]
+            last_part_of_ts = last_part_of_ts.reshape(1, -1)
+            if current_ts_id == 0:
+                all_transformed_features = last_part_of_ts
+            else:
+                all_transformed_features = np.hstack((all_transformed_features, last_part_of_ts))
+
+        self.features_columns = all_transformed_features
+        return all_transformed_features
 
 
 class SparseLaggedTransformationImplementation(LaggedImplementation):

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -146,8 +146,7 @@ class LaggedImplementation(DataOperationImplementation):
                                                simple_target, forecast_length,
                                                input_data.idx)
 
-            self.features_columns = self.features_columns[-1]
-            self.features_columns = self.features_columns.reshape(1, -1)
+            self.features_columns = self.features_columns[-1].reshape(1, -1)
             return self.features_columns
 
         if len(input_data.features.shape) > 1:
@@ -165,8 +164,7 @@ class LaggedImplementation(DataOperationImplementation):
                 current_ts = np.ravel(input_data.features[:, current_ts_id])
 
             # Take last window_size elements for current ts
-            last_part_of_ts = current_ts[-self.window_size:]
-            last_part_of_ts = last_part_of_ts.reshape(1, -1)
+            last_part_of_ts = current_ts[-self.window_size:].reshape(1, -1)
             if current_ts_id == 0:
                 all_transformed_features = last_part_of_ts
             else:

--- a/fedot/preprocessing/data_types.py
+++ b/fedot/preprocessing/data_types.py
@@ -180,14 +180,14 @@ class TableTypesCorrector:
             # Information about column types is empty - there is a need to launch algorithm to collect info
             self.features_columns_info = define_column_types(predictors)
             predictors = self.features_types_converting(features=predictors)
-        if not self.target_columns_info:
+        if not self.target_columns_info and task.task_type != TaskTypesEnum.ts_forecasting:
             self.target_columns_info = define_column_types(target)
             target = self.target_types_converting(target=target, task=task)
 
         features_types = _generate_list_with_types(self.features_columns_info, self.features_converted_columns)
         self._check_columns_vs_types_number(predictors, features_types)
 
-        if target is None:
+        if target is None or task.task_type == TaskTypesEnum.ts_forecasting:
             return {'features': features_types}
         else:
             target_types = _generate_list_with_types(self.target_columns_info, self.target_converted_columns)

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -144,7 +144,7 @@ def get_single_feature_data(task=None):
                             target=np.array([[0], [0], [0], [1], [1], [1]]),
                             task=task,
                             data_type=DataTypesEnum.table,
-                             supplementary_data=supp_data)
+                            supplementary_data=supp_data)
 
     return train_input
 

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -81,8 +81,8 @@ def get_small_classification_dataset():
 
 def get_time_series():
     """ Function returns time series for time series forecasting task """
-    len_forecast = 100
-    synthetic_ts = generate_synthetic_data(length=1000)
+    len_forecast = 5
+    synthetic_ts = generate_synthetic_data(length=80)
 
     train_data = synthetic_ts[:-len_forecast]
     test_data = synthetic_ts[-len_forecast:]
@@ -105,6 +105,20 @@ def get_time_series():
                               data_type=DataTypesEnum.ts)
 
     return train_input, predict_input, test_data
+
+
+def get_multivariate_time_series():
+    """ Generate several time series in one InputData block """
+    ts_1 = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).reshape((-1, 1))
+    ts_2 = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]).reshape((-1, 1))
+    several_ts = np.hstack((ts_1, ts_2))
+
+    task = Task(TaskTypesEnum.ts_forecasting,
+                TsForecastingParams(forecast_length=2))
+    train_input = InputData(idx=np.arange(0, len(several_ts)),
+                            features=several_ts, target=np.ravel(ts_1),
+                            task=task, data_type=DataTypesEnum.ts)
+    return train_input
 
 
 def get_nan_inf_data():
@@ -433,3 +447,11 @@ def test_label_encoding_correct():
     assert predicted_train.predict[1, 0] == 1
     # Label 'c' was not in the training sample - convert it into 2
     assert predicted_test.predict[0, 0] == 2
+
+
+def test_lagged_with_multivariate_time_series():
+    """
+    Checking the correct processing of multivariate time series in the lagged operation
+    """
+    input_data = get_multivariate_time_series()
+    a = 0

--- a/test/unit/pipelines/test_pipeline.py
+++ b/test/unit/pipelines/test_pipeline.py
@@ -23,6 +23,7 @@ from fedot.preprocessing.preprocessing import DataPreprocessor
 from test.unit.dag.test_graph_operator import get_pipeline
 from test.unit.pipelines.test_pipeline_comparison import pipeline_first
 from test.unit.pipelines.test_pipeline_tuning import classification_dataset
+from test.unit.tasks.test_forecasting import get_ts_data
 
 seed(1)
 np.random.seed(1)
@@ -459,3 +460,15 @@ def test_pipeline_unfit(data_fixture, request):
         assert pipeline.predict(data)
 
 
+def test_ts_forecasting_pipeline_with_poly_features():
+    """ Test pipeline with polynomial features in ts forecasting task """
+    lagged_node = PrimaryNode('lagged')
+    poly_node = SecondaryNode('poly_features', nodes_from=[lagged_node])
+    ridge_node = SecondaryNode('ridge', nodes_from=[poly_node])
+    pipeline = Pipeline(ridge_node)
+
+    train_data, test_data = get_ts_data(n_steps=25, forecast_length=5)
+
+    pipeline.fit(train_data)
+    prediction = pipeline.predict(test_data)
+    assert prediction is not None


### PR DESCRIPTION
In this PR it was added the possibility to supply two time series to the input of the lagged operation. A bug has been fixed that occurred when poly_features was used in a time-series pipeline. 
A RFE processing was refactored also: It is now possible to reject features with less than 3 unique values.