### PR TITLE
Cross-validation support for cache

### DIFF
--- a/fedot/core/composer/cache.py
+++ b/fedot/core/composer/cache.py
@@ -22,12 +22,22 @@ class OperationsCache:
         if clear_exiting:
             self.clear()
 
-    def save_node(self, node, partial_id='all'):
+    def save_node(self, node, partial_id=''):
+        """
+        :param node: node for caching
+        :param partial_id: optional part of cache item UID
+                            (can be used to specify the number of CV fold)
+        """
         if node.fitted_operation is not None:
             _save_cache_for_node(self.db_path, f'{node.descriptive_id}_{partial_id}',
                                  CachedState(node.fitted_operation))
 
-    def save_pipeline(self, pipeline, partial_id='all'):
+    def save_pipeline(self, pipeline, partial_id=''):
+        """
+        :param pipeline: pipeline for caching
+        :param partial_id: optional part of cache item UID
+                            (can be used to specify the number of CV fold)
+        """
         try:
             for node in pipeline.nodes:
                 _save_cache_for_node(self.db_path, f'{node.descriptive_id}_{partial_id}',
@@ -43,9 +53,14 @@ class OperationsCache:
         folder_path = f'{str(default_fedot_data_dir())}/tmp_*'
         clear_folder(folder_path)
 
-    def get(self, node, partial_id='all'):
-        found_operation = _load_cache_for_node(self.db_path, f'{node.descriptive_id}_{partial_id}')
-        # TODO: Add node and node from cache "fitted on data" field comparison
+    def get(self, node, partial_id=''):
+        """
+        :param node: node which fitted state should be loaded from cache
+        :param partial_id: optional part of cache item UID
+                            (can be used to specify the number of CV fold)
+        """
+        found_operation = _load_cache_for_node(self.db_path,
+                                               f'{node.descriptive_id}_{partial_id}')
         return found_operation
 
 

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -20,7 +20,6 @@ from fedot.core.repository.quality_metrics_repository import (MetricsEnum,
 from fedot.core.repository.tasks import TaskTypesEnum
 from fedot.core.validation.compose.tabular import table_metric_calculation
 from fedot.core.validation.compose.time_series import ts_metric_calculation
-from fedot.core.validation.split import tabular_cv_generator, ts_cv_generator
 from fedot.remote.remote_evaluator import RemoteEvaluator, init_data_for_remote_execution
 
 sample_split_ratio_for_tasks = {
@@ -162,11 +161,7 @@ class GPComposer(Composer):
                 self.log.info('For ts cross validation validation_blocks number was changed from None to 3 blocks')
                 self.composer_requirements.validation_blocks = 3
 
-            cv_data_sets = list(ts_cv_generator(data, folds=self.composer_requirements.cv_folds,
-                                                validation_blocks=self.composer_requirements.validation_blocks,
-                                                log=self.log))
-
-            metric_function_for_nodes = partial(ts_metric_calculation, cv_data_sets,
+            metric_function_for_nodes = partial(ts_metric_calculation, data,
                                                 self.composer_requirements.cv_folds,
                                                 self.composer_requirements.validation_blocks,
                                                 self.metrics,
@@ -174,9 +169,9 @@ class GPComposer(Composer):
 
         else:
             self.log.info("KFolds cross validation for pipeline composing was applied.")
-            cv_data_sets = list(tabular_cv_generator(data, self.composer_requirements.cv_folds))
 
-            metric_function_for_nodes = partial(table_metric_calculation, cv_data_sets,
+            metric_function_for_nodes = partial(table_metric_calculation, data,
+                                                self.composer_requirements.cv_folds,
                                                 self.metrics,
                                                 log=self.log,
                                                 cache=self.cache)

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -20,6 +20,7 @@ from fedot.core.repository.quality_metrics_repository import (MetricsEnum,
 from fedot.core.repository.tasks import TaskTypesEnum
 from fedot.core.validation.compose.tabular import table_metric_calculation
 from fedot.core.validation.compose.time_series import ts_metric_calculation
+from fedot.core.validation.split import tabular_cv_generator, ts_cv_generator
 from fedot.remote.remote_evaluator import RemoteEvaluator, init_data_for_remote_execution
 
 sample_split_ratio_for_tasks = {
@@ -75,7 +76,7 @@ class GPComposer(Composer):
         super().__init__(metrics=metrics, composer_requirements=composer_requirements,
                          initial_pipelines=initial_pipelines)
 
-        self.cache = OperationsCache()
+        self.cache = OperationsCache(log=logger)
 
         self.optimiser = optimiser
         self.cache_path = None
@@ -131,7 +132,8 @@ class GPComposer(Composer):
             self.cache.clear()
         else:
             self.cache.clear(tmp_only=True)
-            self.cache = OperationsCache(self.cache_path, clear_exiting=not self.use_existing_cache)
+            self.cache = OperationsCache(log=self.log, db_path=self.cache_path,
+                                         clear_exiting=not self.use_existing_cache)
 
         opt_result = self.optimiser.optimise(objective_function_for_pipeline,
                                              on_next_iteration_callback=on_next_iteration_callback)
@@ -159,18 +161,25 @@ class GPComposer(Composer):
             if self.composer_requirements.validation_blocks is None:
                 self.log.info('For ts cross validation validation_blocks number was changed from None to 3 blocks')
                 self.composer_requirements.validation_blocks = 3
-            metric_function_for_nodes = partial(ts_metric_calculation, data,
+
+            cv_data_sets = list(ts_cv_generator(data, folds=self.composer_requirements.cv_folds,
+                                                validation_blocks=self.composer_requirements.validation_blocks,
+                                                log=self.log))
+
+            metric_function_for_nodes = partial(ts_metric_calculation, cv_data_sets,
                                                 self.composer_requirements.cv_folds,
                                                 self.composer_requirements.validation_blocks,
                                                 self.metrics,
                                                 log=self.log)
+
         else:
             self.log.info("KFolds cross validation for pipeline composing was applied.")
-            metric_function_for_nodes = partial(table_metric_calculation, data,
-                                                self.composer_requirements.cv_folds,
-                                                self.metrics,
-                                                log=self.log)
+            cv_data_sets = list(tabular_cv_generator(data, self.composer_requirements.cv_folds))
 
+            metric_function_for_nodes = partial(table_metric_calculation, cv_data_sets,
+                                                self.metrics,
+                                                log=self.log,
+                                                cache=self.cache)
         return metric_function_for_nodes
 
     def composer_metric(self, metrics,
@@ -185,17 +194,14 @@ class GPComposer(Composer):
                 metrics = [metrics]
 
             if self.cache is not None:
-                # TODO improve cache
                 pipeline.fit_from_cache(self.cache)
 
             self.log.debug(f'Pipeline {pipeline.root_node.descriptive_id} fit started')
 
             pipeline.fit(input_data=train_data,
-                         time_constraint=self.composer_requirements.max_pipeline_fit_time)
-            try:
-                self.cache.save_pipeline(pipeline)
-            except Exception as ex:
-                self.log.info(f'Cache can not be saved: {ex}. Continue.')
+                         time_constraint=self.composer_requirements.max_pipeline_fit_time,
+                         use_fitted=self.cache is not None)
+            self.cache.save_pipeline(pipeline)
 
             evaluated_metrics = ()
             for metric in metrics:

--- a/fedot/core/validation/compose/metric_estimation.py
+++ b/fedot/core/validation/compose/metric_estimation.py
@@ -7,7 +7,7 @@ from fedot.core.repository.quality_metrics_repository import MetricsRepository
 
 def metric_evaluation(pipeline, train_data: InputData, test_data: InputData,
                       metrics: list, evaluated_metrics: list,
-                      fold_num: int = None, vb_number: int = None,
+                      fold_id: int = None, vb_number: int = None,
                       cache: OperationsCache = None):
     """ Pipeline training and metrics assessment
 
@@ -16,12 +16,12 @@ def metric_evaluation(pipeline, train_data: InputData, test_data: InputData,
     :param test_data: InputData for validation
     :param metrics: list with metrics for evaluation
     :param evaluated_metrics: list with metrics values
-    :param fold_num: number of fold for cross-validation
+    :param fold_id: id of fold for cross-validation
     :param vb_number: number of validation blocks for time series
     :param cache: instance of cache class
     """
     if cache is not None:
-        pipeline.fit_from_cache(cache, fold_num)
+        pipeline.fit_from_cache(cache, fold_id)
 
     pipeline.fit(train_data, use_fitted=cache is not None)
 
@@ -34,7 +34,7 @@ def metric_evaluation(pipeline, train_data: InputData, test_data: InputData,
         evaluated_metrics[index].extend([metric_value])
 
     if cache is not None:
-        cache.save_pipeline(pipeline, fold_num)
+        cache.save_pipeline(pipeline, fold_id)
 
     # enforce memory cleaning
     pipeline.unfit()

--- a/fedot/core/validation/compose/tabular.py
+++ b/fedot/core/validation/compose/tabular.py
@@ -1,36 +1,39 @@
-from typing import Callable, Optional, Tuple
+from typing import Callable, Tuple, Optional, List, Union
 
 import numpy as np
 
+from fedot.core.composer.cache import OperationsCache
 from fedot.core.data.data import InputData
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.tasks import TaskTypesEnum
 from fedot.core.validation.compose.metric_estimation import metric_evaluation
-from fedot.core.validation.split import tabular_cv_generator
 
 
-def table_metric_calculation(reference_data: InputData, cv_folds: int,
+def table_metric_calculation(reference_data: Union[InputData, List[Tuple[InputData, InputData]]],
                              metrics: [str, Callable], pipeline: Optional[Pipeline],
+                             cache: Optional[OperationsCache] = None,
                              log=None) -> [Tuple[float, ...], None]:
     """ Perform cross validation on tabular data for regression and classification tasks
 
     :param reference_data: InputData for validation
-    :param cv_folds: number of folds to split data
     :param metrics: name of metric or callable object
     :param pipeline: Pipeline for validation
+    :param cache: cache manager for fitted models
     :param log: object for logging
     """
-    if reference_data.task.task_type is TaskTypesEnum.clustering:
-        raise NotImplementedError(f"Tabular cross validation for {reference_data.task.task_type} is not supported")
+    if ((isinstance(reference_data, InputData) and reference_data.task.task_type is TaskTypesEnum.clustering) or
+            (isinstance(reference_data, List) and reference_data[0][0].task.task_type is TaskTypesEnum.clustering)):
+        raise NotImplementedError(f"Tabular cross validation for clustering is not supported")
 
     log.debug(f'Pipeline {pipeline.root_node.descriptive_id} fit for cross validation started')
     try:
         evaluated_metrics = [[] for _ in range(len(metrics))]
-        for train_data, test_data in tabular_cv_generator(reference_data, cv_folds):
+        for fold_num, data_pair in enumerate(reference_data):
+            train_data, test_data = data_pair
             # Calculate metric value for every fold of data
-            evaluated_metrics = metric_evaluation(pipeline, train_data,
-                                                  test_data, metrics,
-                                                  evaluated_metrics)
+            evaluated_metrics = metric_evaluation(pipeline=pipeline, train_data=train_data,
+                                                  test_data=test_data, metrics=metrics,
+                                                  evaluated_metrics=evaluated_metrics, fold_num=fold_num, cache=cache)
         evaluated_metrics = tuple(map(lambda x: np.mean(x), evaluated_metrics))
         log.debug(f'Pipeline {pipeline.root_node.descriptive_id} with metrics: {list(evaluated_metrics)}')
 

--- a/fedot/core/validation/compose/time_series.py
+++ b/fedot/core/validation/compose/time_series.py
@@ -1,16 +1,20 @@
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
+from typing import Union, List
 
 import numpy as np
 
+from fedot.core.composer.cache import OperationsCache
 from fedot.core.data.data import InputData
 from fedot.core.validation.compose.metric_estimation import metric_evaluation
-from fedot.core.validation.split import ts_cv_generator
 
 
-def ts_metric_calculation(reference_data: InputData, cv_folds: int,
+def ts_metric_calculation(reference_data: Union[InputData, List[Tuple[InputData, InputData]]],
+                          cv_folds: int,
                           validation_blocks: int,
                           metrics: [str, Callable] = None,
-                          pipeline=None, log=None) -> [Tuple[float, ...], None]:
+                          pipeline=None,
+                          cache: Optional[OperationsCache] = None,
+                          log=None) -> [Tuple[float, ...], None]:
     """ Determine metric value for time series forecasting pipeline based
     on data for validation
 
@@ -18,18 +22,22 @@ def ts_metric_calculation(reference_data: InputData, cv_folds: int,
     :param cv_folds: number of folds to split data
     :param validation_blocks: number of validation blocks for time series validation
     :param metrics: name of metric or callable object
-    :param pipeline: Pipeline for validation
+    :param pipeline: pipeline for validation
+    :param cache: cache manager for fitted models
     :param log: object for logging
     """
     log.debug(f'Pipeline {pipeline.root_node.descriptive_id} fit for cross validation started')
     try:
         evaluated_metrics = [[] for _ in range(len(metrics))]
-        for train_data, test_data, vb_number in ts_cv_generator(reference_data, cv_folds, validation_blocks, log):
+        fold_num = 0
+        for train_data, test_data, validation_blocks_num in reference_data:
             # Calculate metric value for every fold of data
-            evaluated_metrics = metric_evaluation(pipeline, train_data,
-                                                  test_data, metrics,
-                                                  evaluated_metrics,
-                                                  vb_number)
+            evaluated_metrics = metric_evaluation(pipeline=pipeline, train_data=train_data,
+                                                  test_data=test_data, metrics=metrics,
+                                                  evaluated_metrics=evaluated_metrics,
+                                                  vb_number=validation_blocks_num,
+                                                  fold_num=fold_num, cache=cache)
+            fold_num += 1
         evaluated_metrics = tuple(map(lambda x: np.mean(x), evaluated_metrics))
         log.debug(f'Pipeline {pipeline.root_node.descriptive_id} with metrics: {list(evaluated_metrics)}')
     except Exception as ex:

--- a/fedot/core/validation/compose/time_series.py
+++ b/fedot/core/validation/compose/time_series.py
@@ -1,11 +1,11 @@
-from typing import Callable, Optional, Tuple
-from typing import Union, List
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
 from fedot.core.composer.cache import OperationsCache
 from fedot.core.data.data import InputData
 from fedot.core.validation.compose.metric_estimation import metric_evaluation
+from fedot.core.validation.split import ts_cv_generator
 
 
 def ts_metric_calculation(reference_data: Union[InputData, List[Tuple[InputData, InputData]]],
@@ -29,15 +29,16 @@ def ts_metric_calculation(reference_data: Union[InputData, List[Tuple[InputData,
     log.debug(f'Pipeline {pipeline.root_node.descriptive_id} fit for cross validation started')
     try:
         evaluated_metrics = [[] for _ in range(len(metrics))]
-        fold_num = 0
-        for train_data, test_data, validation_blocks_num in reference_data:
-            # Calculate metric value for every fold of data
+        fold_id = 0
+        for train_data, test_data, validation_blocks_number in ts_cv_generator(
+                reference_data, cv_folds, validation_blocks, log):
+            # Calculate metric value for each fold of data
             evaluated_metrics = metric_evaluation(pipeline=pipeline, train_data=train_data,
                                                   test_data=test_data, metrics=metrics,
                                                   evaluated_metrics=evaluated_metrics,
-                                                  vb_number=validation_blocks_num,
-                                                  fold_num=fold_num, cache=cache)
-            fold_num += 1
+                                                  vb_number=validation_blocks_number,
+                                                  fold_id=fold_id, cache=cache)
+            fold_id += 1
         evaluated_metrics = tuple(map(lambda x: np.mean(x), evaluated_metrics))
         log.debug(f'Pipeline {pipeline.root_node.descriptive_id} with metrics: {list(evaluated_metrics)}')
     except Exception as ex:

--- a/fedot/sensitivity/operations_hp_sensitivity/multi_operations_sensitivity.py
+++ b/fedot/sensitivity/operations_hp_sensitivity/multi_operations_sensitivity.py
@@ -54,7 +54,7 @@ class MultiOperationsHPAnalyze:
         Default: Sobol method with Saltelli sample algorithm
         :return: Main and total Sobol indices for every parameter per node.
         """
-        if not self._pipeline.fitted_on_data:
+        if not self._pipeline.is_fitted:
             self._pipeline.fit(self._train_data)
 
         # create problem

--- a/fedot/sensitivity/operations_hp_sensitivity/one_operation_sensitivity.py
+++ b/fedot/sensitivity/operations_hp_sensitivity/one_operation_sensitivity.py
@@ -7,14 +7,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.metrics import mean_squared_error
 
-from fedot.core.pipelines.pipeline import Pipeline
-from fedot.core.pipelines.node import Node
 from fedot.core.data.data import InputData
 from fedot.core.log import default_log, Log
 from fedot.core.operations.operation_template import extract_operation_params
+from fedot.core.pipelines.node import Node
+from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utils import default_fedot_data_dir
-from fedot.sensitivity.operations_hp_sensitivity.problem import OneOperationProblem
 from fedot.sensitivity.node_sa_approaches import NodeAnalyzeApproach
+from fedot.sensitivity.operations_hp_sensitivity.problem import OneOperationProblem
 from fedot.sensitivity.operations_hp_sensitivity.sa_and_sample_methods import analyze_method_by_name, \
     sample_method_by_name
 from fedot.sensitivity.sa_requirements import SensitivityAnalysisRequirements, HyperparamsAnalysisMetaParams
@@ -45,7 +45,7 @@ class OneOperationHPAnalyze(NodeAnalyzeApproach):
                 is_dispersion_analysis: bool = False) -> Union[dict, float]:
 
         # check whether the pipeline is fitted
-        if not self._pipeline.fitted_on_data:
+        if not self._pipeline.is_fitted:
             self._pipeline.fit(self._train_data)
 
         # create problem

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -290,7 +290,6 @@ def test_gp_composer_saving_info_from_process(data_fixture, request):
         global_cache_len_after = len(cache.dict)
     assert global_cache_len_before < global_cache_len_after
     assert new_pipeline.computation_time is not None
-    assert new_pipeline.fitted_on_data is not None
 
 
 def test_gp_composer_builder_default_params_correct():

--- a/test/unit/pipelines/test_node_cache.py
+++ b/test/unit/pipelines/test_node_cache.py
@@ -226,14 +226,15 @@ def test_cache_actuality_after_primary_node_changed_to_subtree(data_setup):
     assert not any([cache.get(node) for node in nodes_with_non_actual_cache])
 
 
-def test_cache_historical_state_using(data_setup):
+def test_cache_historical_state_using_with_cv(data_setup):
+    cv_fold = 1
     cache = OperationsCache()
     train, _ = data_setup
     pipeline = pipeline_first()
 
     # pipeline fitted, model goes to cache
     pipeline.fit(input_data=train)
-    cache.save_pipeline(pipeline)
+    cache.save_pipeline(pipeline, partial_id=cv_fold)
     new_node = SecondaryNode(operation_type='logit')
     old_node = pipeline.root_node.nodes_from[0]
 
@@ -244,16 +245,16 @@ def test_cache_historical_state_using(data_setup):
     assert not cache.get(pipeline.root_node)
     # fit modified pipeline
     pipeline.fit(input_data=train)
-    cache.save_pipeline(pipeline)
+    cache.save_pipeline(pipeline, partial_id=cv_fold)
     # cache is actual now
-    assert cache.get(pipeline.root_node)
+    assert cache.get(pipeline.root_node, partial_id=cv_fold)
 
     # change node back
     pipeline.update_node(old_node=pipeline.root_node.nodes_from[0],
                          new_node=old_node)
     # cache is actual without new fitting,
     # because the cached model was saved after first fit
-    assert cache.get(pipeline.root_node)
+    assert cache.get(pipeline.root_node, partial_id=cv_fold)
 
 
 def test_multi_pipeline_caching_with_cache(data_setup):

--- a/test/unit/preprocessing/test_pipeline_preprocessing.py
+++ b/test/unit/preprocessing/test_pipeline_preprocessing.py
@@ -96,7 +96,7 @@ def test_nans_columns_process_correctly():
     data_with_nans = data_with_too_much_nans()
 
     pipeline = correct_preprocessing_params(pipeline, numerical_min_uniques=5)
-    pipeline.fit(data_with_nans)
+    pipeline.fit(data_with_nans, use_fitted=True)
 
     # Ridge should use only one feature to make prediction
     fitted_ridge = pipeline.nodes[0]
@@ -178,7 +178,7 @@ def test_pipeline_with_imputer():
 
     mixed_input = get_mixed_data(task=Task(TaskTypesEnum.regression),
                                  extended=True)
-    pipeline.fit(mixed_input)
+    pipeline.fit(mixed_input, use_fitted=True)
 
     # Coefficients for ridge regression
     coefficients = pipeline.nodes[0].operation.fitted_operation.coef_
@@ -257,7 +257,7 @@ def test_data_with_mixed_types_per_column_processed_correctly():
 
     pipeline = Pipeline(PrimaryNode('dt'))
     pipeline = correct_preprocessing_params(pipeline, numerical_min_uniques=5)
-    pipeline.fit(train_data)
+    pipeline.fit(train_data, use_fitted=True)
     predicted = pipeline.predict(test_data)
 
     importances = pipeline.nodes[0].operation.fitted_operation.feature_importances_

--- a/test/unit/preprocessing/test_preprocessors.py
+++ b/test/unit/preprocessing/test_preprocessors.py
@@ -2,13 +2,12 @@ import numpy as np
 
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
+from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
+from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import TaskTypesEnum, Task
 from fedot.preprocessing.data_types import TableTypesCorrector
-from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
-from fedot.core.pipelines.pipeline import Pipeline
 from fedot.preprocessing.structure import DEFAULT_SOURCE_NAME
-
 from test.unit.preprocessing.test_pipeline_preprocessing import data_with_mixed_types_in_each_column, \
     correct_preprocessing_params
 
@@ -127,7 +126,7 @@ def test_complicated_table_types_processed_correctly():
 
     pipeline = Pipeline(PrimaryNode('dt'))
     pipeline = correct_preprocessing_params(pipeline, categorical_max_classes_th=13)
-    train_predicted = pipeline.fit(train_data)
+    train_predicted = pipeline.fit(train_data, use_fitted=True)
     pipeline.predict(test_data)
 
     # Table types corrector after fitting


### PR DESCRIPTION
Cache for fitted models is not working for CV-based metrics now.
This PR tries to fix it by the adding of fold-based supplementary ids for cache.

Main changes:
- preliminary data preparation for CV to improve performance and stability of results
- fit_from_scratch marked as obsolete, now the fit has the same behaviour
- fitted_on_data check removed as redunant