### PR TITLE
Test coverage corrected

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,6 @@ coverage:
 ignore:
   - "fedot/remote"  # external computational client can not be fully tested
   - "fedot/sensitivity" # unit test are moved to integration test due to the time restrictions
+  - "fedot/utilities" # unit test are moved to integration test due to the time restrictions
+  - "fedot/visualisation" # complicated to test in unit-like way, tested in integration tests
+  - "fedot/core/operations/evaluation/automl.py" # require to heavy external dependencies - tested in integration test

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         threshold: 1%
     patch: false
+ignore:
+  - "fedot/remote"  # external computational client can not be fully tested
+  - "fedot/sensitivity" # unit test are moved to integration test due to the time restrictions


### PR DESCRIPTION
'Sensetivity' folder excluded (since it is tested as integrational) as well as 'remote' (can not be tested directly)