### PR TITLE
fix_available_operations

### DIFF
--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -53,8 +53,10 @@ def run_with_random_search_composer():
     train_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_train.csv'
     test_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_test.csv'
 
+    composer_params = {'available_operations': ['class_decompose', 'rf', 'linear', 'xgboost', 'dt']}
+
     automl = Fedot(problem='classification', timeout=1, verbose_level=4,
-                   preset='fast_train')
+                   preset='fast_train', composer_params=composer_params)
 
     automl.api_composer.optimiser = RandomSearchOptimizer
 

--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -63,4 +63,5 @@ def run_with_random_search_composer():
     print(automl.get_metrics())
 
 
-run_with_random_search_composer()
+if __name__ == '__main__':
+    run_with_random_search_composer()

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -155,8 +155,12 @@ class ApiComposer:
 
         metric_function = self.obtain_metric(api_params['task'], composer_params['composer_metric'])
 
-        if composer_params['available_operations'] is None:
+        if not composer_params['available_operations']:
             composer_params['available_operations'] = get_operations_for_task(api_params['task'], mode='model')
+        else:
+            api_params['initial_assumption'] = self.initial_assumptions.\
+                    get_initial_assumption(api_params['train_data'], api_params['task'],
+                                           composer_params['available_operations'])
 
         api_params['logger'].message('Composition started. Parameters tuning: {}. ''Set of candidate models: {}. '
                                      'Time limit: {} min'.format(tuning_params['with_tuning'],

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -158,9 +158,14 @@ class ApiComposer:
         if not composer_params['available_operations']:
             composer_params['available_operations'] = get_operations_for_task(api_params['task'], mode='model')
         else:
-            api_params['initial_assumption'] = self.initial_assumptions.\
-                    get_initial_assumption(api_params['train_data'], api_params['task'],
-                                           composer_params['available_operations'])
+            if api_params['task'] == TaskTypesEnum.ts_forecasting and \
+                    'lagged' not in api_params['available_operations']:
+                api_params['available_operations'].append('lagged')
+
+            if not api_params['initial_assumption']:
+                api_params['initial_assumption'] = self.initial_assumptions.\
+                        get_initial_assumption(api_params['train_data'], api_params['task'],
+                                               composer_params['available_operations'], api_params['logger'])
 
         api_params['logger'].message('Composition started. Parameters tuning: {}. ''Set of candidate models: {}. '
                                      'Time limit: {} min'.format(tuning_params['with_tuning'],

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -150,6 +150,20 @@ class ApiComposer:
             secondary_operations = available_operations
         return primary_operations, secondary_operations
 
+    def _set_initial_assumption(self, api_params: dict, composer_params: dict):
+        """ Generates and sets an initial assumption, if not given, from the given available operations
+        Also, since it is impossible to form a valid pipeline for the time series problem without 'lagged' operation,
+        if it is not in the list of available ones, it is added """
+
+        if api_params['task'] == TaskTypesEnum.ts_forecasting and \
+                'lagged' not in api_params['available_operations']:
+            api_params['available_operations'].append('lagged')
+
+        if not api_params['initial_assumption']:
+            api_params['initial_assumption'] = self.initial_assumptions. \
+                get_initial_assumption(api_params['train_data'], api_params['task'],
+                                       composer_params['available_operations'], api_params['logger'])
+
     def compose_fedot_model(self, api_params: dict, composer_params: dict, tuning_params: dict):
         """ Function for composing FEDOT pipeline model """
 
@@ -158,14 +172,7 @@ class ApiComposer:
         if not composer_params['available_operations']:
             composer_params['available_operations'] = get_operations_for_task(api_params['task'], mode='model')
         else:
-            if api_params['task'] == TaskTypesEnum.ts_forecasting and \
-                    'lagged' not in api_params['available_operations']:
-                api_params['available_operations'].append('lagged')
-
-            if not api_params['initial_assumption']:
-                api_params['initial_assumption'] = self.initial_assumptions.\
-                        get_initial_assumption(api_params['train_data'], api_params['task'],
-                                               composer_params['available_operations'], api_params['logger'])
+            self._set_initial_assumption(api_params=api_params, composer_params=composer_params)
 
         api_params['logger'].message('Composition started. Parameters tuning: {}. ''Set of candidate models: {}. '
                                      'Time limit: {} min'.format(tuning_params['with_tuning'],

--- a/fedot/api/api_utils/initial_assumptions.py
+++ b/fedot/api/api_utils/initial_assumptions.py
@@ -80,7 +80,7 @@ class ApiInitialAssumptions:
                     node_lagged = PrimaryNode('lagged')
                     operations_to_choose_from = \
                         self._get_operations_for_the_task(task_type=TaskTypesEnum.regression, data_type=data.data_type,
-                                                          repo='all', available_operations=available_operations)
+                                                          repo='model', available_operations=available_operations)
                     if not operations_to_choose_from:
                         logger.message("Unable to construct an initial assumption from the passed "
                                        "available operations, default initial assumption will be used")
@@ -94,11 +94,10 @@ class ApiInitialAssumptions:
                         task.task_type == TaskTypesEnum.classification:
                     operations_to_choose_from = \
                         self._get_operations_for_the_task(task_type=task.task_type, data_type=data.data_type,
-                                                          repo='all', available_operations=available_operations)
+                                                          repo='model', available_operations=available_operations)
                     if not operations_to_choose_from:
                         logger.message("Unable to construct an initial assumption from the passed "
                                        "available operations, default initial assumption will be used")
-                        print('HERE2')
                         correct_pipelines.append(pipeline)
                         continue
 

--- a/fedot/api/api_utils/initial_assumptions.py
+++ b/fedot/api/api_utils/initial_assumptions.py
@@ -12,6 +12,8 @@ from fedot.core.repository.operation_types_repository import OperationTypesRepos
 from fedot.core.log import Log
 
 NOT_FITTED_ERR_MSG = 'Model not fitted yet'
+UNSUITABLE_AVAILABLE_OPERATIONS_MSG = "Unable to construct an initial assumption from the passed " \
+                                      "available operations, default initial assumption will be used"
 
 
 class ApiInitialAssumptions:
@@ -50,8 +52,7 @@ class ApiInitialAssumptions:
         operations_for_the_task = \
             OperationTypesRepository(repo).suitable_operation(task_type=task_type,
                                                               data_type=data_type)[0]
-        operations_to_choose_from = [operation for operation in operations_for_the_task
-                                     if operation in available_operations]
+        operations_to_choose_from = list(set(operations_for_the_task).intersection(available_operations))
         return operations_to_choose_from
 
     @staticmethod
@@ -82,8 +83,7 @@ class ApiInitialAssumptions:
                         self._get_operations_for_the_task(task_type=TaskTypesEnum.regression, data_type=data.data_type,
                                                           repo='model', available_operations=available_operations)
                     if not operations_to_choose_from:
-                        logger.message("Unable to construct an initial assumption from the passed "
-                                       "available operations, default initial assumption will be used")
+                        logger.message(UNSUITABLE_AVAILABLE_OPERATIONS_MSG)
                         correct_pipelines.append(pipeline)
                         continue
 
@@ -96,8 +96,7 @@ class ApiInitialAssumptions:
                         self._get_operations_for_the_task(task_type=task.task_type, data_type=data.data_type,
                                                           repo='model', available_operations=available_operations)
                     if not operations_to_choose_from:
-                        logger.message("Unable to construct an initial assumption from the passed "
-                                       "available operations, default initial assumption will be used")
+                        logger.message(UNSUITABLE_AVAILABLE_OPERATIONS_MSG)
                         correct_pipelines.append(pipeline)
                         continue
 

--- a/fedot/api/api_utils/initial_assumptions.py
+++ b/fedot/api/api_utils/initial_assumptions.py
@@ -64,9 +64,11 @@ class ApiInitialAssumptions:
                 return False
         return True
 
-    def _create_correct_unidata_pipeline(self, task, data, pipeline, available_operations, logger):
-        """ Creates a pilepine from the available operations. If it is impossible to create a valid pipeline
-        from the given available operations, returns the default one """
+    def _create_unidata_pipeline_on_random_operation(self, task, data, pipeline, available_operations, logger):
+        """ Creates pipeline from one model randomly selected from the pool of available operations.
+        For time series problem, first node with 'lagged' operation, then the randomly selected model.
+        If it is impossible to create a valid pipeline from the given available operations,
+        returns the default one """
 
         if task.task_type == TaskTypesEnum.ts_forecasting:
             node_lagged = PrimaryNode('lagged')
@@ -106,7 +108,9 @@ class ApiInitialAssumptions:
             if self._are_only_available_operations(pipeline, available_operations):
                 correct_pipelines.append(pipeline)
             else:
-                correct_pipeline = self._create_correct_unidata_pipeline(task, data, pipeline, available_operations, logger)
+                correct_pipeline = self._create_unidata_pipeline_on_random_operation(task, data,
+                                                                                     pipeline, available_operations,
+                                                                                     logger)
                 correct_pipelines.append(correct_pipeline)
         return correct_pipelines
 

--- a/fedot/core/composer/gp_composer/specific_operators.py
+++ b/fedot/core/composer/gp_composer/specific_operators.py
@@ -90,7 +90,7 @@ def boosting_mutation(pipeline: Pipeline, requirements, params, **kwargs) -> Any
         available_operations.append('lagged')
 
     for node in node_boost.ordered_subnodes_hierarchy():
-        if node.content['name'].__str__() not in available_operations:
+        if str(node.content['name']) not in available_operations:
             return pipeline
 
     node_final = SecondaryNode(choice(requirements.secondary),

--- a/fedot/core/composer/gp_composer/specific_operators.py
+++ b/fedot/core/composer/gp_composer/specific_operators.py
@@ -1,5 +1,5 @@
 from random import choice, random
-from typing import Any
+from typing import List, Any
 
 from fedot.core.optimisers.gp_comp.operators.mutation import get_mutation_prob
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
@@ -84,4 +84,20 @@ def boosting_mutation(pipeline: Pipeline, requirements, params, **kwargs) -> Any
     node_final = SecondaryNode(choice(requirements.secondary),
                                nodes_from=[existing_pipeline.root_node, node_boost])
     pipeline = Pipeline(node_final)
+
+    filter_pipeline_with_available_operations(pipeline,
+                                              list(set(requirements.primary + requirements.secondary)))
+
     return pipeline
+
+
+def filter_pipeline_with_available_operations(pipeline: Pipeline, available_operations: List[str]):
+    """ Iterates through all nodes of the pipeline and removes those that
+    are not specified in available operations """
+
+    pipeline_operations = [node.operation.operation_type for node in pipeline.nodes]
+    for i, operation in enumerate(pipeline_operations):
+        if operation not in available_operations:
+            for node in pipeline.nodes:
+                if node.operation.operation_type == operation:
+                    pipeline.operator.delete_node(node=node)

--- a/fedot/core/composer/gp_composer/specific_operators.py
+++ b/fedot/core/composer/gp_composer/specific_operators.py
@@ -93,6 +93,9 @@ def boosting_mutation(pipeline: Pipeline, requirements, params, **kwargs) -> Any
 
     # Check if all nodes in the boosting pipeline can be used according to available_operations
     available_operations = list(set(requirements.primary + requirements.secondary))
+    if task_type == TaskTypesEnum.ts_forecasting:
+        all_data_operations.append('lagged')
+
     for node in node_boost.ordered_subnodes_hierarchy():
         if node.content['name'].__str__() not in available_operations:
             return pipeline

--- a/fedot/core/optimisers/gp_comp/operators/mutation.py
+++ b/fedot/core/optimisers/gp_comp/operators/mutation.py
@@ -11,7 +11,6 @@ from fedot.core.optimisers.gp_comp.gp_operators import random_graph
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.optimisers.opt_history import ParentOperator
-from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utils import DEFAULT_PARAMS_STUB, ComparableEnum as Enum
 
 if TYPE_CHECKING:
@@ -263,7 +262,7 @@ def single_add_mutation(graph: Any, requirements, params, max_depth, *args, **kw
 
 def single_change_mutation(graph: Any, requirements, params, *args, **kwargs):
     """
-    Add new node between two sequential existing modes
+    Change node between two sequential existing modes
     """
     node = choice(graph.nodes)
     nodes_from = node.nodes_from
@@ -285,7 +284,7 @@ def single_change_mutation(graph: Any, requirements, params, *args, **kwargs):
 
 def single_drop_mutation(graph: Any, params, *args, **kwargs):
     """
-    Add new node between two sequential existing modes
+    Drop single node from graph
     """
     node_to_del = choice(graph.nodes)
     node_name = node_to_del.content['name']

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -12,7 +12,6 @@ from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.log import Log, default_log
 from fedot.core.operations.model import Model
 from fedot.core.optimisers.timer import Timer
-from fedot.core.optimisers.utils.population_utils import input_data_characteristics
 from fedot.core.pipelines.node import Node, PrimaryNode, SecondaryNode
 from fedot.core.pipelines.template import PipelineTemplate
 from fedot.core.pipelines.tuning.unified import PipelineTuner
@@ -59,7 +58,7 @@ class Pipeline(Graph):
                 self.operator.update_node(old_node=node,
                                           new_node=SecondaryNode(nodes_from=node.nodes_from,
                                                                  content=node.content))
-            elif not node.nodes_from and not self.operator.node_children(node):
+            elif not node.nodes_from and not self.operator.node_children(node) and node != self.root_node:
                 self.nodes.remove(node)
             elif not node.nodes_from and not isinstance(node, PrimaryNode):
                 self.operator.update_node(old_node=node,

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -383,8 +383,9 @@ def test_boosting_mutation_for_linear_graph():
                                          [OptNode({'name': 'class_decompose'},
                                                   [model_node, init_node])])]))
 
-    composer_requirements = PipelineComposerRequirements(primary=['scaling'],
-                                                         secondary=['logit'], mutation_prob=1)
+    available_operations = [node.content['name'] for node in boosting_graph.nodes]
+    composer_requirements = PipelineComposerRequirements(primary=available_operations,
+                                                         secondary=available_operations, mutation_prob=1)
 
     graph_params = GraphGenerationParams(adapter=PipelineAdapter(),
                                          advisor=PipelineChangeAdvisor(task=Task(TaskTypesEnum.classification)),
@@ -432,8 +433,9 @@ def test_boosting_mutation_for_non_lagged_ts_model():
     # to ensure hyperparameters of custom models
     boosting_graph = adapter.adapt(adapter.restore(boosting_graph))
 
-    composer_requirements = PipelineComposerRequirements(primary=['smoothing'],
-                                                         secondary=['ridge'], mutation_prob=1)
+    available_operations = [node.content['name'].operation_type for node in boosting_graph.nodes]
+    composer_requirements = PipelineComposerRequirements(primary=available_operations,
+                                                         secondary=available_operations, mutation_prob=1)
 
     graph_params = GraphGenerationParams(adapter=adapter,
                                          advisor=PipelineChangeAdvisor(
@@ -458,7 +460,8 @@ def test_boosting_mutation_for_non_lagged_ts_model():
     data_train, data_test = get_ts_data()
     pipeline.fit(data_train)
     result = pipeline.predict(data_test)
-    assert result is not None
+    # assert result is not None
+    assert True
 
 
 def test_pipeline_adapters_params_correct():

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -392,12 +392,12 @@ def test_boosting_mutation_for_linear_graph():
                                          rules_for_constraint=DEFAULT_DAG_RULES)
     successful_mutation_boosting = False
     for _ in range(100):
-        graph_after_mutation = mutation(types=[boosting_mutation],
-                                        params=graph_params,
-                                        ind=Individual(linear_one_node),
-                                        requirements=composer_requirements,
-                                        log=default_log(__name__), max_depth=2).graph
         if not successful_mutation_boosting:
+            graph_after_mutation = mutation(types=[boosting_mutation],
+                                            params=graph_params,
+                                            ind=Individual(linear_one_node),
+                                            requirements=composer_requirements,
+                                            log=default_log(__name__), max_depth=2).graph
             successful_mutation_boosting = \
                 graph_after_mutation.root_node.descriptive_id == boosting_graph.root_node.descriptive_id
         else:
@@ -443,12 +443,12 @@ def test_boosting_mutation_for_non_lagged_ts_model():
                                          rules_for_constraint=DEFAULT_DAG_RULES)
     successful_mutation_boosting = False
     for _ in range(100):
-        graph_after_mutation = mutation(types=[boosting_mutation],
-                                        params=graph_params,
-                                        ind=Individual(linear_two_nodes),
-                                        requirements=composer_requirements,
-                                        log=default_log(__name__), max_depth=2).graph
         if not successful_mutation_boosting:
+            graph_after_mutation = mutation(types=[boosting_mutation],
+                                            params=graph_params,
+                                            ind=Individual(linear_two_nodes),
+                                            requirements=composer_requirements,
+                                            log=default_log(__name__), max_depth=2).graph
             successful_mutation_boosting = \
                 graph_after_mutation.root_node.descriptive_id == boosting_graph.root_node.descriptive_id
         else:

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -460,8 +460,7 @@ def test_boosting_mutation_for_non_lagged_ts_model():
     data_train, data_test = get_ts_data()
     pipeline.fit(data_train)
     result = pipeline.predict(data_test)
-    # assert result is not None
-    assert True
+    assert result is not None
 
 
 def test_pipeline_adapters_params_correct():

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -433,7 +433,7 @@ def test_boosting_mutation_for_non_lagged_ts_model():
     # to ensure hyperparameters of custom models
     boosting_graph = adapter.adapt(adapter.restore(boosting_graph))
 
-    available_operations = [node.content['name'].operation_type for node in boosting_graph.nodes]
+    available_operations = [node.content['name'] for node in boosting_graph.nodes]
     composer_requirements = PipelineComposerRequirements(primary=available_operations,
                                                          secondary=available_operations, mutation_prob=1)
 


### PR DESCRIPTION
Now the setting of composer_params['available_operations'] affects the initial assumption and mutations. The initial assumption is built only from the available operations and boosting mutation can no longer add nodes to the pipeline with operations/models that are not specified in the 'available_operations' (if composer_params['available_operations'] is specified)