### PR TITLE
OS-independent paths in serialization

### DIFF
--- a/fedot/core/operations/operation_template.py
+++ b/fedot/core/operations/operation_template.py
@@ -125,6 +125,11 @@ class OperationTemplate(OperationTemplateAbstract):
         self.fitted_operation = node.fitted_operation
 
     def convert_to_dict(self) -> dict:
+        # Convert compound path into separate files and directories
+        if self.fitted_operation_path is not None and os.sep in self.fitted_operation_path:
+            fitted_path = os.path.split(self.fitted_operation_path)
+        else:
+            fitted_path = self.fitted_operation_path
 
         operation_object = {
             "operation_id": self.operation_id,
@@ -133,7 +138,7 @@ class OperationTemplate(OperationTemplateAbstract):
             "custom_params": self.custom_params,
             "params": self.params,
             "nodes_from": self.nodes_from,
-            "fitted_operation_path": self.fitted_operation_path,
+            "fitted_operation_path": fitted_path,
             "rating": self.rating,
         }
 
@@ -179,7 +184,14 @@ class OperationTemplate(OperationTemplateAbstract):
             self.params['dtype'] = np.dtype(self.params['dtype'])
         self.nodes_from = operation_object['nodes_from']
         if 'fitted_operation_path' in operation_object:
-            self.fitted_operation_path = operation_object['fitted_operation_path']
+            fitted_operation_path = operation_object['fitted_operation_path']
+            if isinstance(fitted_operation_path, str):
+                self.fitted_operation_path = fitted_operation_path
+            elif isinstance(fitted_operation_path, list):
+                # Path were set as folders and files in tuple or list
+                self.fitted_operation_path = os.path.join(fitted_operation_path[0],
+                                                          fitted_operation_path[1])
+
         if 'custom_params' in operation_object:
             self.custom_params = operation_object['custom_params']
         if 'operation_name' in operation_object:

--- a/fedot/core/pipelines/template.py
+++ b/fedot/core/pipelines/template.py
@@ -163,7 +163,7 @@ class PipelineTemplate:
                         node['custom_params'][key] = None
 
         # Store information about preprocessing
-        preprocessing_path = os.path.join('preprocessing', 'data_preprocessor.pkl')
+        preprocessing_path = ['preprocessing', 'data_preprocessor.pkl']
 
         json_object = {
             "total_pipeline_operations": list(self.total_pipeline_operations),
@@ -186,7 +186,11 @@ class PipelineTemplate:
             return None
 
         # Save preprocessing module
-        dict_fitted_operations['preprocessing'] = self.export_preprocessing(path)
+        preprocessing_path = self.export_preprocessing(path)
+        if isinstance(preprocessing_path, str):
+            preprocessing_splitted = os.path.split(preprocessing_path)
+            preprocessing_path = [preprocessing_splitted[-2], preprocessing_splitted[-1]]
+        dict_fitted_operations['preprocessing'] = preprocessing_path
         return dict_fitted_operations
 
     def _prepare_paths(self, path: str, with_time: bool = True):

--- a/test/unit/utilities/test_pipeline_import_export.py
+++ b/test/unit/utilities/test_pipeline_import_export.py
@@ -30,7 +30,6 @@ def preprocessing_files_before_and_after_tests(request):
              'test_import_custom_json_object_to_pipeline_and_fit_correctly_no_exception',
              'test_save_pipeline_with_np_int_type', 'test_pipeline_with_preprocessing_serialized_correctly',
              'test_multimodal_pipeline_serialized_correctly']
-    paths = []
 
     delete_files = create_func_delete_files(paths)
     delete_files()

--- a/test/unit/utilities/test_pipeline_import_export.py
+++ b/test/unit/utilities/test_pipeline_import_export.py
@@ -30,6 +30,7 @@ def preprocessing_files_before_and_after_tests(request):
              'test_import_custom_json_object_to_pipeline_and_fit_correctly_no_exception',
              'test_save_pipeline_with_np_int_type', 'test_pipeline_with_preprocessing_serialized_correctly',
              'test_multimodal_pipeline_serialized_correctly']
+    paths = []
 
     delete_files = create_func_delete_files(paths)
     delete_files()


### PR DESCRIPTION
In the folders with serialized models in the json files, the paths were written with "/" separator
Now the form of the record has been changed, now the paths are stored as a list, for example

```
"preprocessing": ["preprocessing","data_preprocessor.pkl"
```

The implementation is backward-compatible with the previous version