### PR TITLE
Modify validation rules for decompose

### DIFF
--- a/fedot/core/pipelines/validation.py
+++ b/fedot/core/pipelines/validation.py
@@ -10,7 +10,8 @@ from fedot.core.optimisers.graph import OptGraph
 from fedot.core.pipelines.validation_rules import has_correct_data_connections, has_correct_data_sources, \
     has_correct_operation_positions, has_final_operation_as_model, has_no_conflicts_in_decompose, \
     has_no_conflicts_with_data_flow, has_no_data_flow_conflicts_in_ts_pipeline, has_primary_nodes, \
-    only_non_lagged_operations_are_primary, is_pipeline_contains_ts_operations
+    only_non_lagged_operations_are_primary, is_pipeline_contains_ts_operations, has_no_conflicts_during_multitask, \
+    has_no_conflicts_after_class_decompose
 
 common_rules = [has_one_root,
                 has_no_cycle,
@@ -22,7 +23,9 @@ common_rules = [has_one_root,
                 has_no_conflicts_with_data_flow,
                 has_no_conflicts_in_decompose,
                 has_correct_data_connections,
-                has_correct_data_sources]
+                has_correct_data_sources,
+                has_no_conflicts_during_multitask,
+                has_no_conflicts_after_class_decompose]
 
 ts_rules = [is_pipeline_contains_ts_operations,
             only_non_lagged_operations_are_primary,

--- a/fedot/core/pipelines/validation.py
+++ b/fedot/core/pipelines/validation.py
@@ -23,13 +23,14 @@ common_rules = [has_one_root,
                 has_no_conflicts_with_data_flow,
                 has_no_conflicts_in_decompose,
                 has_correct_data_connections,
-                has_correct_data_sources,
-                has_no_conflicts_during_multitask,
-                has_no_conflicts_after_class_decompose]
+                has_correct_data_sources]
 
 ts_rules = [is_pipeline_contains_ts_operations,
             only_non_lagged_operations_are_primary,
             has_no_data_flow_conflicts_in_ts_pipeline]
+
+class_rules = [has_no_conflicts_during_multitask,
+               has_no_conflicts_after_class_decompose]
 
 
 def validate(graph: Graph, rules: List[Callable] = None, task=None):
@@ -49,6 +50,9 @@ def validate(graph: Graph, rules: List[Callable] = None, task=None):
     # Perform time series specific rules
     if task and task.task_type is TaskTypesEnum.ts_forecasting:
         for rule_func in ts_rules:
+            _rule_check(graph, rule_func)
+    elif task and task.task_type is TaskTypesEnum.classification:
+        for rule_func in class_rules:
             _rule_check(graph, rule_func)
     return True
 

--- a/fedot/core/pipelines/validation_rules.py
+++ b/fedot/core/pipelines/validation_rules.py
@@ -255,7 +255,7 @@ def has_no_conflicts_during_multitask(pipeline: Pipeline):
 
     if 'class_decompose' not in pipeline_operations:
         # There are no decompose operations in the pipeline
-        if number_of_unique_pipeline_operations != operations_for_task:
+        if number_of_unique_pipeline_operations != len(operations_for_task):
             # There are operations in the pipeline that solve different tasks
             __check_multitask_operation_location(pipeline, all_operations)
 
@@ -273,6 +273,8 @@ def has_no_conflicts_after_class_decompose(pipeline: Pipeline):
 
     # Check for correct descendants after classification decompose
     for node in pipeline.nodes:
+        if node.nodes_from is None:
+            continue
         parent_operations = [node.operation.operation_type for node in node.nodes_from]
         if 'class_decompose' in parent_operations:
             # Check is this model for regression task

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -148,7 +148,8 @@
 				"non_linear",
 				"dimensionality_transforming",
 				"correct_params",
-				"non_applicable_for_ts"
+				"non_applicable_for_ts",
+				"non-default"
 			]
 		},
 		"poly_features": {

--- a/test/unit/pipelines/test_pipeline_comparison.py
+++ b/test/unit/pipelines/test_pipeline_comparison.py
@@ -9,15 +9,15 @@ from fedot.core.pipelines.pipeline import Pipeline
 
 
 def pipeline_first():
-    #    XG
+    #    RF
     #  |     \
-    # XG     KNN
+    # RF     KNN
     # |  \    |  \
     # LR LDA LR  LDA
     pipeline = Pipeline()
 
     root_of_tree, root_child_first, root_child_second = \
-        [SecondaryNode(model) for model in ('xgboost', 'xgboost', 'knn')]
+        [SecondaryNode(model) for model in ('rf', 'rf', 'knn')]
 
     for root_node_child in (root_child_first, root_child_second):
         for requirement_model in ('logit', 'lda'):
@@ -32,14 +32,14 @@ def pipeline_first():
 
 
 def pipeline_second():
-    #      XG
+    #      RF
     #   |      \
-    #  XG      KNN
+    #  RF      KNN
     #  | \      |  \
-    # LR XG   LR   LDA
+    # LR RF   LR   LDA
     #    |  \
     #   KNN  LDA
-    new_node = SecondaryNode('xgboost')
+    new_node = SecondaryNode('rf')
     for model_type in ('knn', 'lda'):
         new_node.nodes_from.append(PrimaryNode(model_type))
     pipeline = pipeline_first()
@@ -49,10 +49,10 @@ def pipeline_second():
 
 
 def pipeline_third():
-    #      XG
+    #      RF
     #   /  |  \
     #  KNN LDA KNN
-    root_of_tree = SecondaryNode('xgboost')
+    root_of_tree = SecondaryNode('rf')
     for model_type in ('knn', 'lda', 'knn'):
         root_of_tree.nodes_from.append(PrimaryNode(model_type))
     pipeline = Pipeline()
@@ -65,14 +65,14 @@ def pipeline_third():
 
 
 def pipeline_fourth():
-    #      XG
+    #      RF
     #   |  \  \
-    #  KNN  XG  KNN
+    #  KNN  RF  KNN
     #      |  \
     #    KNN   KNN
 
     pipeline = pipeline_third()
-    new_node = SecondaryNode('xgboost')
+    new_node = SecondaryNode('rf')
     [new_node.nodes_from.append(PrimaryNode('knn')) for _ in range(2)]
     pipeline.update_subtree(pipeline.root_node.nodes_from[1], new_node)
 

--- a/test/unit/pipelines/test_pipeline_validation.py
+++ b/test/unit/pipelines/test_pipeline_validation.py
@@ -8,7 +8,8 @@ from fedot.core.pipelines.validation import (validate)
 from fedot.core.pipelines.validation_rules import has_correct_operation_positions, has_final_operation_as_model, \
     has_no_conflicts_in_decompose, has_no_conflicts_with_data_flow, has_no_data_flow_conflicts_in_ts_pipeline, \
     has_primary_nodes, is_pipeline_contains_ts_operations, only_non_lagged_operations_are_primary, \
-    has_correct_data_sources, has_parent_contain_single_resample
+    has_correct_data_sources, has_parent_contain_single_resample, has_no_conflicts_during_multitask, \
+    has_no_conflicts_after_class_decompose
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
 PIPELINE_ERROR_PREFIX = 'Invalid pipeline configuration:'
@@ -186,10 +187,10 @@ def ts_pipeline_with_incorrect_data_flow():
     return pipeline
 
 
-def pipeline_with_incorrect_parent_amount_for_decompose():
+def pipeline_with_incorrect_parent_number_for_decompose():
     """ Pipeline structure:
            logit
-    scaling                        xgboost
+    scaling                        rf
            class_decompose -> rfr
     For class_decompose connection with "logit" model needed
     """
@@ -212,6 +213,21 @@ def pipeline_with_incorrect_parents_position_for_decompose():
 
     node_first = PrimaryNode('logit')
     node_second = SecondaryNode('scaling', nodes_from=[node_first])
+    node_decompose = SecondaryNode('class_decompose', nodes_from=[node_second, node_first])
+    node_rfr = SecondaryNode('rfr', nodes_from=[node_decompose])
+    node_rf = SecondaryNode('rf', nodes_from=[node_rfr, node_second])
+    pipeline = Pipeline(node_rf)
+    return pipeline
+
+
+def correct_decompose_pipeline():
+    """
+            logit
+    scaling                         rf
+            class_decompose -> rfr
+    """
+    node_first = PrimaryNode('scaling')
+    node_second = SecondaryNode('logit', nodes_from=[node_first])
     node_decompose = SecondaryNode('class_decompose', nodes_from=[node_second, node_first])
     node_rfr = SecondaryNode('rfr', nodes_from=[node_decompose])
     node_rf = SecondaryNode('rf', nodes_from=[node_rfr, node_second])
@@ -362,7 +378,7 @@ def test_only_non_lagged_operations_are_primary():
 
 
 def test_has_two_parents_for_decompose_operations():
-    incorrect_pipeline = pipeline_with_incorrect_parent_amount_for_decompose()
+    incorrect_pipeline = pipeline_with_incorrect_parent_number_for_decompose()
 
     with pytest.raises(Exception) as exc:
         assert has_no_conflicts_in_decompose(incorrect_pipeline)
@@ -379,6 +395,42 @@ def test_decompose_parents_has_wright_positions():
     assert str(exc.value) == f'{PIPELINE_ERROR_PREFIX} For decompose operation Model as first parent is required'
 
 
+def test_decompose_operation_remove_in_pipeline():
+    """
+    In the process of evolution, edges and nodes may have been removed from the decompose pipeline.
+    Or a decompose node could be replaced with a new one. Such pipelines are incorrect.
+    In this test replacement the class_decompose with logit operation is performed
+    """
+    current_pipeline = correct_decompose_pipeline()
+    for node in current_pipeline.nodes:
+        if node.operation.operation_type == 'class_decompose':
+            # Replace decompose node with simple classification model
+            node.operation.operation_type = 'logit'
+
+    with pytest.raises(ValueError) as exc:
+        has_no_conflicts_during_multitask(current_pipeline)
+
+    assert str(exc.value) == f'{PIPELINE_ERROR_PREFIX} Current pipeline can not solve multitask problem'
+
+
+def test_incorrect_node_after_decompose_operation():
+    """
+    The regression model should be next after class_decompose operation.
+    If it doesn't, then the pipelining is incorrect
+    """
+    current_pipeline = correct_decompose_pipeline()
+    for node in current_pipeline.nodes:
+        if node.operation.operation_type == 'rfr':
+            # Replace regression model with classification one
+            node.operation.operation_type = 'lda'
+
+    with pytest.raises(ValueError) as exc:
+        has_no_conflicts_after_class_decompose(current_pipeline)
+
+    expected_error = f'{PIPELINE_ERROR_PREFIX} After classification decompose it is required to use regression model'
+    assert str(exc.value) == expected_error
+
+
 def test_data_sources_validation():
     incorrect_pipeline = pipeline_with_incorrect_data_sources()
 
@@ -391,7 +443,7 @@ def test_data_sources_validation():
     assert has_correct_data_sources(correct_pipeline)
 
 
-def custom_validation_test():
+def test_custom_validation():
     incorrect_pipeline = pipeline_with_incorrect_parents_position_for_decompose()
 
     assert validate(incorrect_pipeline, rules=[has_no_cycle])


### PR DESCRIPTION
The rules for pipelines with the decompose operation have been modified. Now if two tasks will be solved simultaneously in a pipeline, such pipelines can be evaluated by the algorithm as correct and incorrect (based on the location of decompose operations or the absence of decompose operations)