### PR TITLE
fix get_metrics method

### DIFF
--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -313,12 +313,15 @@ class Fedot:
                 prediction = deepcopy(self.prediction)
                 if metric_name == "roc_auc":  # for roc-auc we need probabilities
                     prediction.predict = self.predict_proba(self.test_data)
+                else:
+                    prediction.predict = self.predict(self.test_data)
                 real = deepcopy(self.test_data)
 
                 # Work inplace - correct predictions
-                self.data_processor.correct_predictions(metric_name=metric_name,
-                                                        real=real,
+                self.data_processor.correct_predictions(real=real,
                                                         prediction=prediction)
+
+                real.target = np.ravel(real.target)
 
                 metric_value = abs(metric_cls.metric(reference=real,
                                                      predicted=prediction))

--- a/test/unit/api/test_api_utils.py
+++ b/test/unit/api/test_api_utils.py
@@ -1,16 +1,17 @@
 from copy import deepcopy
-
-import numpy as np
+import random
 
 from examples.simple.classification.classification_pipelines import classification_pipeline_without_balancing
 from fedot.api.api_utils.api_composer import ApiComposer
 from fedot.api.api_utils.api_data import ApiDataProcessor
 from fedot.api.api_utils.assumptions.assumptions_builder import AssumptionsBuilder
 from fedot.api.main import Fedot
+from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.preprocessing.preprocessing import DataPreprocessor
 from ..api.test_main_api import get_dataset
+from ..tasks.test_classification import get_binary_classification_data
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 from fedot.core.log import default_log
 from fedot.core.pipelines.pipeline import Pipeline
@@ -50,18 +51,35 @@ def test_compose_fedot_model_with_tuning():
     logs.check_present(expected, order_matters=False)
 
 
-def test_output_classification_converting_correct():
+def test_output_binary_classification_correct():
     """ Check the correctness of prediction for binary classification task """
 
     task_type = 'classification'
 
-    train_data, test_data, _ = get_dataset(task_type=task_type)
+    data = get_binary_classification_data()
 
-    model = Fedot(problem=task_type, timeout=0.5)
-    model.fit(train_data)
-    model.predict(test_data)
+    random.seed(1)
+    train_data, test_data = train_test_data_setup(data, shuffle_flag=True)
+
+    model = Fedot(problem=task_type, timeout=0.1)
+
+    model.train_data = model.data_processor.define_data(features=train_data.features,
+                                                        target=train_data.target,
+                                                        is_predict=False)
+
+    model.test_data = model.data_processor.define_data(features=test_data.features,
+                                                       target=test_data.target,
+                                                       is_predict=True)
+
+    pipeline = Pipeline(PrimaryNode('logit'))
+    pipeline.fit(train_data)
+
+    model.prediction = pipeline.predict(test_data)
+    model.current_pipeline = pipeline
+
     metrics = model.get_metrics(metric_names=['roc_auc', 'f1'])
-    assert isinstance(metrics['f1'], float)
+    assert metrics['roc_auc'] >= 0.6
+    assert metrics['f1'] >= 0.6
 
 
 def test_predefined_initial_assumption():

--- a/test/unit/api/test_api_utils.py
+++ b/test/unit/api/test_api_utils.py
@@ -62,22 +62,10 @@ def test_output_binary_classification_correct():
     train_data, test_data = train_test_data_setup(data, shuffle_flag=True)
 
     model = Fedot(problem=task_type, timeout=0.1)
-
-    model.train_data = model.data_processor.define_data(features=train_data.features,
-                                                        target=train_data.target,
-                                                        is_predict=False)
-
-    model.test_data = model.data_processor.define_data(features=test_data.features,
-                                                       target=test_data.target,
-                                                       is_predict=True)
-
-    pipeline = Pipeline(PrimaryNode('logit'))
-    pipeline.fit(train_data)
-
-    model.prediction = pipeline.predict(test_data)
-    model.current_pipeline = pipeline
-
+    model.fit(train_data, predefined_model='logit')
+    model.predict(test_data)
     metrics = model.get_metrics(metric_names=['roc_auc', 'f1'])
+
     assert metrics['roc_auc'] >= 0.6
     assert metrics['f1'] >= 0.6
 

--- a/test/unit/api/test_api_utils.py
+++ b/test/unit/api/test_api_utils.py
@@ -51,22 +51,17 @@ def test_compose_fedot_model_with_tuning():
 
 
 def test_output_classification_converting_correct():
-    """ Check the correctness of correct prediction method for binary classification task """
+    """ Check the correctness of prediction for binary classification task """
 
-    task = Task(task_type=TaskTypesEnum.classification)
-    real = InputData(idx=[0, 1, 2], features=np.array([[0], [1], [2]]),
-                     target=np.array([[0], [1], [1]]),
-                     task=task, data_type=DataTypesEnum.table)
-    prediction = OutputData(idx=[0, 1, 2], features=np.array([[0], [1], [2]]),
-                            predict=np.array([[0.5], [0.7], [0.7]]),
-                            target=np.array([[0], [1], [1]]),
-                            task=task, data_type=DataTypesEnum.table)
+    task_type = 'classification'
 
-    data_processor = ApiDataProcessor(task=task)
-    # Perform correction inplace
-    data_processor.correct_predictions(metric_name='f1', real=real, prediction=prediction)
+    train_data, test_data, _ = get_dataset(task_type=task_type)
 
-    assert int(prediction.predict[1]) == 1
+    model = Fedot(problem=task_type, timeout=0.5)
+    model.fit(train_data)
+    model.predict(test_data)
+    metrics = model.get_metrics(metric_names=['roc_auc', 'f1'])
+    assert isinstance(metrics['f1'], float)
 
 
 def test_predefined_initial_assumption():


### PR DESCRIPTION
Earlier in this method, when calculating ROCAUC metric, predictions were redefined and probabilities were placed in `prediction.predict`. Then the probabilities were converted into labels
Now at the very beginning when calculating the metric for which labels are needed, predictions are given in labels