### PR TITLE
Fix test_pipeline_fit_time_constraint

### DIFF
--- a/test/unit/pipelines/test_pipeline.py
+++ b/test/unit/pipelines/test_pipeline.py
@@ -391,8 +391,7 @@ def test_pipeline_fit_time_constraint(data_fixture, request):
         computation_time_first = test_pipeline_first.computation_time
         assert type(received_ex) is TimeoutError
     comp_time_proc_with_first_constraint = (time.time() - process_start_time)
-    time_constraint = datetime.timedelta(seconds=2)
-    test_pipeline_first.unfit(unfit_preprocessor=True)
+    time_constraint = datetime.timedelta(seconds=5)
     process_start_time = time.time()
 
     try:


### PR DESCRIPTION
Fixed occasional test error when computational time of pipeline with higher time constraint was lower than computational time with less time constraint
Time constraint affects fit time, but fit time also fluctuates because of internal hardware reasons. The dispersion of this fluctuation seems to be constant. Therefore, if fit process is optimized, the fit time of both time constraint values in test is reduced, but dispersion remains the same. This raises the probability of dispersions' overlay and, hence, the test fail. Change of timeouts to 1 and 5 seconds provides stable work of test 