### PR TITLE
Added _calculate_loss_function with exception processing

### DIFF
--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -307,7 +307,7 @@ def _calculate_loss_function(loss_function, loss_params, target, preds):
         metric_value = loss_function(target, preds, **loss_params)
     except ValueError:
         try:
-            metric_value = loss_function(target, np.max(preds, axis=1), **loss_params)
+            metric_value = loss_function(target, preds[:, 1], **loss_params)
         except ValueError:
             metric_value = loss_function(target, np.argmax(preds, axis=1), **loss_params)
 

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -134,7 +134,7 @@ class HyperoptTuner(ABC):
                                                      loss_function=loss_function,
                                                      loss_params=loss_params)
 
-        if self.obtained_metric in (-MAX_METRIC_VALUE, MAX_METRIC_VALUE):
+        if self.obtained_metric == self._default_metric_value:
             self.obtained_metric = None
 
         self.log.info('Hyperparameters optimization finished')

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -149,7 +149,7 @@ class HyperoptTuner(ABC):
             # Maximization
             init_metric = -1 * (self.init_metric - deviation)
             if self.obtained_metric is None:
-                self.log.info(f'is None. Initial metric is {init_metric:.3f}')
+                self.log.info(f'{prefix_init_phrase} is None. Initial metric is {init_metric:.3f}')
                 return self.init_pipeline
 
             self.obtained_metric *= -1
@@ -165,7 +165,7 @@ class HyperoptTuner(ABC):
             # Minimization
             init_metric = self.init_metric + deviation
             if self.obtained_metric is None:
-                self.log.info(f'is None. Initial metric is {init_metric:.3f}')
+                self.log.info(f'{prefix_init_phrase} is None. Initial metric is {init_metric:.3f}')
                 return self.init_pipeline
             elif self.obtained_metric <= init_metric:
                 self.log.info(f'{prefix_tuned_phrase} {self.obtained_metric:.3f} equal or '

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -79,7 +79,7 @@ class HyperoptTuner(ABC):
         :param loss_function: function to minimize (or maximize)
         :param loss_params: parameters for loss function
 
-        :return : value of loss function
+        :return: value of loss function
         """
 
         try:
@@ -213,7 +213,7 @@ def _create_multi_target_prediction(target, optimal=True):
     :param target: target for define what problem is solving (max or min)
     :param optimal: whether return optimal probabilities or not
 
-    :return : 2d-array of classes probabilities
+    :return: 2d-array of classes probabilities
     """
 
     len_target = target.shape[0]
@@ -234,7 +234,7 @@ def _convert_target_dimension(target):
 
     :param target: target for define what problem is solving (max or min)
 
-    :return : 2d-array of classes probabilities
+    :return: 2d-array of classes probabilities
     """
 
     nb_classes = len(np.unique(target))
@@ -257,7 +257,7 @@ def _greater_is_better(target, loss_function, loss_params, data_type) -> bool:
     :param loss_function: loss function
     :param loss_params: parameters for loss function
 
-    :return : bool value is it good to maximize metric or not
+    :return: bool value is it good to maximize metric or not
     """
 
     if isinstance(target[0], str):
@@ -290,15 +290,25 @@ def _greater_is_better(target, loss_function, loss_params, data_type) -> bool:
         return False
 
 
-def _calculate_loss_function(loss_function, loss_params, test_target, preds):
+def _calculate_loss_function(loss_function, loss_params, target, preds):
+    """ Function processing preds and calculating metric (loss function)
+
+    :param loss_function: loss function
+    :param loss_params: parameters for loss function
+    :param target: target for evaluation
+    :param preds: prediction for evaluation
+
+    :return: calculated loss_function
+    """
+
     if loss_params is None:
         loss_params = {}
     try:
-        metric_value = loss_function(test_target, preds, **loss_params)
+        metric_value = loss_function(target, preds, **loss_params)
     except ValueError:
         try:
-            metric_value = loss_function(test_target, np.max(preds, axis=1), **loss_params)
+            metric_value = loss_function(target, np.max(preds, axis=1), **loss_params)
         except ValueError:
-            metric_value = loss_function(test_target, np.argmax(preds, axis=1), **loss_params)
+            metric_value = loss_function(target, np.argmax(preds, axis=1), **loss_params)
 
     return metric_value

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -304,11 +304,14 @@ def _calculate_loss_function(loss_function, loss_params, target, preds):
     if loss_params is None:
         loss_params = {}
     try:
+        # actual for regression and classification metrics that requires all classes probabilities
         metric_value = loss_function(target, preds, **loss_params)
     except ValueError:
         try:
+            # transform class probabilities to 1st class probability, actual for binary auc_roc-like metrics
             metric_value = loss_function(target, preds[:, 1], **loss_params)
         except ValueError:
+            # transform class probabilities to assigned class, actual for accuracy-like metrics
             metric_value = loss_function(target, np.argmax(preds, axis=1), **loss_params)
 
     return metric_value

--- a/test/unit/pipelines/test_pipeline_tuning.py
+++ b/test/unit/pipelines/test_pipeline_tuning.py
@@ -15,7 +15,7 @@ from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.tuning.search_space import SearchSpace
 from fedot.core.pipelines.tuning.sequential import SequentialTuner
-from fedot.core.pipelines.tuning.tuner_interface import _greater_is_better
+from fedot.core.pipelines.tuning.tuner_interface import _greater_is_better, _calculate_loss_function
 from fedot.core.pipelines.tuning.unified import PipelineTuner
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
@@ -376,3 +376,37 @@ def test_greater_is_better():
     assert _greater_is_better(target, custom_maximized_metrics, None, data_type)
     assert not _greater_is_better(target, mse, None, data_type)
     assert not _greater_is_better(target, custom_minimized_metrics, None, data_type)
+
+
+def test_calculate_loss_function():
+    """ Tests _calculate_loss_function correctness on quality metrics"""
+    target = np.array([1, 0, 1, 0, 1])
+    multi_target = np.array([2, 0, 1, 0, 1])
+    regr_target = np.array([0.2, 0.1, 1, 0.3, 1.7])
+    pred_clear = np.array([1, 0, 1, 0, 0])
+    pred_prob = np.array([[0.2, 0.8],
+                          [0.7, 0.3],
+                          [0.4, 0.6],
+                          [0.51, 0.49],
+                          [0.51, 0.49]])
+    multi_pred_clear = np.array([2, 0, 1, 0, 2])
+    multi_pred_prob = np.array([[0.2, 0.3, 0.5],
+                                [0.6, 0.3, 0.1],
+                                [0.3, 0.4, 0.3],
+                                [0.5, 0.4, 0.1],
+                                [0.1, 0.4, 0.5]])
+    regr_pred = np.array([0.23, 0.15, 1.2, 0.4, 1.16])
+
+    assert _calculate_loss_function(acc, None, target, pred_prob) == 0.8
+    assert _calculate_loss_function(acc, None, target, pred_clear) == 0.8
+    assert np.allclose(a=_calculate_loss_function(roc, None, target, pred_prob),
+                       b=7 / 12,
+                       rtol=1e-9)
+
+    assert _calculate_loss_function(acc, None, multi_target, multi_pred_prob) == 0.8
+    assert _calculate_loss_function(acc, None, multi_target, multi_pred_clear) == 0.8
+    assert np.allclose(a=_calculate_loss_function(roc, {'multi_class': 'ovo'}, multi_target, multi_pred_prob),
+                       b=11 / 12,
+                       rtol=1e-9)
+
+    assert _calculate_loss_function(mse, None, regr_target, regr_pred) == 0.069

--- a/test/unit/pipelines/test_pipeline_tuning.py
+++ b/test/unit/pipelines/test_pipeline_tuning.py
@@ -150,6 +150,7 @@ def test_pipeline_tuner_regression_correct(data_fixture, request):
             tuned_pipeline = pipeline_tuner.tune_pipeline(input_data=train_data,
                                                           loss_function=mse,
                                                           loss_params={'squared': False})
+            assert pipeline_tuner.obtained_metric is not None
     is_tuning_finished = True
 
     assert is_tuning_finished
@@ -175,6 +176,7 @@ def test_pipeline_tuner_classification_correct(data_fixture, request):
                                            algo=tpe.suggest)
             tuned_pipeline = pipeline_tuner.tune_pipeline(input_data=train_data,
                                                           loss_function=roc)
+            assert pipeline_tuner.obtained_metric is not None
     is_tuning_finished = True
 
     assert is_tuning_finished
@@ -202,6 +204,7 @@ def test_sequential_tuner_regression_correct(data_fixture, request):
             tuned_pipeline = sequential_tuner.tune_pipeline(input_data=train_data,
                                                             loss_function=mse,
                                                             loss_params={'squared': False})
+            assert sequential_tuner.obtained_metric is not None
     is_tuning_finished = True
 
     assert is_tuning_finished
@@ -227,6 +230,7 @@ def test_sequential_tuner_classification_correct(data_fixture, request):
                                                algo=tpe.suggest)
             tuned_pipeline = sequential_tuner.tune_pipeline(input_data=train_data,
                                                             loss_function=roc)
+            assert sequential_tuner.obtained_metric is not None
     is_tuning_finished = True
 
     assert is_tuning_finished
@@ -253,6 +257,7 @@ def test_certain_node_tuning_regression_correct(data_fixture, request):
             tuned_pipeline = sequential_tuner.tune_node(input_data=train_data,
                                                         node_index=0,
                                                         loss_function=mse)
+            assert sequential_tuner.obtained_metric is not None
     is_tuning_finished = True
 
     assert is_tuning_finished
@@ -279,6 +284,7 @@ def test_certain_node_tuning_classification_correct(data_fixture, request):
             tuned_pipeline = sequential_tuner.tune_node(input_data=train_data,
                                                         node_index=0,
                                                         loss_function=roc)
+            assert sequential_tuner.obtained_metric is not None
     is_tuning_finished = True
 
     assert is_tuning_finished

--- a/test/unit/pipelines/test_pipeline_tuning.py
+++ b/test/unit/pipelines/test_pipeline_tuning.py
@@ -400,7 +400,7 @@ def test_calculate_loss_function():
     assert _calculate_loss_function(acc, None, target, pred_prob) == 0.8
     assert _calculate_loss_function(acc, None, target, pred_clear) == 0.8
     assert np.allclose(a=_calculate_loss_function(roc, None, target, pred_prob),
-                       b=7 / 12,
+                       b=11 / 12,
                        rtol=1e-9)
 
     assert _calculate_loss_function(acc, None, multi_target, multi_pred_prob) == 0.8


### PR DESCRIPTION
PipelineTuner is not able to optimize metrics that have formats that are different from to return of cv_tabular_predictions. Thus it is needed to operate cases when metrics required another format.
Examples: auc for binary classification, accuracy