### PR TITLE
Fixed required pandas version for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scikit-optimize>=0.7.4
-pandas>=1.1.0,<1.3.0; python_version < '3.8'
+pandas>=1.1.0,<1.3.0; python_version <= '3.8'
 pandas>=1.3.0; python_version >='3.9'
 statsmodels>=0.12.0
 dataclasses==0.7; python_version < '3.7'


### PR DESCRIPTION
There was a gap in requirements that left "pandas" version for python 3.8 unspecified.