### PR TITLE
Hotfix of PermissionError for logger

### DIFF
--- a/fedot/core/log.py
+++ b/fedot/core/log.py
@@ -33,6 +33,8 @@ class SingletonMeta(type):
 
 class LogManager(metaclass=SingletonMeta):
     __logger_dict = {}
+    # stores the flag of error notification for each log file (e.g. permission error).
+    __errors_for_log_files = {}
 
     def __init__(self):
         pass
@@ -56,7 +58,12 @@ class LogManager(metaclass=SingletonMeta):
             file_handler.setLevel(logging.DEBUG)
             file_handler.setFormatter(formatter)
             self.__logger_dict[logger_name].addHandler(file_handler)
-        except PermissionError:
+            self.__errors_for_log_files[log_file] = False
+        except PermissionError as ex:
+            if (log_file not in self.__errors_for_log_files or
+                    not self.__errors_for_log_files[log_file]):
+                self.__errors_for_log_files[log_file] = True
+                print(f'Logger problem: Can not log to {log_file} because of {ex}')
             # if log_file is unavailable
             pass
         self.__logger_dict[logger_name].setLevel(logging.DEBUG)

--- a/fedot/core/log.py
+++ b/fedot/core/log.py
@@ -60,12 +60,12 @@ class LogManager(metaclass=SingletonMeta):
             self.__logger_dict[logger_name].addHandler(file_handler)
             self.__errors_for_log_files[log_file] = False
         except PermissionError as ex:
-            if (log_file not in self.__errors_for_log_files or
-                    not self.__errors_for_log_files[log_file]):
+            # if log_file is unavailable
+            if not self.__errors_for_log_files.get(log_file, False):
                 self.__errors_for_log_files[log_file] = True
                 print(f'Logger problem: Can not log to {log_file} because of {ex}')
-            # if log_file is unavailable
-            pass
+        else:
+            self.__errors_for_log_files[log_file] = False
         self.__logger_dict[logger_name].setLevel(logging.DEBUG)
         self.__logger_dict[logger_name].addHandler(console_handler)
 

--- a/fedot/core/log.py
+++ b/fedot/core/log.py
@@ -49,12 +49,17 @@ class LogManager(metaclass=SingletonMeta):
 
     def _setup_default_logger(self, log_file, logger_name):
         formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        file_handler = RotatingFileHandler(log_file)
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(formatter)
         console_handler = logging.StreamHandler(sys.stdout)
+
+        try:
+            file_handler = RotatingFileHandler(log_file)
+            file_handler.setLevel(logging.DEBUG)
+            file_handler.setFormatter(formatter)
+            self.__logger_dict[logger_name].addHandler(file_handler)
+        except PermissionError:
+            # if log_file is unavailable
+            pass
         self.__logger_dict[logger_name].setLevel(logging.DEBUG)
-        self.__logger_dict[logger_name].addHandler(file_handler)
         self.__logger_dict[logger_name].addHandler(console_handler)
 
     def _setup_logger_from_json_file(self, config_file):

--- a/fedot/core/log.py
+++ b/fedot/core/log.py
@@ -58,7 +58,6 @@ class LogManager(metaclass=SingletonMeta):
             file_handler.setLevel(logging.DEBUG)
             file_handler.setFormatter(formatter)
             self.__logger_dict[logger_name].addHandler(file_handler)
-            self.__errors_for_log_files[log_file] = False
         except PermissionError as ex:
             # if log_file is unavailable
             if not self.__errors_for_log_files.get(log_file, False):

--- a/other_requirements/extra.txt
+++ b/other_requirements/extra.txt
@@ -11,3 +11,6 @@ Pillow >= 8.2.*
 # Texts
 gensim >= 4.1.2
 nltk >= 3.5
+
+# Misc
+protobuf~=3.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ joblib >= 0.17.*
 requests >= 2.*
 tqdm
 typing >= 3.7.*
+protobuf~=3.19.0
 
 # Tests
 pytest >= 6.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ joblib >= 0.17.*
 requests >= 2.*
 tqdm
 typing >= 3.7.*
-protobuf~=3.19.0
 
 # Tests
 pytest >= 6.2.*


### PR DESCRIPTION
In existing implementation, if it is forbidden to edit /tmp/log.txt, then logger raises the exception after each usage.

The new code catches the PermissionError and disables in-file logger.