### PR TITLE
Leaderboard added to OptHistory

### DIFF
--- a/cases/credit_scoring/credit_scoring_problem.py
+++ b/cases/credit_scoring/credit_scoring_problem.py
@@ -36,6 +36,9 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
     predict = automl.predict(test_file_path)
     metrics = automl.get_metrics()
 
+    if automl.history:
+        automl.history.print_leaderboard()
+
     if is_visualise:
         automl.current_pipeline.show()
 

--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -1,16 +1,16 @@
-from typing import Any, Optional, Union, Sequence
+from typing import Any, Optional, Sequence, Union
 
 from fedot.api.main import Fedot
 from fedot.core.composer.gp_composer.specific_operators import boosting_mutation, parameter_change_mutation
 from fedot.core.dag.graph import Graph
 from fedot.core.log import Log
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
+from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation
+from fedot.core.optimisers.objective import Objective, ObjectiveFunction
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.optimisers.timer import OptimisationTimer
 from fedot.core.utils import fedot_project_root
-from fedot.core.optimisers.objective import Objective, ObjectiveFunction
 
 
 class RandomMutationSearchOptimizer(GraphOptimiser):
@@ -39,7 +39,7 @@ class RandomMutationSearchOptimizer(GraphOptimiser):
         evaluator = dispatcher.dispatch(objective)
 
         num_iter = 0
-        best = Individual(self.initial_graph)
+        best = Individual(self.initial_graphs)
         evaluator([best])
 
         with timer as t:

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
-from typing import Any, List, Optional, Union, Tuple, Dict
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from networkx import set_node_attributes, graph_edit_distance
+from networkx import graph_edit_distance, set_node_attributes
 
 from fedot.core.dag.graph_node import GraphNode
 from fedot.core.pipelines.convert import graph_structure_as_nx_graph
@@ -185,6 +185,12 @@ class GraphOperator:
             'length': self._graph.length,
             'nodes': self._graph.nodes,
         })
+
+    @property
+    def descriptive_id(self) -> str:
+        root_list = ensure_wrapped_in_sequence(self.root_node())
+        full_desc_id = ''.join([r.descriptive_id for r in root_list])
+        return full_desc_id
 
     def graph_depth(self) -> int:
         if not self._graph.nodes:

--- a/fedot/core/optimisers/fitness/fitness.py
+++ b/fedot/core/optimisers/fitness/fitness.py
@@ -144,10 +144,8 @@ class SingleObjFitness(Fitness):
         return is_metric_worse(self._values, other._values)  # lexicographic comparison
 
     def __str__(self) -> str:
-        if len(self._values) == 1:
-            return str(self._values[0])
-        else:
-            return str(self._values)
+        # For single objective return only the primary value
+        return str(round(self.value, 4))
 
 
 def null_fitness() -> SingleObjFitness:

--- a/fedot/core/optimisers/fitness/multi_objective_fitness.py
+++ b/fedot/core/optimisers/fitness/multi_objective_fitness.py
@@ -110,6 +110,9 @@ class MultiObjFitness(Fitness):
                 self.valid and other.valid and
                 self.allclose(self.wvalues, other.wvalues))
 
+    def __str__(self):
+        return str(tuple(round(wval, 4) for wval in self.wvalues))
+
     def _check_length(self, values, weights=None):
         if weights is None:
             weights = self.weights

--- a/fedot/core/optimisers/generation_keeper.py
+++ b/fedot/core/optimisers/generation_keeper.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Sequence, Type, Iterable, Dict
+from typing import Dict, Iterable, Sequence, Type
 
 import numpy as np
 from deap.tools import HallOfFame, ParetoFront
@@ -7,8 +7,8 @@ from deap.tools import HallOfFame, ParetoFront
 from fedot.core.optimisers.fitness import is_metric_worse
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
-from fedot.core.repository.quality_metrics_repository import MetricsEnum, QualityMetricsEnum, ComplexityMetricsEnum
 from fedot.core.optimisers.objective.objective import Objective
+from fedot.core.repository.quality_metrics_repository import ComplexityMetricsEnum, MetricsEnum, QualityMetricsEnum
 
 
 class ImprovementWatcher(ABC):
@@ -57,7 +57,7 @@ class GenerationKeeper(ImprovementWatcher):
                  objective: Objective,
                  keep_n_best: int = 1,
                  initial_generation: PopulationT = None):
-        self._generation_num = -1  # -1 means state before initial generation is added
+        self._generation_num = 0  # 0 means state before initial generation is added
         self._stagnation_counter = 0  # Initialized in non-stagnated state
         self._metrics_improvement = {metric_id: False for metric_id in objective.metrics}
         self.archive = ParetoFront() if objective.is_multi_objective else HallOfFame(maxsize=keep_n_best)

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -185,7 +185,8 @@ class EvoGraphOptimiser(GraphOptimiser):
 
     def assign_positional_ids(self, pop: PopulationT):
         for ind_id, ind in enumerate(pop):
-            ind.positional_id = f'g{self.generations.generation_num}-i{ind_id}'
+            ind.pop_num = self.generations.generation_num
+            ind.ind_num = ind_id
 
     def optimise(self, objective: ObjectiveFunction,
                  show_progress: bool = True) -> Union[OptGraph, List[OptGraph]]:

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -1,11 +1,13 @@
 from copy import deepcopy
 from functools import partial
-from typing import Any, Optional, Union, List, Iterable, Sequence
+from typing import Any, Iterable, List, Optional, Sequence, Union
 
 from tqdm import tqdm
 
 from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.log import Log
+from fedot.core.optimisers.generation_keeper import GenerationKeeper
+from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.gp_operators import (
     clean_operators_history,
     random_graph
@@ -13,22 +15,21 @@ from fedot.core.optimisers.gp_comp.gp_operators import (
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.initial_population_builder import InitialPopulationBuilder
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, crossover
-from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum, inheritance
-from fedot.core.optimisers.generation_keeper import GenerationKeeper
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
+from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum, regularized_population
+from fedot.core.optimisers.gp_comp.operators.selection import SelectionTypesEnum, crossover_parents_selection, selection
 from fedot.core.optimisers.gp_comp.parameters.graph_depth import AdaptiveGraphDepth
 from fedot.core.optimisers.gp_comp.parameters.operators_prob import init_adaptive_operators_prob
 from fedot.core.optimisers.gp_comp.parameters.population_size import PopulationSize, init_adaptive_pop_size
-from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum, regularized_population
-from fedot.core.optimisers.gp_comp.operators.selection import SelectionTypesEnum, selection, crossover_parents_selection
-from fedot.core.pipelines.pipeline import Pipeline
-from fedot.core.utilities.grouped_condition import GroupedCondition
 from fedot.core.optimisers.graph import OptGraph
+from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction
+from fedot.core.optimisers.objective.objective import Objective
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.optimisers.timer import OptimisationTimer
-from fedot.core.optimisers.objective import Objective, ObjectiveFunction, GraphFunction
+from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.utilities.grouped_condition import GroupedCondition
 
 
 class GPGraphOptimiserParameters(GraphOptimiserParameters):
@@ -112,8 +113,7 @@ class EvoGraphOptimiser(GraphOptimiser):
         # stopping_after_n_generation may be None, so use some obvious max number
         max_stagnation_length = parameters.stopping_after_n_generation or requirements.num_of_generations
         self.stop_optimisation = \
-            GroupedCondition(self.log) \
-            .add_condition(
+            GroupedCondition(self.log).add_condition(
                 lambda: self.timer.is_time_limit_reached(self.generations.generation_num),
                 'Optimisation stopped: Time limit is reached'
             ).add_condition(
@@ -146,7 +146,7 @@ class EvoGraphOptimiser(GraphOptimiser):
 
     def _init_population(self, pop_size: int, max_depth: int) -> PopulationT:
         builder = InitialPopulationBuilder(self.graph_generation_params, self.log)
-        if not self.initial_graph:
+        if not self.initial_graphs:
             random_graph_sampler = partial(random_graph, self.graph_generation_params, self.requirements, max_depth)
             builder.with_custom_sampler(random_graph_sampler)
         else:
@@ -156,12 +156,13 @@ class EvoGraphOptimiser(GraphOptimiser):
             def mutate_operator(ind: Individual):
                 return self._mutate(ind, max_depth, custom_requirements=initial_req)
 
-            initial_graphs = [self.graph_generation_params.adapter.adapt(g) for g in self.initial_graph]
+            initial_graphs = [self.graph_generation_params.adapter.adapt(g) for g in self.initial_graphs]
             builder.with_initial_graphs(initial_graphs).with_mutation(mutate_operator)
 
         return builder.build(pop_size)
 
     def _next_population(self, next_population: PopulationT):
+        self.assign_positional_ids(next_population)
         self.generations.append(next_population)
         self._optimisation_callback(next_population, self.generations)
         clean_operators_history(next_population)
@@ -182,6 +183,10 @@ class EvoGraphOptimiser(GraphOptimiser):
         # Redirect callback to evaluation dispatcher
         self.eval_dispatcher.set_evaluation_callback(callback)
 
+    def assign_positional_ids(self, pop: PopulationT):
+        for ind_id, ind in enumerate(pop):
+            ind.positional_id = f'g{self.generations.generation_num}-i{ind_id}'
+
     def optimise(self, objective: ObjectiveFunction,
                  show_progress: bool = True) -> Union[OptGraph, List[OptGraph]]:
 
@@ -191,6 +196,12 @@ class EvoGraphOptimiser(GraphOptimiser):
         with self.timer, tqdm(total=self.requirements.num_of_generations,
                               desc='Generations', unit='gen', initial=1,
                               disable=not show_progress or self.log.verbosity_level == -1):
+
+            # Adding of initial assumptions to history as zero generation
+            if self.initial_graphs:
+                initial_individuals = [Individual(self.graph_generation_params.adapter.adapt(g)) for g in
+                                       self.initial_graphs]
+                self._next_population(evaluator(initial_individuals))
 
             pop_size = self._pop_size.initial
             self._next_population(evaluator(self._init_population(pop_size, self._graph_depth.initial)))

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -117,7 +117,7 @@ class EvoGraphOptimiser(GraphOptimiser):
                 lambda: self.timer.is_time_limit_reached(self.generations.generation_num),
                 'Optimisation stopped: Time limit is reached'
             ).add_condition(
-                lambda: self.generations.generation_num >= requirements.num_of_generations,
+                lambda: self.generations.generation_num >= requirements.num_of_generations + 1,
                 'Optimisation stopped: Max number of generations reached'
             ).add_condition(
                 lambda: self.generations.stagnation_duration >= max_stagnation_length,

--- a/fedot/core/optimisers/gp_comp/individual.py
+++ b/fedot/core/optimisers/gp_comp/individual.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fedot.core.optimisers.fitness.fitness import Fitness, null_fitness
@@ -17,6 +17,7 @@ class Individual:
         self.metadata: Dict[str, Any] = metadata or {}
         self.fitness: Fitness = null_fitness()
         self.uid = str(uuid4())
+        self.positional_id = ''
 
     def __eq__(self, other: 'Individual'):
         return self.uid == other.uid

--- a/fedot/core/optimisers/gp_comp/individual.py
+++ b/fedot/core/optimisers/gp_comp/individual.py
@@ -17,7 +17,16 @@ class Individual:
         self.metadata: Dict[str, Any] = metadata or {}
         self.fitness: Fitness = null_fitness()
         self.uid = str(uuid4())
-        self.positional_id = ''
+        self.pop_num = None
+        self.ind_num = None
+
+    @property
+    def positional_id(self) -> str:
+        """
+        Identified for location of individual in history of population-based optimisation
+        :return: string representation of population number and number of individual in population
+        """
+        return f'g{self.pop_num}-i{self.ind_num}'
 
     def __eq__(self, other: 'Individual'):
         return self.uid == other.uid

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -175,6 +175,10 @@ class OptGraph:
         return roots
 
     @property
+    def descriptive_id(self):
+        return self.operator.descriptive_id
+
+    @property
     def length(self) -> int:
         return len(self.nodes)
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -252,18 +252,18 @@ class OptHistory:
         separator = ' | '
         print(separator.join(['Position', 'Fitness', 'Generation', 'Pipeline']))
         for ind_num, individual in enumerate(top_individuals):
-            fitness = round(individual.fitness, 4)
+            fitness = str(individual.fitness.values)
             print(separator.join([f'{ind_num:>3}, '
-                                  f'{fitness:>4}, '
+                                  f'{fitness:>6}, '
                                   f'{individual.positional_id:>8}, '
                                   f'{individual.graph.descriptive_id}']))
 
         # add info about initial assumptions (stored as zero generation)
         for i, individual in enumerate(self.individuals[0]):
             ind = f'I{i}'
-            fitness = round(individual.fitness, 4)
+            fitness = str(individual.fitness.values)
             print(separator.join([f'{ind:>3}'
-                                  f'{fitness:>4}',
+                                  f'{fitness:>6}',
                                   f'-',
                                   f'{individual.graph.descriptive_id}']))
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -237,7 +237,7 @@ class OptHistory:
         Prints ordered description of best solutions in history
         :param top_n: number of solutions to print
         """
-        all_individuals = list(itertools.chain(*self.individuals))
+        all_individuals = itertools.chain(*self.individuals)
 
         sorted_individuals_by_position = \
             sorted(all_individuals,
@@ -252,18 +252,16 @@ class OptHistory:
         separator = ' | '
         print(separator.join(['Position', 'Fitness', 'Generation', 'Pipeline']))
         for ind_num, individual in enumerate(top_individuals):
-            fitness = str(individual.fitness)
             print(separator.join([f'{ind_num:>3}, '
-                                  f'{fitness:>8}, '
+                                  f'{str(individual.fitness):>8}, '
                                   f'{individual.positional_id:>8}, '
                                   f'{individual.graph.descriptive_id}']))
 
         # add info about initial assumptions (stored as zero generation)
         for i, individual in enumerate(self.individuals[0]):
             ind = f'I{i}'
-            fitness = str(individual.fitness)
             print(separator.join([f'{ind:>3}'
-                                  f'{fitness:>8}',
+                                  f'{str(individual.fitness):>8}',
                                   f'-',
                                   f'{individual.graph.descriptive_id}']))
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -252,18 +252,18 @@ class OptHistory:
         separator = ' | '
         print(separator.join(['Position', 'Fitness', 'Generation', 'Pipeline']))
         for ind_num, individual in enumerate(top_individuals):
-            fitness = str(individual.fitness.values)
+            fitness = str(individual.fitness)
             print(separator.join([f'{ind_num:>3}, '
-                                  f'{fitness:>6}, '
+                                  f'{fitness:>8}, '
                                   f'{individual.positional_id:>8}, '
                                   f'{individual.graph.descriptive_id}']))
 
         # add info about initial assumptions (stored as zero generation)
         for i, individual in enumerate(self.individuals[0]):
             ind = f'I{i}'
-            fitness = str(individual.fitness.values)
+            fitness = str(individual.fitness)
             print(separator.join([f'{ind:>3}'
-                                  f'{fitness:>6}',
+                                  f'{fitness:>8}',
                                   f'-',
                                   f'{individual.graph.descriptive_id}']))
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -5,19 +5,18 @@ import os
 import shutil
 import warnings
 from copy import deepcopy
-from typing import Any, List, Optional, Union, Sequence
+from typing import Any, List, Optional, Sequence, Union
 
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.generation_keeper import GenerationKeeper
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
-from fedot.core.serializers import Serializer
 from fedot.core.optimisers.objective import Objective
-from fedot.core.visualisation.opt_viz import PipelineEvolutionVisualiser, PlotTypesEnum
-
 from fedot.core.optimisers.utils.population_utils import get_metric_position
 from fedot.core.repository.quality_metrics_repository import QualityMetricsEnum
+from fedot.core.serializers import Serializer
 from fedot.core.utils import default_fedot_data_dir
+from fedot.core.visualisation.opt_viz import PipelineEvolutionVisualiser, PlotTypesEnum
 
 
 class OptHistory:
@@ -112,7 +111,8 @@ class OptHistory:
             shutil.rmtree(path, ignore_errors=True)
             os.mkdir(path)
 
-    def show(self, plot_type: Optional[Union[PlotTypesEnum, str]] = PlotTypesEnum.fitness_box, save_path: Optional[str] = None,
+    def show(self, plot_type: Optional[Union[PlotTypesEnum, str]] = PlotTypesEnum.fitness_box,
+             save_path: Optional[str] = None,
              pct_best: Optional[float] = None, show_fitness: Optional[bool] = True):
         """ Visualizes fitness values or operations used across generations.
 
@@ -231,6 +231,41 @@ class OptHistory:
             else:
                 return os.path.join(default_fedot_data_dir(), self.save_folder)
         return None
+
+    def print_leaderboard(self, top_n: int = 10):
+        """
+        Prints ordered description of best solutions in history
+        :param top_n: number of solutions to print
+        """
+        all_individuals = list(itertools.chain(*self.individuals))
+
+        sorted_individuals_by_position = \
+            sorted(all_individuals,
+                   key=lambda ind: ind.positional_id)
+
+        sorted_individuals = sorted(sorted_individuals_by_position,
+                                    key=lambda ind: ind.fitness, reverse=True)
+        top_individuals = \
+            [list(ind)[0] for _, ind in itertools.groupby(sorted_individuals,
+                                                          key=lambda ind: ind.graph.descriptive_id)][:top_n]
+
+        separator = ' | '
+        print(separator.join(['Position', 'Fitness', 'Generation', 'Pipeline']))
+        for ind_num, individual in enumerate(top_individuals):
+            fitness = round(individual.fitness, 4)
+            print(separator.join([f'{ind_num:>3}, '
+                                  f'{fitness:>4}, '
+                                  f'{individual.positional_id:>8}, '
+                                  f'{individual.graph.descriptive_id}']))
+
+        # add info about initial assumptions (stored as zero generation)
+        for i, individual in enumerate(self.individuals[0]):
+            ind = f'I{i}'
+            fitness = round(individual.fitness, 4)
+            print(separator.join([f'{ind:>3}'
+                                  f'{fitness:>4}',
+                                  f'-',
+                                  f'{individual.graph.descriptive_id}']))
 
 
 def log_to_history(history: OptHistory, population: PopulationT, generations: GenerationKeeper):

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -245,9 +245,7 @@ class OptHistory:
 
         sorted_individuals = sorted(sorted_individuals_by_position,
                                     key=lambda ind: ind.fitness, reverse=True)
-        top_individuals = \
-            [list(ind)[0] for _, ind in itertools.groupby(sorted_individuals,
-                                                          key=lambda ind: ind.graph.descriptive_id)][:top_n]
+        top_individuals = list({ind.graph.descriptive_id: ind for ind in sorted_individuals}.values())[:top_n]
 
         separator = ' | '
         print(separator.join(['Position', 'Fitness', 'Generation', 'Pipeline']))

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import (Any, Callable, List, Optional, Union, Sequence)
+from typing import (Any, Callable, List, Optional, Sequence, Union)
 
 from fedot.core.composer.advisor import DefaultChangeAdvisor
 from fedot.core.dag.graph import Graph
@@ -77,7 +77,6 @@ class GraphOptimiser:
                  graph_generation_params: Optional[GraphGenerationParams] = None,
                  parameters: Optional[GraphOptimiserParameters] = None,
                  log: Optional[Log] = None):
-
         self.log = log or default_log(self.__class__.__name__)
 
         self._objective = objective
@@ -85,7 +84,7 @@ class GraphOptimiser:
         self.graph_generation_params = graph_generation_params or GraphGenerationParams()
         self.parameters = parameters or GraphOptimiserParameters()
 
-        self.initial_graph = ensure_wrapped_in_sequence(initial_graph)
+        self.initial_graphs = ensure_wrapped_in_sequence(initial_graph)
 
         self._optimisation_callback: OptimisationCallback = do_nothing_callback
 

--- a/fedot/core/serializers/coders/opt_history_serialization.py
+++ b/fedot/core/serializers/coders/opt_history_serialization.py
@@ -1,6 +1,6 @@
 import operator
 from functools import reduce
-from typing import TYPE_CHECKING, Any, Dict, List, Type
+from typing import Any, Dict, List, TYPE_CHECKING, Type
 
 from fedot.core.optimisers.opt_history import OptHistory
 
@@ -12,13 +12,14 @@ from . import any_from_json
 
 def _convert_parent_individuals(individuals: List[List['Individual']]) -> List[List['Individual']]:
     # get all individuals from all generations
-    all_individuals = reduce(operator.concat, individuals)
-    lookup_dict = {ind.uid: ind for ind in all_individuals}
+    if individuals:
+        all_individuals = reduce(operator.concat, individuals)
+        lookup_dict = {ind.uid: ind for ind in all_individuals}
 
-    for ind in all_individuals:
-        for parent_op in ind.parent_operators:
-            for parent_ind_idx, parent_ind_uid in enumerate(parent_op.parent_individuals):
-                parent_op.parent_individuals[parent_ind_idx] = lookup_dict.get(parent_ind_uid, None)
+        for ind in all_individuals:
+            for parent_op in ind.parent_operators:
+                for parent_ind_idx, parent_ind_uid in enumerate(parent_op.parent_individuals):
+                    parent_op.parent_individuals[parent_ind_idx] = lookup_dict.get(parent_ind_uid, None)
     return individuals
 
 

--- a/test/unit/optimizer/test_generation_keeper.py
+++ b/test/unit/optimizer/test_generation_keeper.py
@@ -1,14 +1,13 @@
 from typing import Sequence
 
+from fedot.core.optimisers.fitness import Fitness, MultiObjFitness, null_fitness
 from fedot.core.optimisers.generation_keeper import GenerationKeeper
 from fedot.core.optimisers.gp_comp.individual import Individual
-
-from fedot.core.optimisers.fitness import Fitness, MultiObjFitness, null_fitness
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.graph import OptGraph, OptNode
-from fedot.core.repository.quality_metrics_repository import RegressionMetricsEnum, ComplexityMetricsEnum
-from fedot.core.utils import DEFAULT_PARAMS_STUB
 from fedot.core.optimisers.objective.objective import Objective
+from fedot.core.repository.quality_metrics_repository import ComplexityMetricsEnum, RegressionMetricsEnum
+from fedot.core.utils import DEFAULT_PARAMS_STUB
 
 
 def create_individual(fitness: Fitness = None) -> Individual:
@@ -48,13 +47,13 @@ def test_archive_no_improvement():
     assert archive.stagnation_duration == 0
     assert archive.is_any_improved
     assert archive.is_quality_improved and archive.is_complexity_improved
-    assert archive.generation_num == 0
+    assert archive.generation_num == 1
 
     archive.append(population1())
     assert archive.stagnation_duration == 1
     assert not archive.is_any_improved
     assert not archive.is_quality_improved and not archive.is_complexity_improved
-    assert archive.generation_num == 1
+    assert archive.generation_num == 2
 
 
 def test_archive_multiobj_one_improvement():
@@ -68,7 +67,7 @@ def test_archive_multiobj_one_improvement():
 
     assert archive.stagnation_duration == 0
     assert archive.is_any_improved
-    assert archive.generation_num == 1
+    assert archive.generation_num == 2
     # plus one non-dominated individual
     # minus one strongly dominated individual (substituted by better one)
     assert len(archive.best_individuals) == previous_size + 1

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -64,6 +64,13 @@ def test_prepare_for_visualisation(capsys):
     assert 'n_lda_default_params' in captured.out
     assert 'Position' in captured.out
 
+    dumped_history = history.save()
+    loaded_history = OptHistory.load(dumped_history)
+    loaded_history.print_leaderboard()
+    captured = capsys.readouterr()
+    assert 'n_lda_default_params' in captured.out
+    assert 'Position' in captured.out
+
 
 def test_all_historical_quality():
     pop_size = 4

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -52,12 +52,17 @@ def test_individual_graph_type_is_optgraph():
             assert type(history.individuals[gen][ind].graph) == OptGraph
 
 
-def test_prepare_for_visualisation():
+def test_prepare_for_visualisation(capsys):
     generations_quantity = 2
     pop_size = 10
     history = generate_history(generations_quantity, pop_size)
     assert len(history.historical_pipelines) == pop_size * generations_quantity
     assert len(history.all_historical_fitness) == pop_size * generations_quantity
+
+    history.print_leaderboard()
+    captured = capsys.readouterr()
+    assert 'n_lda_default_params' in captured.out
+    assert 'Position' in captured.out
 
 
 def test_all_historical_quality():


### PR DESCRIPTION
In this PR, the H2O-like leaderboard is added. How to use:

`history.print_leaderboard()`

It consists of:
1) TOP 10 graphs obtained by optimiser
2) Initial assumptions

The main aim is to demonstrate for user how the optimised solution differs from initial one.

Example:
![image](https://user-images.githubusercontent.com/5711814/170886503-b1e53a54-5ffd-4725-b45f-91fafd3b5f5a.png)
