### PR TITLE
Generalize Evaluation subsystem and Objective interface

### DIFF
--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -5,13 +5,12 @@ from fedot.core.composer.gp_composer.specific_operators import boosting_mutation
 from fedot.core.dag.graph import Graph
 from fedot.core.log import Log
 from fedot.core.optimisers.gp_comp.individual import Individual
-from fedot.core.optimisers.gp_comp.operators.evaluation import EvaluationDispatcher
+from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.optimisers.timer import OptimisationTimer
 from fedot.core.utils import fedot_project_root
-from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.objective.objective_eval import ObjectiveEvaluate
+from fedot.core.optimisers.objective import Objective, ObjectiveFunction
 
 
 class RandomMutationSearchOptimizer(GraphOptimiser):
@@ -33,11 +32,11 @@ class RandomMutationSearchOptimizer(GraphOptimiser):
                              MutationTypesEnum.single_drop,
                              MutationTypesEnum.single_add]
 
-    def optimise(self, objective_evaluator: ObjectiveEvaluate, show_progress: bool = True):
+    def optimise(self, objective: ObjectiveFunction, show_progress: bool = True):
 
         timer = OptimisationTimer(log=self.log, timeout=self.requirements.timeout)
-        evaluator = EvaluationDispatcher(objective_evaluator, self.graph_generation_params.adapter,
-                                         timer=timer, log=self.log, n_jobs=1)
+        dispatcher = MultiprocessingDispatcher(self.graph_generation_params.adapter, timer, log=self.log, n_jobs=1)
+        evaluator = dispatcher.dispatch(objective)
 
         num_iter = 0
         best = Individual(self.initial_graph)

--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -1,11 +1,11 @@
-from typing import Any, Callable, List, Optional, Union, Sequence
+from typing import Any, Optional, Union, Sequence
 
 from fedot.api.main import Fedot
 from fedot.core.composer.gp_composer.specific_operators import boosting_mutation, parameter_change_mutation
 from fedot.core.dag.graph import Graph
 from fedot.core.log import Log
 from fedot.core.optimisers.gp_comp.individual import Individual
-from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
+from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.optimisers.timer import OptimisationTimer

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -9,8 +9,10 @@ from fedot.core.composer.composer import Composer, ComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.log import Log
+from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher, ObjectiveEvaluationDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationStrengthEnum
 from fedot.core.optimisers.graph import OptGraph
+from fedot.core.optimisers.objective import ObjectiveEvaluate, GraphFunction
 from fedot.core.optimisers.objective.data_objective_builder import DataObjectiveBuilder
 from fedot.core.optimisers.opt_history import OptHistory, log_to_history
 from fedot.core.optimisers.optimizer import GraphOptimiser
@@ -73,16 +75,17 @@ class GPComposer(Composer):
                  cache: Optional[OperationsCache] = None):
 
         super().__init__(optimiser, composer_requirements, initial_pipelines, logger)
+        self.composer_requirements = composer_requirements
 
         self.optimiser = optimiser
         self.cache: Optional[OperationsCache] = cache
 
         self._history = OptHistory(self.optimiser.objective, self.optimiser.parameters.history_folder)
-        self.objective_builder = DataObjectiveBuilder(self.optimiser.objective,
-                                                      self.composer_requirements.max_pipeline_fit_time,
-                                                      self.composer_requirements.cv_folds,
-                                                      self.composer_requirements.validation_blocks,
-                                                      self.cache, self.log)
+        self.objective_builder = DataObjectiveBuilder(optimiser.objective,
+                                                      composer_requirements.max_pipeline_fit_time,
+                                                      composer_requirements.cv_folds,
+                                                      composer_requirements.validation_blocks,
+                                                      cache, logger)
 
     def compose_pipeline(self, data: Union[InputData, MultiModalData]) -> Union[Pipeline, List[Pipeline]]:
         self.optimiser.graph_generation_params.advisor.task = data.task
@@ -99,12 +102,21 @@ class GPComposer(Composer):
         # shuffle data if necessary
         data.shuffle()
 
+        # Keep history of optimization
         self._history.clean_results()
         history_callback = partial(log_to_history, self._history)
         self.optimiser.optimisation_callback = history_callback
 
+        # Define objective function
         objective_evaluator = self.objective_builder.build(data)
-        opt_result = self.optimiser.optimise(objective_evaluator)
+        objective_function = objective_evaluator.evaluate
+
+        # Define callback for computing intermediate metrics if needed
+        if self.composer_requirements.collect_intermediate_metric:
+            self.optimiser.set_evaluation_callback(objective_evaluator.evaluate_intermediate_metrics)
+
+        # Finally, run optimization process
+        opt_result = self.optimiser.optimise(objective_function)
 
         best_pipeline = self._convert_opt_results_to_pipeline(opt_result)
         self.log.info('GP composition finished')

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -9,10 +9,8 @@ from fedot.core.composer.composer import Composer, ComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.log import Log
-from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher, ObjectiveEvaluationDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationStrengthEnum
 from fedot.core.optimisers.graph import OptGraph
-from fedot.core.optimisers.objective import ObjectiveEvaluate, GraphFunction
 from fedot.core.optimisers.objective.data_objective_builder import DataObjectiveBuilder
 from fedot.core.optimisers.opt_history import OptHistory, log_to_history
 from fedot.core.optimisers.optimizer import GraphOptimiser

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -105,7 +105,7 @@ class GPComposer(Composer):
         # Keep history of optimization
         self._history.clean_results()
         history_callback = partial(log_to_history, self._history)
-        self.optimiser.optimisation_callback = history_callback
+        self.optimiser.set_optimisation_callback(history_callback)
 
         # Define objective function
         objective_evaluator = self.objective_builder.build(data)

--- a/fedot/core/composer/random_composer.py
+++ b/fedot/core/composer/random_composer.py
@@ -84,13 +84,13 @@ class RandomSearchOptimiser(GraphOptimiser):
         self._iter_num = iter_num
         super().__init__(objective)
 
-    def optimise(self, objective_evaluator: ObjectiveFunction, show_progress: bool = True) -> Pipeline:
+    def optimise(self, objective: ObjectiveFunction, show_progress: bool = True) -> Pipeline:
         best_metric_value = 1000
         best_set = None
         history = []
         for i in range(self._iter_num):
             new_pipeline = self._factory()
-            new_metric_value = objective_evaluator(new_pipeline).value
+            new_metric_value = objective(new_pipeline).value
             new_metric_value = round(new_metric_value, 3)
             if new_metric_value < best_metric_value:
                 best_metric_value = new_metric_value

--- a/fedot/core/composer/random_composer.py
+++ b/fedot/core/composer/random_composer.py
@@ -14,23 +14,21 @@ from fedot.core.pipelines.pipeline import Node, Pipeline
 
 
 class RandomSearchComposer(Composer):
-    def __init__(self, optimiser: 'RandomSearchOptimiser',
-                 composer_requirements: ComposerRequirements,
-                 metrics: Optional[Callable] = None):
+    def __init__(self,
+                 optimiser: 'RandomSearchOptimiser',
+                 composer_requirements: ComposerRequirements):
         super().__init__(optimiser, composer_requirements)
         self.optimiser = optimiser
-        self._metrics = metrics
 
     def compose_pipeline(self, data: InputData) -> Pipeline:
         train_data = data
         test_data = data
 
-        # custom objective evaluator
-        def objective_eval(pipeline: Pipeline) -> Fitness:
+        def prepared_objective(pipeline: Pipeline) -> Fitness:
             pipeline.fit(train_data)
             return self.optimiser.objective(pipeline, reference_data=test_data)
 
-        best_pipeline = self.optimiser.optimise(objective_eval)
+        best_pipeline = self.optimiser.optimise(prepared_objective)
         return best_pipeline
 
 

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -111,13 +111,14 @@ class MultiprocessingDispatcher(ObjectiveEvaluationDispatcher):
         adapted_graph = self._graph_adapter.restore(graph)
 
         ind.fitness = self._objective_eval(adapted_graph)
-        ind.graph = self._graph_adapter.adapt(adapted_graph)
 
         if self._post_eval_callback:
             self._post_eval_callback(adapted_graph)
         if self._cleanup:
             self._cleanup(adapted_graph)
         gc.collect()
+
+        ind.graph = self._graph_adapter.adapt(adapted_graph)
 
         end_time = timeit.default_timer()
         ind.metadata['computation_time_in_seconds'] = end_time - start_time

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional
 from fedot.core.dag.graph import Graph
 from fedot.core.log import Log, default_log
 from fedot.core.optimisers.adapters import BaseOptimizationAdapter
+from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import EvaluationOperator, PopulationT
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -1,6 +1,7 @@
 import gc
 import multiprocessing
 import timeit
+from abc import ABC, abstractmethod
 from contextlib import closing
 from random import choice
 
@@ -9,8 +10,8 @@ from typing import Dict, Optional
 from fedot.core.dag.graph import Graph
 from fedot.core.log import Log, default_log
 from fedot.core.optimisers.adapters import BaseOptimizationAdapter
+from fedot.core.optimisers.gp_comp.operators.operator import EvaluationOperator, PopulationT
 from fedot.core.optimisers.graph import OptGraph
-from fedot.core.optimisers.gp_comp.operators.operator import *
 from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction
 from fedot.core.optimisers.timer import Timer, get_forever_timer
 from fedot.remote.remote_evaluator import RemoteEvaluator

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -165,7 +165,7 @@ class EvoGraphOptimiser(GraphOptimiser):
 
     def _next_population(self, next_population: PopulationT):
         self.generations.append(next_population)
-        self.optimisation_callback(next_population, self.generations)
+        self._optimisation_callback(next_population, self.generations)
         clean_operators_history(next_population)
         self.population = next_population
         self._operators_prob_update()

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -15,7 +15,7 @@ from fedot.core.optimisers.gp_comp.gp_operators import (
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.initial_population_builder import InitialPopulationBuilder
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, crossover
-from fedot.core.optimisers.gp_comp.operators.evaluation import EvaluationDispatcher
+from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher, ObjectiveEvaluationDispatcher
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum, inheritance
 from fedot.core.optimisers.generation_keeper import GenerationKeeper
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation
@@ -30,8 +30,7 @@ from fedot.core.utilities.grouped_condition import GroupedCondition
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.optimisers.timer import OptimisationTimer
-from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.objective.objective_eval import ObjectiveEvaluate
+from fedot.core.optimisers.objective import Objective, ObjectiveFunction, GraphFunction
 
 
 class GPGraphOptimiserParameters(GraphOptimiserParameters):
@@ -106,6 +105,11 @@ class EvoGraphOptimiser(GraphOptimiser):
         self.population = None
         self.generations = GenerationKeeper(self.objective)
         self.timer = OptimisationTimer(timeout=self.requirements.timeout, log=self.log)
+        self.eval_dispatcher = MultiprocessingDispatcher(graph_adapter=graph_generation_params.adapter,
+                                                         timer=self.timer,
+                                                         n_jobs=requirements.n_jobs,
+                                                         graph_cleanup_fn=Pipeline.unfit,
+                                                         log=log)
 
         # stopping_after_n_generation may be None, so use some obvious max number
         max_stagnation_length = parameters.stopping_after_n_generation or requirements.num_of_generations
@@ -159,14 +163,6 @@ class EvoGraphOptimiser(GraphOptimiser):
 
         return builder.build(pop_size)
 
-    def _get_evaluator(self, objective_evaluator: ObjectiveEvaluate) -> EvaluationDispatcher:
-        return EvaluationDispatcher(objective_evaluator,
-                                    graph_adapter=self.graph_generation_params.adapter,
-                                    timer=self.timer,
-                                    n_jobs=self.requirements.n_jobs,
-                                    collect_intermediate_metrics=self.requirements.collect_intermediate_metric,
-                                    log=self.log)
-
     def _next_population(self, next_population: PopulationT):
         self.generations.append(next_population)
         self.optimisation_callback(next_population, self.generations)
@@ -184,10 +180,15 @@ class EvoGraphOptimiser(GraphOptimiser):
             self.requirements.mutation_prob, self.requirements.crossover_prob = \
                 self._operators_prob.next(self.population)
 
-    def optimise(self, objective_evaluator: ObjectiveEvaluate,
+    def set_evaluation_callback(self, callback: Optional[GraphFunction]):
+        # Redirect callback to evaluation dispatcher
+        self.eval_dispatcher.set_evaluation_callback(callback)
+
+    def optimise(self, objective: ObjectiveFunction,
                  show_progress: bool = True) -> Union[OptGraph, List[OptGraph]]:
 
-        evaluator = self._get_evaluator(objective_evaluator)
+        # eval_dispatcher defines how to evaluate objective on the whole population
+        evaluator = self.eval_dispatcher.dispatch(objective)
 
         with self.timer, tqdm(total=self.requirements.num_of_generations,
                               desc='Generations', unit='gen', initial=1,

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -106,7 +106,7 @@ class EvoGraphOptimiser(GraphOptimiser):
         self.eval_dispatcher = MultiprocessingDispatcher(graph_adapter=graph_generation_params.adapter,
                                                          timer=self.timer,
                                                          n_jobs=requirements.n_jobs,
-                                                         graph_cleanup_fn=Pipeline.unfit,
+                                                         graph_cleanup_fn=_unfit_pipeline,
                                                          log=log)
 
         # stopping_after_n_generation may be None, so use some obvious max number
@@ -277,3 +277,8 @@ class EvoGraphOptimiser(GraphOptimiser):
                          crossover_prob=self.requirements.crossover_prob,
                          max_depth=self.max_depth, log=self.log,
                          params=self.graph_generation_params)
+
+
+def _unfit_pipeline(graph: Any):
+    if isinstance(graph, Pipeline):
+        graph.unfit()

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from functools import partial
-from itertools import zip_longest
-from typing import Any, Optional, Union, List, Iterable, Sequence, Tuple
+from typing import Any, Optional, Union, List, Iterable, Sequence
 
 from tqdm import tqdm
 
@@ -9,13 +8,12 @@ from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirem
 from fedot.core.log import Log
 from fedot.core.optimisers.gp_comp.gp_operators import (
     clean_operators_history,
-    num_of_parents_in_crossover,
     random_graph
 )
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.initial_population_builder import InitialPopulationBuilder
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, crossover
-from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher, ObjectiveEvaluationDispatcher
+from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum, inheritance
 from fedot.core.optimisers.generation_keeper import GenerationKeeper
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation

--- a/fedot/core/optimisers/gp_comp/operators/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/operators/evaluation.py
@@ -11,44 +11,76 @@ from fedot.core.log import Log, default_log
 from fedot.core.optimisers.adapters import BaseOptimizationAdapter
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.gp_comp.operators.operator import *
+from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction
 from fedot.core.optimisers.timer import Timer, get_forever_timer
-from fedot.core.optimisers.objective import ObjectiveEvaluate
 from fedot.remote.remote_evaluator import RemoteEvaluator
 
 
-class EvaluationDispatcher(Operator[PopulationT]):
-    """Defines objective-independent details of how evaluation of individuals must be handled.
-    Responsibilities:
-    - Handle evaluation policy (e.g. sequential, parallel, async) and dispatch evaluation.
-    - Delegate Fitness computation to ObjectiveEvaluate for each individual in the population.
-    - Save additional metadata related to evaluation process (e.g. computation time)
+class ObjectiveEvaluationDispatcher(ABC):
+    """Builder for evaluation operator.
+    Takes objective function and decides how to evaluate it over population:
+    - defines implementation-specific evaluation policy (e.g. sequential, parallel, async);
+    - saves additional metadata (e.g. computation time, intermediate metrics values).
     """
+
+    @abstractmethod
+    def dispatch(self, objective: ObjectiveFunction) -> EvaluationOperator:
+        """Return mapped objective function for evaluating population."""
+        raise NotImplementedError()
+
+    def set_evaluation_callback(self, callback: Optional[GraphFunction]):
+        """Set or reset (with None) post-evaluation callback
+        that's called on each graph after its evaluation."""
+        pass
+
+
+class MultiprocessingDispatcher(ObjectiveEvaluationDispatcher):
+    """Evaluates objective function on population using multiprocessing pool
+    and optionally model evaluation cache with RemoteEvaluator.
+
+    Usage: call `dispatch(objective_function)` to get evaluation function.
+
+    :param graph_adapter: adapter for mapping between OptGraph and Graph.
+    :param log: logger to use
+    :param n_jobs: number of jobs for multiprocessing or 1 for no multiprocessing.
+    :param graph_cleanup_fn: function to call after graph evaluation, primarily for memory cleanup.
+    """
+
     def __init__(self,
-                 objective_eval: ObjectiveEvaluate,
                  graph_adapter: BaseOptimizationAdapter,
                  timer: Timer = None,
                  log: Log = None,
                  n_jobs: int = 1,
-                 collect_intermediate_metrics: bool = False):
-        self._objective_eval = objective_eval
+                 graph_cleanup_fn: Optional[GraphFunction] = None):
+        self._objective_eval = None
         self._graph_adapter = graph_adapter
-        self._collect_intermediate_metrics = collect_intermediate_metrics
+        self._cleanup = graph_cleanup_fn
+        self._post_eval_callback = None
 
         self.timer = timer or get_forever_timer()
-        self.logger = log or default_log('Population evaluation')
+        self.logger = log or default_log(self.__class__.__name__)
         self._n_jobs = n_jobs
         self._reset_eval_cache()
 
-    def __call__(self, population: PopulationT) -> PopulationT:
+    def dispatch(self, objective: ObjectiveFunction) -> EvaluationOperator:
+        """Return handler to this object that hides all details
+        and allows only to evaluate population with provided objective."""
+        self._objective_eval = objective
+        return self.evaluate_with_cache
+
+    def set_evaluation_callback(self, callback: Optional[GraphFunction]):
+        self._post_eval_callback = callback
+
+    def evaluate_with_cache(self, population: PopulationT) -> PopulationT:
         reversed_population = list(reversed(population))
         self._remote_compute_cache(reversed_population)
-        evaluated_population = self.evaluate_dispatch(reversed_population)
+        evaluated_population = self.evaluate_population(reversed_population)
         self._reset_eval_cache()
         if not evaluated_population and reversed_population:
             raise AttributeError('Too many fitness evaluation errors. Composing stopped.')
         return evaluated_population
 
-    def evaluate_dispatch(self, individuals: PopulationT) -> PopulationT:
+    def evaluate_population(self, individuals: PopulationT) -> PopulationT:
         n_jobs = determine_n_jobs(self._n_jobs, self.logger)
 
         if n_jobs == 1:
@@ -75,19 +107,19 @@ class EvaluationDispatcher(Operator[PopulationT]):
         graph = self.evaluation_cache.get(ind.uid, ind.graph)
         _restrict_n_jobs_in_nodes(graph)
         adapted_graph = self._graph_adapter.restore(graph)
+
         ind.fitness = self._objective_eval(adapted_graph)
-        if self._collect_intermediate_metrics:
-            self._objective_eval.evaluate_intermediate_metrics(adapted_graph)
-        self._cleanup_memory(adapted_graph)
         ind.graph = self._graph_adapter.adapt(adapted_graph)
+
+        if self._post_eval_callback:
+            self._post_eval_callback(adapted_graph)
+        if self._cleanup:
+            self._cleanup(adapted_graph)
+        gc.collect()
 
         end_time = timeit.default_timer()
         ind.metadata['computation_time_in_seconds'] = end_time - start_time
         return ind if ind.fitness.valid else None
-
-    def _cleanup_memory(self, graph: Graph):
-        self._objective_eval.cleanup(graph)
-        gc.collect()
 
     def _reset_eval_cache(self):
         self.evaluation_cache: Dict[int, Graph] = {}

--- a/fedot/core/optimisers/gp_comp/operators/operator.py
+++ b/fedot/core/optimisers/gp_comp/operators/operator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TypeVar, Generic, Sequence
+from typing import TypeVar, Generic, Sequence, Callable
 
 from fedot.core.optimisers.gp_comp.individual import Individual
 
@@ -23,3 +23,6 @@ class Operator(ABC, Generic[T]):
     @abstractmethod
     def __call__(self, operand: T) -> T:
         pass
+
+
+EvaluationOperator = Callable[[PopulationT], PopulationT]

--- a/fedot/core/optimisers/gp_comp/operators/regularization.py
+++ b/fedot/core/optimisers/gp_comp/operators/regularization.py
@@ -1,9 +1,8 @@
 from copy import deepcopy
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from fedot.core.composer.constraint import constraint_function
 from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
-from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, EvaluationOperator
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.optimizer import GraphGenerationParams

--- a/fedot/core/optimisers/gp_comp/operators/regularization.py
+++ b/fedot/core/optimisers/gp_comp/operators/regularization.py
@@ -3,8 +3,8 @@ from typing import Any, List, Optional
 
 from fedot.core.composer.constraint import constraint_function
 from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
-from fedot.core.optimisers.gp_comp.operators.evaluation import EvaluationDispatcher
-from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
+from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
+from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, EvaluationOperator
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
@@ -16,7 +16,7 @@ class RegularizationTypesEnum(Enum):
 
 
 def regularized_population(reg_type: RegularizationTypesEnum, population: PopulationT,
-                           evaluator: EvaluationDispatcher,
+                           evaluator: EvaluationOperator,
                            params: GraphGenerationParams,
                            size: Optional[int] = None) -> PopulationT:
     if reg_type is RegularizationTypesEnum.decremental:
@@ -28,7 +28,7 @@ def regularized_population(reg_type: RegularizationTypesEnum, population: Popula
 
 
 def decremental_regularization(population: PopulationT,
-                               evaluator: EvaluationDispatcher,
+                               evaluator: EvaluationOperator,
                                params: GraphGenerationParams,
                                size: Optional[int] = None) -> PopulationT:
     size = size or len(population)

--- a/fedot/core/optimisers/objective/__init__.py
+++ b/fedot/core/optimisers/objective/__init__.py
@@ -1,4 +1,4 @@
-from .objective import Objective, ObjectiveFunction
+from .objective import Objective, GraphFunction, ObjectiveFunction
 from .objective_eval import ObjectiveEvaluate
 from .data_objective_eval import PipelineObjectiveEvaluate, DataSource
 from .data_objective_builder import DataObjectiveBuilder

--- a/fedot/core/optimisers/objective/data_objective_eval.py
+++ b/fedot/core/optimisers/objective/data_objective_eval.py
@@ -44,10 +44,6 @@ class PipelineObjectiveEvaluate(ObjectiveEvaluate[Pipeline]):
         self._cache = cache
         self._log = log or default_log(__name__)
 
-    @property
-    def objective(self) -> Objective:
-        return self._objective
-
     def evaluate(self, graph: Pipeline) -> Fitness:
         # Seems like a workaround for situation when logger is lost
         #  when adapting and restoring it to/from OptGraph.

--- a/fedot/core/optimisers/objective/data_objective_eval.py
+++ b/fedot/core/optimisers/objective/data_objective_eval.py
@@ -115,6 +115,3 @@ class PipelineObjectiveEvaluate(ObjectiveEvaluate[Pipeline]):
                                                    validation_blocks=self._validation_blocks)
             # saving only the most important first metric
             node.metadata.metric = intermediate_fitness.values[0]
-
-    def cleanup(self, graph: Pipeline):
-        graph.unfit()

--- a/fedot/core/optimisers/objective/objective.py
+++ b/fedot/core/optimisers/objective/objective.py
@@ -6,8 +6,11 @@ from fedot.core.log import Log, default_log
 from fedot.core.optimisers.fitness import *
 from fedot.core.repository.quality_metrics_repository import MetricType, MetricsRepository
 
+
 G = TypeVar('G', bound=Graph, covariant=True)
-ObjectiveFunction = Callable[[G], Fitness]
+R = TypeVar('R', contravariant=True)
+GraphFunction = Callable[[G], R]
+ObjectiveFunction = GraphFunction[G, Fitness]
 
 
 class Objective:

--- a/fedot/core/optimisers/objective/objective_eval.py
+++ b/fedot/core/optimisers/objective/objective_eval.py
@@ -27,11 +27,6 @@ class ObjectiveEvaluate(ABC, Generic[G]):
         self._objective = objective
         self._objective_kwargs = objective_kwargs
 
-    @property
-    def objective(self) -> Objective:
-        """Returns underlying objective."""
-        return self._objective
-
     def __call__(self, graph: G) -> Fitness:
         """Provides functional interface for ObjectiveEvaluate."""
         return self.evaluate(graph)

--- a/fedot/core/optimisers/objective/objective_eval.py
+++ b/fedot/core/optimisers/objective/objective_eval.py
@@ -43,7 +43,3 @@ class ObjectiveEvaluate(ABC, Generic[G]):
     def evaluate_intermediate_metrics(self, graph: G):
         """Compute intermediate metrics for each graph node and store it there."""
         pass
-
-    def cleanup(self, graph: G):
-        """Clean resources after graph evaluation, if necessary."""
-        pass

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -7,9 +7,9 @@ from fedot.core.dag.graph import Graph
 from fedot.core.log import Log, default_log
 from fedot.core.optimisers.adapters import BaseOptimizationAdapter, DirectAdapter
 from fedot.core.optimisers.generation_keeper import GenerationKeeper
-from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
+from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, EvaluationOperator
 from fedot.core.optimisers.graph import OptGraph
-from fedot.core.optimisers.objective import Objective, ObjectiveEvaluate
+from fedot.core.optimisers.objective import Objective, ObjectiveEvaluate, ObjectiveFunction, GraphFunction
 from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
 
 OptimisationCallback = Callable[[PopulationT, GenerationKeeper], None]
@@ -95,12 +95,17 @@ class GraphOptimiser:
         return self._objective
 
     @abstractmethod
-    def optimise(self, objective_evaluator: ObjectiveEvaluate,
+    def optimise(self, objective: ObjectiveFunction,
                  show_progress: bool = True) -> Union[OptGraph, List[OptGraph]]:
         """
         Method for running of optimization using specified algorithm.
-        :param objective_evaluator: Defines specific Objective and graph evaluation policy.
+        :param objective: objective function that specifies optimization target
         :param show_progress: print output the describes the progress during iterations
         :return: best graph (or list of graph for multi-objective case)
         """
+        pass
+
+    def set_evaluation_callback(self, callback: Optional[GraphFunction]):
+        """Set or reset (with None) post-evaluation callback
+        that's called on each graph after its evaluation."""
         pass

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -12,7 +12,7 @@ from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import Objective, ObjectiveEvaluate, ObjectiveFunction, GraphFunction
 from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
 
-OptimisationCallback = Callable[[PopulationT, GenerationKeeper], None]
+OptimisationCallback = Callable[[PopulationT, GenerationKeeper], Any]
 
 
 def do_nothing_callback(*args, **kwargs):
@@ -87,8 +87,7 @@ class GraphOptimiser:
 
         self.initial_graph = ensure_wrapped_in_sequence(initial_graph)
 
-        # optimisation: callback function that runs on each iteration
-        self.optimisation_callback: OptimisationCallback = do_nothing_callback
+        self._optimisation_callback: OptimisationCallback = do_nothing_callback
 
     @property
     def objective(self) -> Objective:
@@ -104,6 +103,11 @@ class GraphOptimiser:
         :return: best graph (or list of graph for multi-objective case)
         """
         pass
+
+    def set_optimisation_callback(self, callback: Optional[OptimisationCallback]):
+        """Set optimisation callback that must run on each iteration.
+        Reset the callback if None is passed."""
+        self._optimisation_callback = callback or do_nothing_callback
 
     def set_evaluation_callback(self, callback: Optional[GraphFunction]):
         """Set or reset (with None) post-evaluation callback

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -16,7 +16,7 @@ from fedot.core.operations.model import Model
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
 from fedot.core.optimisers.gp_comp.operators.crossover import crossover, CrossoverTypesEnum
-from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
+from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, mutation
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -150,8 +150,8 @@ def test_collect_intermediate_metric(pipeline: Pipeline, input_data: InputData, 
 
     objective_builder = DataObjectiveBuilder(Objective(metrics))
     objective_eval = objective_builder.build(input_data)
-    dispatcher = MultiprocessingDispatcher(graph_gen_params.adapter,
-                                           post_eval_callback=objective_eval.evaluate_intermediate_metrics)
+    dispatcher = MultiprocessingDispatcher(graph_gen_params.adapter)
+    dispatcher.set_evaluation_callback(objective_eval.evaluate_intermediate_metrics)
     evaluate = dispatcher.dispatch(objective_eval)
 
     population = [Individual(adapter.adapt(pipeline))]

--- a/test/unit/optimizer/test_external.py
+++ b/test/unit/optimizer/test_external.py
@@ -11,8 +11,7 @@ from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimise
     OptimisationCallback, do_nothing_callback
 from fedot.core.pipelines.node import PrimaryNode
 from fedot.core.pipelines.pipeline import Pipeline
-from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.objective.objective_eval import ObjectiveEvaluate
+from fedot.core.optimisers.objective.objective import Objective, ObjectiveFunction
 from test.unit.models.test_model import classification_dataset
 
 _ = classification_dataset  # to avoid auto-removing of import
@@ -35,7 +34,7 @@ class StaticOptimizer(GraphOptimiser):
         self.change_types = []
         self.node_name = kwargs.get('node_name')
 
-    def optimise(self, objective_evaluator: ObjectiveEvaluate, show_progress: bool = True):
+    def optimise(self, objective: ObjectiveFunction, show_progress: bool = True):
         if self.node_name:
             return OptGraph(OptNode(self.node_name))
         return OptGraph(OptNode('logit'))

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -15,7 +15,7 @@ from fedot.core.optimisers.adapters import DirectAdapter, PipelineAdapter
 from fedot.core.optimisers.gp_comp.gp_operators import filter_duplicates
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, crossover
-from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
+from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, _adapt_and_apply_mutations, mutation, \
     reduce_mutation, single_drop_mutation
 from fedot.core.optimisers.graph import OptGraph, OptNode

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -15,7 +15,7 @@ from fedot.core.optimisers.adapters import DirectAdapter, PipelineAdapter
 from fedot.core.optimisers.gp_comp.gp_operators import filter_duplicates
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, crossover
-from fedot.core.optimisers.gp_comp.operators.evaluation import EvaluationDispatcher
+from fedot.core.optimisers.gp_comp.operators.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, _adapt_and_apply_mutations, mutation, \
     reduce_mutation, single_drop_mutation
 from fedot.core.optimisers.graph import OptGraph, OptNode
@@ -126,7 +126,7 @@ def test_evaluate_individuals():
     timeout = datetime.timedelta(minutes=0.001)
     params = GraphGenerationParams(adapter=PipelineAdapter(), advisor=PipelineChangeAdvisor())
     with OptimisationTimer(timeout=timeout) as t:
-        evaluator = EvaluationDispatcher(objective_eval, params.adapter, timer=t)
+        evaluator = MultiprocessingDispatcher(params.adapter, timer=t).dispatch(objective_eval)
         evaluated = evaluator(population)
     assert len(evaluated) == 1
     assert evaluated[0].fitness is not None
@@ -136,7 +136,7 @@ def test_evaluate_individuals():
     population = [Individual(adapter.adapt(c)) for c in pipelines_to_evaluate]
     timeout = datetime.timedelta(minutes=5)
     with OptimisationTimer(timeout=timeout) as t:
-        evaluator = EvaluationDispatcher(objective_eval, params.adapter, timer=t)
+        evaluator = MultiprocessingDispatcher(params.adapter, timer=t).dispatch(objective_eval)
         evaluated = evaluator(population)
     assert len(evaluated) == 4
     assert all([ind.fitness.valid for ind in evaluated])


### PR DESCRIPTION
- Use generic ObjectiveFunction (Callable) instead of ObjectiveEvaluate in .optimise interface.
  This generalises Optimiser interface and allows passing arbitrary Callables as Objective functions.
- Introduce ObjectiveEvaluationDispatcher:
  Dispatcher accepts objective function and returns population evaluator.
  Its role is to define details of how objective must be actually evaluated,
  e.g. using multiprocessing, evaluation cache or remote evaluation.
  Rename EvaluationDispatcher to MultiprocessingDispatcher, which reflects its implementation.
- Introduce `evaluation_callback` functionality in Optimiser.
  This allows extracting the need for computing intermediate metrics.
  Now gp_composer defines this callback.

This is a continuation of PR #678 and part of the issue #608 