### PR TITLE
Naive forecasters for time series implemented 

### DIFF
--- a/examples/advanced/time_series_forecasting/composing_pipelines.py
+++ b/examples/advanced/time_series_forecasting/composing_pipelines.py
@@ -14,6 +14,7 @@ from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.optimisers.gp_comp.gp_optimiser import GPGraphOptimiserParameters
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
+from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.quality_metrics_repository import \
     MetricsRepository, RegressionMetricsEnum

--- a/examples/advanced/time_series_forecasting/multi_ts_arctic_forecasting.py
+++ b/examples/advanced/time_series_forecasting/multi_ts_arctic_forecasting.py
@@ -13,6 +13,8 @@ from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.optimisers.gp_comp.gp_optimiser import GPGraphOptimiserParameters
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
+from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
+from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.quality_metrics_repository import \
     MetricsRepository, RegressionMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams

--- a/examples/advanced/time_series_forecasting/multistep.py
+++ b/examples/advanced/time_series_forecasting/multistep.py
@@ -9,6 +9,7 @@ from examples.simple.time_series_forecasting.ts_pipelines import *
 from examples.simple.time_series_forecasting.tuning_pipelines import visualise
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
+from fedot.core.pipelines.pipeline import Pipeline
 
 from fedot.core.pipelines.ts_wrappers import out_of_sample_ts_forecast
 from fedot.core.repository.dataset_types import DataTypesEnum

--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -1,3 +1,5 @@
+from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
+from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_builder import PipelineBuilder
 
 
@@ -242,7 +244,7 @@ def clstm_pipeline():
     clstm_params = {'window_size': 29, 'hidden_size': 50, 'learning_rate': 0.004,
                     'cnn1_kernel_size': 5, 'cnn1_output_size': 32,
                     'cnn2_kernel_size': 4, 'cnn2_output_size': 32,
-                    'batch_size': 64, 'num_epochs': 3}
+                    'batch_size': 64, 'num_epochs': 3, 'teacher_forcing': 0.8}
 
     pip_builder = PipelineBuilder() \
         .add_sequence('lagged', 'ridge', branch_idx=0) \

--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -220,6 +220,11 @@ def ts_stl_arima_pipeline():
     return pipeline
 
 
+def ts_naive_forecast_pipeline():
+    pipeline = Pipeline(PrimaryNode("locf"))
+    return pipeline
+
+
 def clstm_pipeline():
     """
     Return pipeline with the following structure:

--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -1,5 +1,3 @@
-from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
-from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_builder import PipelineBuilder
 
 

--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -220,8 +220,17 @@ def ts_stl_arima_pipeline():
     return pipeline
 
 
-def ts_naive_forecast_pipeline():
-    pipeline = Pipeline(PrimaryNode("locf"))
+def ts_locf_forecast_pipeline():
+    locf_node = PrimaryNode("locf")
+    lagged_node = PrimaryNode("lagged")
+    pipeline = Pipeline(SecondaryNode("ridge", nodes_from=[locf_node, lagged_node]))
+    return pipeline
+
+
+def ts_naive_average_pipeline():
+    naive_average_node = PrimaryNode("ts_naive_average")
+    lagged_node = PrimaryNode("lagged")
+    pipeline = Pipeline(SecondaryNode("ridge", nodes_from=[naive_average_node, lagged_node]))
     return pipeline
 
 

--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -1,5 +1,3 @@
-from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
-from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_builder import PipelineBuilder
 
 
@@ -9,14 +7,14 @@ def ts_ets_pipeline():
     cut -> ets -> final forecast
     Where cut - cut part of dataset and ets - exponential smoothing
     """
-    node_cut = PrimaryNode("cut")
-    node_ets = SecondaryNode("ets", nodes_from=[node_cut])
-    node_ets.custom_params = {"error": "add",
-                              "trend": "add",
-                              "seasonal": "add",
-                              "damped_trend": False,
-                              "seasonal_periods": 20}
-    return Pipeline(node_ets)
+    pip_builder = PipelineBuilder().add_node('cut').add_node('ets',
+                                                             params={'error': 'add',
+                                                                     'trend': 'add',
+                                                                     'seasonal': 'add',
+                                                                     'damped_trend': False,
+                                                                     'seasonal_periods': 20})
+    pipeline = pip_builder.to_pipeline()
+    return pipeline
 
 
 def ts_ets_ridge_pipeline():
@@ -27,21 +25,15 @@ def ts_ets_ridge_pipeline():
     lagged - ridge /
     Where cut - cut part of dataset, ets - exponential smoothing
    """
-    node_cut = PrimaryNode("cut")
-    node_cut.custom_params = {"cut_part": 0.5}
-    node_ets = SecondaryNode("ets", nodes_from=[node_cut])
-    node_ets.custom_params = {"error": "add",
-                              "trend": "add",
-                              "seasonal": "add",
-                              "damped_trend": False,
-                              "seasonal_periods": 20}
+    pip_builder = PipelineBuilder()\
+        .add_sequence(('cut', {'cut_part': 0.5}),
+                      ('ets', {'error': 'add', 'trend': 'add', 'seasonal': 'add',
+                               'damped_trend': False, 'seasonal_periods': 20}),
+                      branch_idx=0)\
+        .add_sequence('lagged', 'ridge', branch_idx=1).join_branches('ridge')
 
-    node_lagged = PrimaryNode("lagged")
-    node_ridge_1 = SecondaryNode("ridge", nodes_from=[node_lagged])
-
-    node_ridge_2 = SecondaryNode("ridge", nodes_from=[node_ridge_1, node_ets])
-
-    return Pipeline(node_ridge_2)
+    pipeline = pip_builder.to_pipeline()
+    return pipeline
 
 
 def ts_glm_pipeline():
@@ -51,9 +43,8 @@ def ts_glm_pipeline():
 
     Where glm - Generalized linear model
     """
-    node_glm = PrimaryNode("glm")
-    node_glm.custom_params = {"family": "gaussian"}
-    return Pipeline(node_glm)
+    pipeline = PipelineBuilder().add_node('glm', params={'family': 'gaussian'}).to_pipeline()
+    return pipeline
 
 
 def ts_glm_ridge_pipeline():
@@ -65,14 +56,12 @@ def ts_glm_ridge_pipeline():
 
     Where glm - Generalized linear model
     """
-    node_glm = PrimaryNode("glm")
+    pip_builder = PipelineBuilder() \
+        .add_sequence('glm', branch_idx=0) \
+        .add_sequence('lagged', 'ridge', branch_idx=1).join_branches('ridge')
 
-    node_lagged = PrimaryNode("lagged")
-    node_ridge_1 = SecondaryNode("ridge", nodes_from=[node_lagged])
-
-    node_ridge_2 = SecondaryNode("ridge", nodes_from=[node_ridge_1, node_glm])
-
-    return Pipeline(node_ridge_2)
+    pipeline = pip_builder.to_pipeline()
+    return pipeline
 
 
 def ts_polyfit_pipeline(degree):
@@ -82,9 +71,8 @@ def ts_polyfit_pipeline(degree):
 
     Where polyfit - Polynomial interpolation
     """
-    node_polyfit = PrimaryNode("polyfit")
-    node_polyfit.custom_params = {"degree": degree}
-    return Pipeline(node_polyfit)
+    pipeline = PipelineBuilder().add_node('polyfit', params={'degree': degree}).to_pipeline()
+    return pipeline
 
 
 def ts_polyfit_ridge_pipeline(degree):
@@ -96,15 +84,12 @@ def ts_polyfit_ridge_pipeline(degree):
 
     Where polyfit - Polynomial interpolation
     """
-    node_polyfit = PrimaryNode("polyfit")
-    node_polyfit.custom_params = {"degree": degree}
+    pip_builder = PipelineBuilder() \
+        .add_sequence(('polyfit', {'degree': degree}), branch_idx=0) \
+        .add_sequence('lagged', 'ridge', branch_idx=1).join_branches('ridge')
 
-    node_lagged = PrimaryNode("lagged")
-    node_ridge_1 = SecondaryNode("ridge", nodes_from=[node_lagged])
-
-    node_ridge_2 = SecondaryNode("ridge", nodes_from=[node_ridge_1, node_polyfit])
-
-    return Pipeline(node_ridge_2)
+    pipeline = pip_builder.to_pipeline()
+    return pipeline
 
 
 def ts_complex_ridge_pipeline():
@@ -114,15 +99,11 @@ def ts_complex_ridge_pipeline():
                     -> ridge -> final forecast
     lagged - ridge /
     """
-    node_lagged_1 = PrimaryNode("lagged")
-    node_lagged_2 = PrimaryNode("lagged")
+    pip_builder = PipelineBuilder() \
+        .add_sequence('lagged', 'rigde', branch_idx=0) \
+        .add_sequence('lagged', 'ridge', branch_idx=1).join_branches('ridge')
 
-    node_ridge_1 = SecondaryNode("ridge", nodes_from=[node_lagged_1])
-    node_ridge_2 = SecondaryNode("ridge", nodes_from=[node_lagged_2])
-
-    node_final = SecondaryNode("ridge", nodes_from=[node_ridge_1, node_ridge_2])
-    pipeline = Pipeline(node_final)
-
+    pipeline = pip_builder.to_pipeline()
     return pipeline
 
 
@@ -137,20 +118,15 @@ def ts_complex_ridge_smoothing_pipeline():
 
     Where smoothing - rolling mean
     """
-    node_smoothing = PrimaryNode("smoothing")
-    node_lagged_1 = SecondaryNode("lagged", nodes_from=[node_smoothing])
-    node_lagged_2 = PrimaryNode("lagged")
+    pip_builder = PipelineBuilder() \
+        .add_sequence('smoothing', 'lagged', 'rigde', branch_idx=0) \
+        .add_sequence('lagged', 'ridge', branch_idx=1).join_branches('ridge')
 
-    node_ridge_1 = SecondaryNode("ridge", nodes_from=[node_lagged_1])
-    node_ridge_2 = SecondaryNode("ridge", nodes_from=[node_lagged_2])
-
-    node_final = SecondaryNode("ridge", nodes_from=[node_ridge_1, node_ridge_2])
-    pipeline = Pipeline(node_final)
-
+    pipeline = pip_builder.to_pipeline()
     return pipeline
 
 
-def ts_complex_dtreg_pipeline(first_node="lagged"):
+def ts_complex_dtreg_pipeline(first_node='lagged'):
     """
         Return pipeline with the following structure:
 
@@ -160,12 +136,11 @@ def ts_complex_dtreg_pipeline(first_node="lagged"):
 
         Where dtreg = tree regressor, rfr - random forest regressor
     """
-    node_lagged_1 = PrimaryNode(first_node)
-    node_lagged_2 = PrimaryNode(first_node)
-    node_dtreg_1 = SecondaryNode("dtreg", nodes_from=[node_lagged_1])
-    node_dtreg_2 = SecondaryNode("dtreg", nodes_from=[node_lagged_2])
-    node_final = SecondaryNode("rfr", nodes_from=[node_dtreg_1, node_dtreg_2])
-    pipeline = Pipeline(node_final)
+    pip_builder = PipelineBuilder() \
+        .add_sequence(first_node, 'dtreg', branch_idx=0) \
+        .add_sequence(first_node, 'dtreg', branch_idx=1).join_branches('rfr')
+
+    pipeline = pip_builder.to_pipeline()
     return pipeline
 
 
@@ -180,11 +155,13 @@ def ts_multiple_ets_pipeline():
 
     Where ets - exponential_smoothing
     """
-    node_ets2 = PrimaryNode("ets")
-    node_ets = PrimaryNode("ets")
-    node_ets3 = PrimaryNode("ets")
-    final_lasso = SecondaryNode('lasso', nodes_from=[node_ets, node_ets2, node_ets3])
-    pipeline = Pipeline(final_lasso)
+    pip_builder = PipelineBuilder() \
+        .add_sequence('ets', branch_idx=0) \
+        .add_sequence('ets', branch_idx=1) \
+        .add_sequence('ets', branch_idx=2) \
+        .join_branches('lasso')
+
+    pipeline = pip_builder.to_pipeline()
     return pipeline
 
 
@@ -195,8 +172,7 @@ def ts_ar_pipeline():
 
     Where ar - auto regression
     """
-    node_ar = PrimaryNode("ar")
-    pipeline = Pipeline(node_ar)
+    pipeline = PipelineBuilder().add_node('ar').to_pipeline()
     return pipeline
 
 
@@ -220,17 +196,37 @@ def ts_stl_arima_pipeline():
     return pipeline
 
 
-def ts_locf_forecast_pipeline():
-    locf_node = PrimaryNode("locf")
-    lagged_node = PrimaryNode("lagged")
-    pipeline = Pipeline(SecondaryNode("ridge", nodes_from=[locf_node, lagged_node]))
+def ts_locf_ridge_pipeline():
+    """
+    Pipeline with naive LOCF (last observation carried forward) model
+    and lagged features
+     locf  \
+            ridge -> final forecast
+    lagged /
+    """
+    pip_builder = PipelineBuilder() \
+        .add_sequence('locf', branch_idx=0) \
+        .add_sequence('lagged', branch_idx=1) \
+        .join_branches('ridge')
+
+    pipeline = pip_builder.to_pipeline()
     return pipeline
 
 
-def ts_naive_average_pipeline():
-    naive_average_node = PrimaryNode("ts_naive_average")
-    lagged_node = PrimaryNode("lagged")
-    pipeline = Pipeline(SecondaryNode("ridge", nodes_from=[naive_average_node, lagged_node]))
+def ts_naive_average_ridge_pipeline():
+    """
+    Pipeline with simple forecasting model (the forecast is mean value for known
+    part)
+    ts_naive_average \
+                      ridge -> final forecast
+         lagged      /
+    """
+    pip_builder = PipelineBuilder() \
+        .add_sequence('ts_naive_average', branch_idx=0) \
+        .add_sequence('lagged', branch_idx=1) \
+        .join_branches('ridge')
+
+    pipeline = pip_builder.to_pipeline()
     return pipeline
 
 
@@ -243,21 +239,15 @@ def clstm_pipeline():
 
     Where clstm - convolutional long short-term memory model
     """
-    node_lagged_1 = PrimaryNode("lagged")
+    clstm_params = {'window_size': 29, 'hidden_size': 50, 'learning_rate': 0.004,
+                    'cnn1_kernel_size': 5, 'cnn1_output_size': 32,
+                    'cnn2_kernel_size': 4, 'cnn2_output_size': 32,
+                    'batch_size': 64, 'num_epochs': 3}
 
-    node_ridge_1 = SecondaryNode("ridge", nodes_from=[node_lagged_1])
-    node_clstm = PrimaryNode("clstm")
-    node_clstm.custom_params = {"window_size": 29,
-                                "hidden_size": 50,
-                                "learning_rate": 0.004,
-                                "cnn1_kernel_size": 5,
-                                "cnn1_output_size": 32,
-                                "cnn2_kernel_size": 4,
-                                "cnn2_output_size": 32,
-                                "batch_size": 64,
-                                "num_epochs": 3}
+    pip_builder = PipelineBuilder() \
+        .add_sequence('lagged', 'ridge', branch_idx=0) \
+        .add_sequence(('clstm', clstm_params), branch_idx=1) \
+        .join_branches('ridge')
 
-    node_final = SecondaryNode("ridge", nodes_from=[node_ridge_1, node_clstm])
-    pipeline = Pipeline(node_final)
-
+    pipeline = pip_builder.to_pipeline()
     return pipeline

--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -244,7 +244,8 @@ def clstm_pipeline():
     clstm_params = {'window_size': 29, 'hidden_size': 50, 'learning_rate': 0.004,
                     'cnn1_kernel_size': 5, 'cnn1_output_size': 32,
                     'cnn2_kernel_size': 4, 'cnn2_output_size': 32,
-                    'batch_size': 64, 'num_epochs': 3, 'teacher_forcing': 0.8}
+                    'batch_size': 64, 'num_epochs': 3, 'teacher_forcing': 0.8,
+                    'optimizer': 'adam', 'loss': 'mse'}
 
     pip_builder = PipelineBuilder() \
         .add_sequence('lagged', 'ridge', branch_idx=0) \

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -91,4 +91,4 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
 
 
 if __name__ == '__main__':
-    run_experiment('australia', ts_ar_pipeline(), len_forecast=50, tuning=True)
+    run_experiment('australia', ts_naive_forecast_pipeline(), len_forecast=50, tuning=True)

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -42,11 +42,6 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
                             target=time_series,
                             task=task,
                             data_type=DataTypesEnum.ts)
-    # train_input = InputData(idx=np.array([0, 1, 2, 3, 4]),
-    #                         features=np.array([0, 1, 2, 3, 4]),
-    #                         target=np.array([0, 1, 2, 3, 4]),
-    #                         task=task,
-    #                         data_type=DataTypesEnum.ts)
     train_data, test_data = train_test_data_setup(train_input)
     test_target = np.ravel(test_data.target)
 

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -92,4 +92,4 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
 
 
 if __name__ == '__main__':
-    run_experiment('australia', ts_naive_average_ridge_pipeline(), len_forecast=50, tuning=True)
+    run_experiment('australia', ts_locf_ridge_pipeline(), len_forecast=50, tuning=True)

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -5,6 +5,7 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error
 from examples.advanced.time_series_forecasting.composing_pipelines import visualise, get_border_line_info
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
+from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from examples.simple.time_series_forecasting.ts_pipelines import *
@@ -91,4 +92,4 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
 
 
 if __name__ == '__main__':
-    run_experiment('australia', ts_naive_average_pipeline(), len_forecast=50, tuning=True)
+    run_experiment('australia', ts_naive_average_ridge_pipeline(), len_forecast=50, tuning=True)

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -42,11 +42,11 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
                             target=time_series,
                             task=task,
                             data_type=DataTypesEnum.ts)
-    # train_input = InputData(idx=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    #                         features=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    #                         target=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    #                         task=task,
-    #                         data_type=DataTypesEnum.ts)
+    train_input = InputData(idx=np.array([0, 1, 2, 3, 4]),
+                            features=np.array([0, 1, 2, 3, 4]),
+                            target=np.array([0, 1, 2, 3, 4]),
+                            task=task,
+                            data_type=DataTypesEnum.ts)
     train_data, test_data = train_test_data_setup(train_input)
     test_target = np.ravel(test_data.target)
 
@@ -96,4 +96,4 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
 
 
 if __name__ == '__main__':
-    run_experiment('australia', ts_naive_average_pipeline(), len_forecast=50, tuning=True)
+    run_experiment('australia', ts_naive_average_pipeline(), len_forecast=2, tuning=True)

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -42,6 +42,11 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
                             target=time_series,
                             task=task,
                             data_type=DataTypesEnum.ts)
+    # train_input = InputData(idx=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    #                         features=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    #                         target=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    #                         task=task,
+    #                         data_type=DataTypesEnum.ts)
     train_data, test_data = train_test_data_setup(train_input)
     test_target = np.ravel(test_data.target)
 
@@ -91,4 +96,4 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
 
 
 if __name__ == '__main__':
-    run_experiment('australia', ts_naive_forecast_pipeline(), len_forecast=50, tuning=True)
+    run_experiment('australia', ts_naive_average_pipeline(), len_forecast=50, tuning=True)

--- a/examples/simple/time_series_forecasting/tuning_pipelines.py
+++ b/examples/simple/time_series_forecasting/tuning_pipelines.py
@@ -42,11 +42,11 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
                             target=time_series,
                             task=task,
                             data_type=DataTypesEnum.ts)
-    train_input = InputData(idx=np.array([0, 1, 2, 3, 4]),
-                            features=np.array([0, 1, 2, 3, 4]),
-                            target=np.array([0, 1, 2, 3, 4]),
-                            task=task,
-                            data_type=DataTypesEnum.ts)
+    # train_input = InputData(idx=np.array([0, 1, 2, 3, 4]),
+    #                         features=np.array([0, 1, 2, 3, 4]),
+    #                         target=np.array([0, 1, 2, 3, 4]),
+    #                         task=task,
+    #                         data_type=DataTypesEnum.ts)
     train_data, test_data = train_test_data_setup(train_input)
     test_target = np.ravel(test_data.target)
 
@@ -96,4 +96,4 @@ def run_experiment(dataset: str, pipeline: Pipeline, len_forecast=250, tuning=Tr
 
 
 if __name__ == '__main__':
-    run_experiment('australia', ts_naive_average_pipeline(), len_forecast=2, tuning=True)
+    run_experiment('australia', ts_naive_average_pipeline(), len_forecast=50, tuning=True)

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -795,3 +795,24 @@ def prepare_target(all_idx, idx, features_columns: np.array, target, forecast_le
         updated_target = ts_target
 
     return updated_idx, updated_features, updated_target
+
+
+def transform_features_and_target_into_lagged(input_data: InputData, forecast_length: int,
+                                              window_size: int):
+    """
+    Perform lagged transformation firstly on features and secondly on target array
+
+    :param input_data: dataclass with features
+    :param forecast_length: forecast horizon
+    :param window_size: window size for features transformation
+    """
+    new_idx, transformed_cols = ts_to_table(idx=input_data.idx,
+                                            time_series=input_data.features,
+                                            window_size=window_size,
+                                            is_lag=True)
+    new_idx, transformed_cols, new_target = prepare_target(all_idx=input_data.idx,
+                                                           idx=new_idx,
+                                                           features_columns=transformed_cols,
+                                                           target=input_data.target,
+                                                           forecast_length=forecast_length)
+    return new_idx, transformed_cols, new_target

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -76,6 +76,12 @@ class NaiveAverageForecastImplementation(ModelImplementation):
             parts = split_rolling_slices(input_data)
             mean_values_for_chunks = self.average_by_axis(parts)
             forecast = np.repeat(mean_values_for_chunks.reshape((-1, 1)), forecast_length, axis=1)
+            forecast = forecast[:-forecast_length, :]
+
+            # Update indices - there is no forecast for first element
+            last_threshold = forecast_length - 1
+            new_idx = input_data.idx[1: -last_threshold]
+            input_data.idx = new_idx
         else:
             elements_to_take = self._how_many_elements_use_for_averaging(input_data.features)
             # Prepare single forecast

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -19,7 +19,6 @@ class RepeatLastValueImplementation(ModelImplementation):
 
     def __init__(self, log: Optional[Log] = None, **params):
         super().__init__(log)
-        self.params = {}
 
     def fit(self, input_data):
         """ Such a simple approach does not support fit method """
@@ -55,7 +54,7 @@ class RepeatLastValueImplementation(ModelImplementation):
         return output_data
 
     def get_params(self):
-        return self.params
+        return {}
 
 
 class NaiveAverageForecastImplementation(ModelImplementation):
@@ -128,15 +127,11 @@ def split_rolling_slices(input_data: InputData):
      [0,   1,   2, nan],
      [0,   1,   2,   3]]
     """
-    # Generate two triangle matrices with nan and zeros
-    dummy_tril_with_zeros = np.tril(np.full(len(input_data.features), 1), k=0)
-    final_matrix = np.tril(np.full(len(input_data.features), 1), k=0)
+    nan_mask = np.triu(np.ones_like(input_data.features, dtype=bool), k=1)
+    final_matrix = np.tril(input_data.features, k=0)
     final_matrix = np.array(final_matrix, dtype=float)
-    final_matrix[final_matrix == 0] = np.nan
+    final_matrix[nan_mask] = np.nan
 
-    actual_tril = np.tril(input_data.features, k=0)
-    actual_tril = np.array(actual_tril, dtype=float)
-    final_matrix[dummy_tril_with_zeros != 0] = actual_tril[dummy_tril_with_zeros != 0]
     return final_matrix
 
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -49,7 +49,7 @@ class RepeatLastValueImplementation(ModelImplementation):
             # Transform the predicted time series into a table
             new_idx, transformed_cols, new_target = transform_features_and_target_into_lagged(input_data,
                                                                                               forecast_length,
-                                                                                              window_size=self.elements_to_repeat)
+                                                                                              self.elements_to_repeat)
             input_data.idx = new_idx
             input_data.target = new_target
             forecast = self._generate_repeated_forecast(transformed_cols, forecast_length)

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -78,7 +78,12 @@ class NaiveAverageForecastImplementation(ModelImplementation):
             forecast = np.repeat(mean_values_for_chunks.reshape((-1, 1)), forecast_length, axis=1)
             forecast = forecast[:-forecast_length, :]
 
-            # Update indices - there is no forecast for first element
+            # Update target
+            _, transformed_target = ts_to_table(idx=input_data.idx, time_series=input_data.target,
+                                                window_size=forecast_length, is_lag=True)
+            input_data.target = transformed_target[1:, :]
+
+            # Update indices - there is no forecast for first element and skip last out of boundaries predictions
             last_threshold = forecast_length - 1
             new_idx = input_data.idx[1: -last_threshold]
             input_data.idx = new_idx

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -6,7 +6,7 @@ from typing import Optional
 from fedot.core.data.data import InputData
 from fedot.core.log import Log
 from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table, \
-    prepare_target
+    prepare_target, transform_features_and_target_into_lagged
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
 from fedot.core.repository.dataset_types import DataTypesEnum
 
@@ -30,16 +30,9 @@ class RepeatLastValueImplementation(ModelImplementation):
 
         if is_fit_pipeline_stage:
             # Transform the predicted time series into a table
-            old_idx = input_data.idx
-            new_idx, transformed_cols = ts_to_table(idx=old_idx,
-                                                    time_series=input_data.features,
-                                                    window_size=1,
-                                                    is_lag=True)
-            new_idx, transformed_cols, new_target = prepare_target(all_idx=input_data.idx,
-                                                                   idx=new_idx,
-                                                                   features_columns=transformed_cols,
-                                                                   target=input_data.target,
-                                                                   forecast_length=forecast_length)
+            new_idx, transformed_cols, new_target = transform_features_and_target_into_lagged(input_data,
+                                                                                              forecast_length,
+                                                                                              window_size=1)
             input_data.idx = new_idx
             input_data.target = new_target
             forecast = np.repeat(transformed_cols, forecast_length, axis=1)

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -1,8 +1,12 @@
+from copy import copy
+
 import numpy as np
 from typing import Optional
 
 from fedot.core.data.data import InputData
 from fedot.core.log import Log
+from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table, \
+    prepare_target
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
 from fedot.core.repository.dataset_types import DataTypesEnum
 
@@ -22,11 +26,28 @@ class RepeatLastValueImplementation(ModelImplementation):
         pass
 
     def predict(self, input_data: InputData, is_fit_pipeline_stage: bool):
+        input_data = copy(input_data)
         forecast_length = input_data.task.task_params.forecast_length
 
-        # Get last known value from history
-        last_observation = input_data.features[-1]
-        forecast = np.array([last_observation] * forecast_length)
+        if is_fit_pipeline_stage:
+            # Transform the predicted time series into a table
+            old_idx = input_data.idx
+            new_idx, transformed_cols = ts_to_table(idx=old_idx,
+                                                    time_series=input_data.features,
+                                                    window_size=1,
+                                                    is_lag=True)
+            new_idx, transformed_cols, new_target = prepare_target(all_idx=input_data.idx,
+                                                                   idx=new_idx,
+                                                                   features_columns=transformed_cols,
+                                                                   target=input_data.target,
+                                                                   forecast_length=forecast_length)
+            input_data.idx = new_idx
+            input_data.target = new_target
+            forecast = np.repeat(transformed_cols, forecast_length, axis=1)
+        else:
+            # Get last known value from history
+            last_observation = input_data.features[-1]
+            forecast = np.array([last_observation] * forecast_length).reshape((1, -1))
 
         output_data = self._convert_to_output(input_data,
                                               predict=forecast,
@@ -35,3 +56,37 @@ class RepeatLastValueImplementation(ModelImplementation):
 
     def get_params(self):
         return self.params
+
+
+class NaiveAverageForecastImplementation(ModelImplementation):
+    """ Class for forecasting time series with mean """
+
+    def __init__(self, log: Optional[Log] = None, **params):
+        super().__init__(log)
+        self.part_for_averaging = params.get('part_for_averaging')
+
+    def fit(self, input_data):
+        """ Such a simple approach does not support fit method """
+        pass
+
+    def predict(self, input_data: InputData, is_fit_pipeline_stage: bool):
+        """ Get desired part of time series for averaging and calculate mean value """
+        forecast_length = input_data.task.task_params.forecast_length
+        elements_to_take = round(len(input_data.features) * self.part_for_averaging)
+        if elements_to_take < 2:
+            elements_to_take = 2
+
+        if is_fit_pipeline_stage:
+            pass
+        else:
+            # Prepare single forecast
+            mean_value = np.nanmean(input_data.features[-elements_to_take:])
+            forecast = np.array([mean_value] * forecast_length)
+
+        output_data = self._convert_to_output(input_data,
+                                              predict=forecast,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def get_params(self):
+        return {'part_for_averaging': self.part_for_averaging}

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -1,0 +1,37 @@
+import numpy as np
+from typing import Optional
+
+from fedot.core.data.data import InputData
+from fedot.core.log import Log
+from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
+from fedot.core.repository.dataset_types import DataTypesEnum
+
+
+class RepeatLastValueImplementation(ModelImplementation):
+    """
+    Repeat last known value of time series to the future -
+    LOCF (last observation carried forward)
+    """
+
+    def __init__(self, log: Optional[Log] = None, **params):
+        super().__init__(log)
+        self.params = {}
+
+    def fit(self, input_data):
+        """ Such a simple approach does not support fit method """
+        pass
+
+    def predict(self, input_data: InputData, is_fit_pipeline_stage: bool):
+        forecast_length = input_data.task.task_params.forecast_length
+
+        # Get last known value from history
+        last_observation = input_data.features[-1]
+        forecast = np.array([last_observation] * forecast_length)
+
+        output_data = self._convert_to_output(input_data,
+                                              predict=forecast,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def get_params(self):
+        return self.params

--- a/fedot/core/operations/evaluation/time_series.py
+++ b/fedot/core/operations/evaluation/time_series.py
@@ -7,6 +7,8 @@ from fedot.core.operations.evaluation.operation_implementations.data_operations.
     ExogDataTransformationImplementation, GaussianFilterImplementation, LaggedTransformationImplementation, \
     TsSmoothingImplementation, SparseLaggedTransformationImplementation, CutImplementation, \
     NumericalDerivativeFilterImplementation
+from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.naive import \
+    RepeatLastValueImplementation
 from fedot.core.operations.evaluation.operation_implementations.models. \
     ts_implementations.statsmodels import AutoRegImplementation, GLMImplementation, ExpSmoothingImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.arima import \
@@ -36,7 +38,8 @@ class FedotTsForecastingStrategy(EvaluationStrategy):
         'ets': ExpSmoothingImplementation,
         'clstm': CLSTMImplementation,
         'polyfit': PolyfitImplementation,
-        'glm': GLMImplementation
+        'glm': GLMImplementation,
+        'locf': RepeatLastValueImplementation
     }
 
     def __init__(self, operation_type: str, params: Optional[dict] = None):

--- a/fedot/core/operations/evaluation/time_series.py
+++ b/fedot/core/operations/evaluation/time_series.py
@@ -8,7 +8,7 @@ from fedot.core.operations.evaluation.operation_implementations.data_operations.
     TsSmoothingImplementation, SparseLaggedTransformationImplementation, CutImplementation, \
     NumericalDerivativeFilterImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.naive import \
-    RepeatLastValueImplementation
+    RepeatLastValueImplementation, NaiveAverageForecastImplementation
 from fedot.core.operations.evaluation.operation_implementations.models. \
     ts_implementations.statsmodels import AutoRegImplementation, GLMImplementation, ExpSmoothingImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.arima import \
@@ -39,7 +39,8 @@ class FedotTsForecastingStrategy(EvaluationStrategy):
         'clstm': CLSTMImplementation,
         'polyfit': PolyfitImplementation,
         'glm': GLMImplementation,
-        'locf': RepeatLastValueImplementation
+        'locf': RepeatLastValueImplementation,
+        'ts_naive_average': NaiveAverageForecastImplementation
     }
 
     def __init__(self, operation_type: str, params: Optional[dict] = None):

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -289,7 +289,8 @@ class SearchSpace:
             'lda': {
                 'solver': (hp.choice, [['svd', 'lsqr', 'eigen']]),
                 'shrinkage': (hp.uniform, [0.1, 0.9])
-            }
+            },
+            'ts_naive_average': {'part_for_averaging': (hp.uniform, [0.1, 1])}
         }
 
         if self.custom_search_space is not None:

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -290,7 +290,8 @@ class SearchSpace:
                 'solver': (hp.choice, [['svd', 'lsqr', 'eigen']]),
                 'shrinkage': (hp.uniform, [0.1, 0.9])
             },
-            'ts_naive_average': {'part_for_averaging': (hp.uniform, [0.1, 1])}
+            'ts_naive_average': {'part_for_averaging': (hp.uniform, [0.1, 1])},
+            'locf': {'part_for_repeat': (hp.uniform, [0.01, 0.5])}
         }
 
         if self.custom_search_space is not None:

--- a/fedot/core/repository/data/default_operation_params.json
+++ b/fedot/core/repository/data/default_operation_params.json
@@ -131,5 +131,8 @@
   "pca": {
     "svd_solver": "full",
     "n_components": "mle"
+  },
+  "ts_naive_average": {
+    "part_for_averaging": 1.0
   }
 }

--- a/fedot/core/repository/data/default_operation_params.json
+++ b/fedot/core/repository/data/default_operation_params.json
@@ -134,5 +134,8 @@
   },
   "ts_naive_average": {
     "part_for_averaging": 1.0
+  },
+  "locf": {
+    "part_for_repeat": -1
   }
 }

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -425,6 +425,16 @@
       ],
 	  "input_type": "[DataTypesEnum.ts]"
     },
+    "ts_naive_average": {
+      "meta": "ts_model",
+      "presets": ["fast_train", "ts"],
+      "tags": [
+        "simple",
+        "interpretable",
+        "non_lagged"
+      ],
+	  "input_type": "[DataTypesEnum.ts]"
+    },
     "svc": {
       "meta": "custom_class",
       "tags": [

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -415,6 +415,16 @@
       ],
 	  "input_type": "[DataTypesEnum.ts]"
     },
+    "locf": {
+      "meta": "ts_model",
+      "presets": ["fast_train", "ts"],
+      "tags": [
+        "simple",
+        "interpretable",
+        "non_lagged"
+      ],
+	  "input_type": "[DataTypesEnum.ts]"
+    },
     "svc": {
       "meta": "custom_class",
       "tags": [

--- a/test/unit/models/test_model.py
+++ b/test/unit/models/test_model.py
@@ -15,7 +15,7 @@ from fedot.core.operations.evaluation.operation_implementations.data_operations.
 from fedot.core.operations.evaluation.operation_implementations.models.discriminant_analysis import \
     LDAImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.naive import \
-    NaiveAverageForecastImplementation
+    NaiveAverageForecastImplementation, RepeatLastValueImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.statsmodels import \
     GLMImplementation
 from fedot.core.operations.model import Model
@@ -341,3 +341,18 @@ def test_ts_naive_average_forecast_correctly():
 
     # Pipeline predict stage
     assert np.array_equal(predict_forecast.predict, np.array([[65, 65, 65, 65]]))
+
+
+def test_locf_forecast_correctly():
+    """ Testing naive LOCF model """
+    train_input, predict_input, _ = synthetic_univariate_ts()
+    model = RepeatLastValueImplementation(part_for_repeat=0.2)
+
+    model.fit(train_input)
+    fit_forecast = model.predict(train_input, is_fit_pipeline_stage=True)
+    predict_forecast = model.predict(predict_input, is_fit_pipeline_stage=False)
+
+    assert (8, 4) == fit_forecast.target.shape
+    assert np.array_equal(fit_forecast.idx, np.array([3, 4, 5, 6, 7, 8, 9, 10]))
+    # Repeated pattern (3 elements to repeat and 4 forecast horizon)
+    assert np.array_equal(predict_forecast.predict, np.array([[110, 120, 130, 110]]))

--- a/test/unit/models/test_model.py
+++ b/test/unit/models/test_model.py
@@ -14,6 +14,8 @@ from fedot.core.operations.evaluation.operation_implementations.data_operations.
     PCAImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.discriminant_analysis import \
     LDAImplementation
+from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.naive import \
+    NaiveAverageForecastImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.ts_implementations.statsmodels import \
     GLMImplementation
 from fedot.core.operations.model import Model
@@ -23,6 +25,7 @@ from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.operation_types_repository import OperationTypesRepository
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from test.unit.common_tests import is_predict_ignores_target
+from test.unit.data_operations.test_time_series_operations import synthetic_univariate_ts
 from test.unit.tasks.test_forecasting import get_ts_data, get_ts_data_with_dt_idx
 from test.unit.tasks.test_regression import get_synthetic_regression_data
 
@@ -321,3 +324,20 @@ def test_pca_model_fit_with_wide_table():
 
     params, changed_hyperparams = pca_model.get_params()
     assert changed_hyperparams[0] == 'n_components'
+
+
+def test_ts_naive_average_forecast_correctly():
+    """ Check if forecasted time series has correct indices """
+    train_input, predict_input, _ = synthetic_univariate_ts()
+
+    model = NaiveAverageForecastImplementation(part_for_averaging=1.0)
+    fit_forecast = model.predict(train_input, is_fit_pipeline_stage=True)
+    predict_forecast = model.predict(predict_input, is_fit_pipeline_stage=False)
+
+    # Check correctness during pipeline fit stage
+    assert (10, 4) == fit_forecast.target.shape
+    assert np.array_equal(fit_forecast.idx, np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    assert np.isclose(fit_forecast.predict[0, 0], 0)
+
+    # Pipeline predict stage
+    assert np.array_equal(predict_forecast.predict, np.array([[65, 65, 65, 65]]))


### PR DESCRIPTION
Two simple forecasting models were added as Implementations into FEDOT framework:
- LOCF - Last observation carried forward - repeats the last known value as many times as the number of elements in the forecast
- Naive average - the forecast is calculated as the average of the last n elements
