### PR TITLE
Refactor ApiComposer for simpler logic

### DIFF
--- a/cases/credit_scoring/credit_scoring_problem_multiobj.py
+++ b/cases/credit_scoring/credit_scoring_problem_multiobj.py
@@ -67,7 +67,7 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
 
     # Create builder for composer and set composer params
     builder = ComposerBuilder(task=task).with_requirements(composer_requirements).with_metrics(
-        metrics).with_optimiser(parameters=optimiser_parameters)
+        metrics).with_optimiser_params(parameters=optimiser_parameters)
 
     # Create GP-based composer
     composer = builder.build()

--- a/cases/multi_modal_genre_prediction.py
+++ b/cases/multi_modal_genre_prediction.py
@@ -43,7 +43,7 @@ def run_multi_modal_case(files_path, is_visualise=True, timeout=datetime.timedel
 
     # the multi modal template (with data sources) is passed as initial assumption for composer
     builder = ComposerBuilder(task=task).with_requirements(composer_requirements). \
-        with_metrics(metric_function).with_optimiser(parameters=optimiser_parameters).with_logger(logger=logger). \
+        with_metrics(metric_function).with_optimiser_params(parameters=optimiser_parameters).with_logger(logger=logger). \
         with_initial_pipelines([initial_pipeline]).with_cache('multi_modal_opt.cache')
 
     # Create GP-based composer

--- a/cases/multi_modal_genre_prediction.py
+++ b/cases/multi_modal_genre_prediction.py
@@ -42,9 +42,13 @@ def run_multi_modal_case(files_path, is_visualise=True, timeout=datetime.timedel
     logger = default_log('FEDOT logger', verbose_level=4)
 
     # the multi modal template (with data sources) is passed as initial assumption for composer
-    builder = ComposerBuilder(task=task).with_requirements(composer_requirements). \
-        with_metrics(metric_function).with_optimiser_params(parameters=optimiser_parameters).with_logger(logger=logger). \
-        with_initial_pipelines([initial_pipeline]).with_cache('multi_modal_opt.cache')
+    builder = ComposerBuilder(task=task) \
+        .with_requirements(composer_requirements) \
+        .with_metrics(metric_function) \
+        .with_optimiser_params(parameters=optimiser_parameters) \
+        .with_logger(logger=logger) \
+        .with_initial_pipelines([initial_pipeline]) \
+        .with_cache('multi_modal_opt.cache')
 
     # Create GP-based composer
     composer = builder.build()

--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -51,7 +51,7 @@ class RandomMutationSearchOptimizer(GraphOptimiser):
                     best = new
                 num_iter += 1
 
-        return best.graph
+        return [best.graph]
 
 
 def run_with_random_search_composer():

--- a/examples/advanced/fedot_based_solutions/graph_model_optimization.py
+++ b/examples/advanced/fedot_based_solutions/graph_model_optimization.py
@@ -106,8 +106,8 @@ def run_custom_example(timeout: datetime.timedelta = None):
         log=default_log(logger_name='Bayesian', verbose_level=1))
 
     objective_eval = ObjectiveEvaluate(objective, data=data)
-    optimized_graph = optimiser.optimise(objective_eval)
-    optimized_network = optimiser.graph_generation_params.adapter.restore(optimized_graph)
+    optimized_graphs = optimiser.optimise(objective_eval)
+    optimized_network = optimiser.graph_generation_params.adapter.restore(optimized_graphs[0])
 
     optimized_network.show()
 

--- a/examples/advanced/pipeline_sensitivity.py
+++ b/examples/advanced/pipeline_sensitivity.py
@@ -35,7 +35,7 @@ def get_composed_pipeline(dataset_to_compose, task, metric_function):
 
     # Create builder for composer and set composer params
     builder = ComposerBuilder(task=task).with_requirements(composer_requirements).with_metrics(
-        metric_function).with_optimiser(parameters=optimiser_parameters)
+        metric_function).with_optimiser_params(parameters=optimiser_parameters)
 
     # Create GP-based composer
     composer = builder.build()

--- a/examples/advanced/sensitivity_analysis/pipelines_access.py
+++ b/examples/advanced/sensitivity_analysis/pipelines_access.py
@@ -53,7 +53,7 @@ def get_composed_pipeline(dataset_to_compose, task, metric_function):
 
     # Create builder for composer and set composer params
     builder = ComposerBuilder(task=task).with_requirements(composer_requirements).with_metrics(
-        metric_function).with_optimiser(parameters=optimiser_parameters)
+        metric_function).with_optimiser_params(parameters=optimiser_parameters)
 
     # Create GP-based composer
     composer = builder.build()

--- a/examples/advanced/time_series_forecasting/composing_pipelines.py
+++ b/examples/advanced/time_series_forecasting/composing_pipelines.py
@@ -103,7 +103,7 @@ def run_composing(dataset: str, pipeline: Pipeline, len_forecast=250):
 
     metric_function = MetricsRepository().metric_by_id(RegressionMetricsEnum.RMSE)
     builder = ComposerBuilder(task=task). \
-        with_optimiser(parameters=optimiser_parameters). \
+        with_optimiser_params(parameters=optimiser_parameters). \
         with_requirements(composer_requirements). \
         with_metrics(metric_function).with_initial_pipelines([pipeline])
     composer = builder.build()

--- a/examples/advanced/time_series_forecasting/multi_ts_arctic_forecasting.py
+++ b/examples/advanced/time_series_forecasting/multi_ts_arctic_forecasting.py
@@ -72,7 +72,7 @@ def compose_pipeline(pipeline, train_data, task):
     optimiser_parameters = GPGraphOptimiserParameters(mutation_types=mutation_types)
     metric_function = MetricsRepository().metric_by_id(RegressionMetricsEnum.MAE)
     builder = ComposerBuilder(task=task). \
-        with_optimiser(parameters=optimiser_parameters). \
+        with_optimiser_params(parameters=optimiser_parameters). \
         with_requirements(composer_requirements). \
         with_metrics(metric_function).with_initial_pipelines([pipeline])
     composer = builder.build()

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -197,6 +197,8 @@ class ApiComposer:
 
         if not preset or preset == 'auto':
             preset = change_preset_based_on_initial_fit(init_pipeline_fit_time, timeout)
+            self.preset_name = preset
+            log.info(f"Preset was changed to {preset}")
         available_operations = self._set_available_operations(task, preset, available_operations)
         composer_requirements = self._init_composer_requirements(api_params, composer_params,
                                                                  self.timer.datetime_composing, available_operations)

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -144,7 +144,7 @@ class ApiComposer:
         return composer_requirements
 
     @staticmethod
-    def _init_optimiser_params(task: Task, composer_params: dict) -> GraphOptimiserParameters:
+    def _init_optimiser_params(task: Task, composer_params: dict) -> GPGraphOptimiserParameters:
 
         genetic_scheme_type = GeneticSchemeTypesEnum.parameter_free
         if composer_params['genetic_scheme'] == 'steady_state':

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -193,7 +193,8 @@ class ApiComposer:
                                       logger=log, cache=self.cache, n_jobs=api_params['n_jobs'])
         log.message(f'Initial pipeline was fitted for {init_pipeline_fit_time.total_seconds()} sec.')
 
-        preset = change_preset_based_on_initial_fit(init_pipeline_fit_time, timeout)
+        if not preset or preset == 'auto':
+            preset = change_preset_based_on_initial_fit(init_pipeline_fit_time, timeout)
         available_operations = self._set_available_operations(task, preset, available_operations)
         composer_requirements = self._init_composer_requirements(api_params, composer_params,
                                                                  self.timer.datetime_composing, available_operations)

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -160,7 +160,6 @@ class ApiComposer:
             genetic_scheme_type=genetic_scheme_type,
             mutation_types=mutations,
             crossover_types=[CrossoverTypesEnum.one_point, CrossoverTypesEnum.subtree],
-            history_folder=composer_params.get('history_folder'),
             stopping_after_n_generation=composer_params.get('stopping_after_n_generation')
         )
         return optimiser_parameters
@@ -219,6 +218,7 @@ class ApiComposer:
             .with_optimiser_params(parameters=self._init_optimiser_params(task, composer_params),
                                    external_parameters=composer_params.get('optimizer_external_params')) \
             .with_metrics(metric_function) \
+            .with_history(composer_params.get('history_folder')) \
             .with_logger(log) \
             .with_cache(self.cache)
         gp_composer: GPComposer = builder.build()

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -210,9 +210,9 @@ class ApiComposer:
         builder = ComposerBuilder(task=task) \
             .with_requirements(composer_requirements) \
             .with_initial_pipelines(initial_assumption) \
-            .with_optimiser(optimiser_cls=composer_params.get('optimizer'),
-                            parameters=self._init_optimiser_params(task, composer_params),
-                            external_parameters= composer_params.get('optimizer_external_params')) \
+            .with_optimiser(composer_params.get('optimizer')) \
+            .with_optimiser_params(parameters=self._init_optimiser_params(task, composer_params),
+                                   external_parameters=composer_params.get('optimizer_external_params')) \
             .with_metrics(metric_function) \
             .with_logger(log) \
             .with_cache(self.cache)

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -211,8 +211,8 @@ class ApiComposer:
             .with_requirements(composer_requirements) \
             .with_initial_pipelines(initial_assumption) \
             .with_optimiser(optimiser_cls=composer_params.get('optimizer'),
-                            optimizer_parameters=self._init_optimiser_params(task, composer_params),
-                            optimizer_external_parameters= composer_params.get('optimizer_external_params')) \
+                            parameters=self._init_optimiser_params(task, composer_params),
+                            external_parameters= composer_params.get('optimizer_external_params')) \
             .with_metrics(metric_function) \
             .with_logger(log) \
             .with_cache(self.cache)

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -187,6 +187,8 @@ class ApiComposer:
                 .from_operations(available_operations) \
                 .with_logger(log)
             initial_assumption = assumptions_builder.build()
+        elif isinstance(initial_assumption, Pipeline):
+            initial_assumption = [initial_assumption]
 
         fitted_initial_pipeline, init_pipeline_fit_time = \
             fit_and_check_correctness(initial_assumption[0], train_data,

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -161,7 +161,7 @@ class ApiComposer:
         return optimiser_parameters
 
     def compose_fedot_model(self, api_params: dict, composer_params: dict, tuning_params: dict,
-                            preset: str) -> Tuple[Pipeline, Collection[Pipeline], OptHistory]:
+                            preset: str) -> Tuple[Pipeline, Sequence[Pipeline], OptHistory]:
         """ Function for composing FEDOT pipeline model """
         log = api_params['logger']
         task = api_params['task']
@@ -224,8 +224,7 @@ class ApiComposer:
             with self.timer.launch_composing():
                 log.message(f'Pipeline composition started.')
                 best_pipelines = gp_composer.compose_pipeline(data=train_data)
-                # TODO (gkirgizov): provide best models
-                best_pipeline_candidates = []
+                best_pipeline_candidates = gp_composer.best_models
         else:
             # Use initial pipeline as final solution
             log.message(f'Timeout is too small for composing and is skipped '

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -92,14 +92,8 @@ class OperationsPreset:
 
 def update_builder(builder: ComposerBuilder,
                    composer_requirements: PipelineComposerRequirements,
-                   fit_time: datetime.timedelta,
-                   full_minutes_timeout: Union[int, None], preset: str) -> Tuple[ComposerBuilder, str]:
+                   new_preset: str) -> ComposerBuilder:
     """ Updates the builder if a preset needs to be set automatically """
-    if preset != 'auto':
-        return builder, preset
-
-    # Find appropriate preset
-    new_preset = change_preset_based_on_initial_fit(fit_time, full_minutes_timeout)
 
     preset_manager = OperationsPreset(task=builder.task, preset_name=new_preset)
     new_operations = preset_manager.composer_params_based_on_preset(composer_params={'preset': new_preset})
@@ -107,7 +101,7 @@ def update_builder(builder: ComposerBuilder,
     composer_requirements.primary = new_operations['available_operations']
     composer_requirements.secondary = copy(new_operations['available_operations'])
     builder.with_requirements(composer_requirements)
-    return builder, new_preset
+    return builder
 
 
 def change_preset_based_on_initial_fit(fit_time: datetime.timedelta,

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -1,10 +1,7 @@
 import datetime
 from copy import copy
-from typing import Tuple, Union
+from typing import Union
 
-from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import \
-    PipelineComposerRequirements
 from fedot.core.constants import BEST_QUALITY_PRESET_NAME, \
     FAST_TRAIN_PRESET_NAME, MINIMAL_PIPELINE_NUMBER_FOR_EVALUATION
 from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_operations_for_task
@@ -33,12 +30,12 @@ class OperationsPreset:
             self.preset_name = updated_params['preset']
 
         if self.preset_name is not None and 'available_operations' not in composer_params:
-            available_operations = self._filter_operations_by_preset()
+            available_operations = self.filter_operations_by_preset()
             updated_params['available_operations'] = available_operations
 
         return updated_params
 
-    def _filter_operations_by_preset(self):
+    def filter_operations_by_preset(self):
         """ Filter operations by preset, remove "heavy" operations and save
         appropriate ones
         """
@@ -88,20 +85,6 @@ class OperationsPreset:
         available_operations = [_ for _ in available_operations if _ not in excluded_operations]
 
         return available_operations
-
-
-def update_builder(builder: ComposerBuilder,
-                   composer_requirements: PipelineComposerRequirements,
-                   new_preset: str) -> ComposerBuilder:
-    """ Updates the builder if a preset needs to be set automatically """
-
-    preset_manager = OperationsPreset(task=builder.task, preset_name=new_preset)
-    new_operations = preset_manager.composer_params_based_on_preset(composer_params={'preset': new_preset})
-    # Insert updated operations list into source composer parameters
-    composer_requirements.primary = new_operations['available_operations']
-    composer_requirements.secondary = copy(new_operations['available_operations'])
-    builder.with_requirements(composer_requirements)
-    return builder
 
 
 def change_preset_based_on_initial_fit(fit_time: datetime.timedelta,

--- a/fedot/api/api_utils/presets.py
+++ b/fedot/api/api_utils/presets.py
@@ -39,9 +39,13 @@ class OperationsPreset:
         """ Filter operations by preset, remove "heavy" operations and save
         appropriate ones
         """
+        preset_name = self.preset_name
+        if 'auto' in preset_name:
+            available_operations = get_operations_for_task(self.task, mode='model')
+            return available_operations
+
         # TODO remove workaround
         # Use best_quality preset but exclude several operations
-        preset_name = self.preset_name
         if 'stable' in self.preset_name:
             # Use best_quality preset but exclude several operations
             preset_name = BEST_QUALITY_PRESET_NAME

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -372,6 +372,7 @@ class Fedot:
         self.predict(self.test_data)
 
     def update_params(self, timeout, num_of_generations, initial_assumption):
+        # TODO: remove, unnecessary method
         if initial_assumption is not None:
             self.params.api_params['initial_assumption'] = initial_assumption
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -165,7 +165,7 @@ class Fedot:
                 self.api_composer.obtain_model(**self.params.api_params)
 
         # Final fit for obtained pipeline on full dataset
-        if self.history is not None:
+        if self.history and not self.history.is_empty():
             self._train_pipeline_on_full_dataset(recommendations, full_train_not_preprocessed)
             self.params.api_params['logger'].message('Final pipeline was fitted')
         else:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from inspect import signature
-from typing import List, Optional, Tuple, Union, Collection
+from typing import List, Optional, Tuple, Union, Collection, Sequence
 
 import numpy as np
 import pandas as pd
@@ -130,7 +130,7 @@ class Fedot:
 
         # Outputs
         self.current_pipeline: Optional[Pipeline] = None
-        self.best_models: Collection[Pipeline] = ()
+        self.best_models: Sequence[Pipeline] = ()
         self.history: Optional[OptHistory] = None
 
     def fit(self,

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -165,7 +165,7 @@ class Fedot:
                 self.api_composer.obtain_model(**self.params.api_params)
 
         # Final fit for obtained pipeline on full dataset
-        if self.history and not self.history.is_empty():
+        if self.history and not self.history.is_empty() or not self.current_pipeline.is_fitted:
             self._train_pipeline_on_full_dataset(recommendations, full_train_not_preprocessed)
             self.params.api_params['logger'].message('Final pipeline was fitted')
         else:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -274,6 +274,9 @@ class Fedot:
 
     def plot_pareto(self):
         metric_names = self.params.metric_to_compose
+        # archive_history stores archives of the best models.
+        # Each archive is sorted from the best to the worst model,
+        # so the best_candidates is sorted too.
         best_candidates = self.history.archive_history[-1]
         PipelineEvolutionVisualiser().visualise_pareto(front=best_candidates,
                                                        objectives_names=metric_names,
@@ -373,11 +376,6 @@ class Fedot:
         self.train_data = self.data_processor.define_data(features=self.train_data, is_predict=False)
         self.test_data = self.data_processor.define_data(features=self.test_data, is_predict=True)
         self.predict(self.test_data)
-
-    def update_params(self, timeout, num_of_generations, initial_assumption):
-        # TODO: remove, unnecessary method
-        if initial_assumption is not None:
-            self.params.api_params['initial_assumption'] = initial_assumption
 
     def explain(self, features: FeaturesType = None,
                 method: str = 'surrogate_dt', visualize: bool = True, **kwargs) -> 'Explainer':

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from inspect import signature
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Collection
 
 import numpy as np
 import pandas as pd
@@ -127,8 +127,10 @@ class Fedot:
         self.prediction: Optional[OutputData] = None
         self.train_data: Optional[InputData] = None
         self.test_data: Optional[InputData] = None
+
+        # Outputs
         self.current_pipeline: Optional[Pipeline] = None
-        self.best_models: Optional[HallOfFame] = None
+        self.best_models: Collection[Pipeline] = ()
         self.history: Optional[OptHistory] = None
 
     def fit(self,
@@ -159,8 +161,8 @@ class Fedot:
             # Fit predefined model and return it without composing
             self.current_pipeline = self._process_predefined_model(predefined_model)
         else:
-            self.current_pipeline, self.best_models, self.history = self.api_composer.obtain_model(
-                **self.params.api_params)
+            self.current_pipeline, self.best_models, self.history = \
+                self.api_composer.obtain_model(**self.params.api_params)
 
         # Final fit for obtained pipeline on full dataset
         if self.history is not None:
@@ -272,7 +274,8 @@ class Fedot:
 
     def plot_pareto(self):
         metric_names = self.params.metric_to_compose
-        PipelineEvolutionVisualiser().visualise_pareto(archive=self.best_models,
+        best_candidates = self.history.archive_history[-1]
+        PipelineEvolutionVisualiser().visualise_pareto(front=best_candidates,
                                                        objectives_names=metric_names,
                                                        show=True)
 

--- a/fedot/api/time.py
+++ b/fedot/api/time.py
@@ -1,5 +1,6 @@
 import datetime
 from contextlib import contextmanager
+from typing import Optional
 
 from fedot.core.constants import COMPOSING_TUNING_PROPORTION
 
@@ -68,7 +69,7 @@ class ApiTime:
         return timeout_for_tuning
 
     @property
-    def datetime_composing(self):
+    def datetime_composing(self) -> Optional[datetime.timedelta]:
         if self.timeout_for_composing is None:
             return None
         return datetime.timedelta(minutes=self.timeout_for_composing)

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -4,11 +4,10 @@ from fedot.core.composer.advisor import PipelineChangeAdvisor
 from fedot.core.composer.cache import OperationsCache
 from fedot.core.composer.composer import Composer
 from fedot.core.composer.gp_composer.gp_composer import GPComposer, PipelineComposerRequirements
-from fedot.core.composer.gp_composer.specific_operators import boosting_mutation, parameter_change_mutation
 from fedot.core.log import Log
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.gp_optimiser import EvoGraphOptimiser, GPGraphOptimiserParameters
-from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
+from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.pipelines.pipeline import Pipeline
@@ -98,13 +97,6 @@ class ComposerBuilder:
     def build(self) -> Composer:
         graph_generation_params = GraphGenerationParams(adapter=PipelineAdapter(self.log),
                                                         advisor=PipelineChangeAdvisor())
-
-        if self.optimiser_parameters.mutation_types is None:
-            self.optimiser_parameters.mutation_types = [boosting_mutation, parameter_change_mutation,
-                                                        MutationTypesEnum.single_edge,
-                                                        MutationTypesEnum.single_change,
-                                                        MutationTypesEnum.single_drop,
-                                                        MutationTypesEnum.single_add]
 
         if len(self.metrics) > 1:
             # TODO add possibility of using regularization in MO alg

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -7,10 +7,10 @@ from fedot.core.composer.gp_composer.gp_composer import GPComposer, PipelineComp
 from fedot.core.log import Log
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.gp_optimiser import EvoGraphOptimiser, GPGraphOptimiserParameters
-from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimiser, GraphOptimiserParameters
 from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.pipelines.validation import common_rules, ts_rules
 from fedot.core.repository.operation_types_repository import get_operations_for_task
 from fedot.core.repository.quality_metrics_repository import (
     MetricsEnum,
@@ -95,8 +95,14 @@ class ComposerBuilder:
         return [ComplexityMetricsEnum.node_num]
 
     def build(self) -> Composer:
+        if self.task.task_type is TaskTypesEnum.ts_forecasting:
+            graph_constraint_rules = common_rules + ts_rules
+        else:
+            graph_constraint_rules = common_rules
+
         graph_generation_params = GraphGenerationParams(adapter=PipelineAdapter(self.log),
-                                                        advisor=PipelineChangeAdvisor(self.task))
+                                                        advisor=PipelineChangeAdvisor(self.task),
+                                                        rules_for_constraint=graph_constraint_rules)
 
         if len(self.metrics) > 1:
             # TODO add possibility of using regularization in MO alg

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -42,6 +42,7 @@ class ComposerBuilder:
     def with_optimiser(self, optimiser_cls: Optional[Type[GraphOptimiser]] = None):
         if optimiser_cls is not None:
             self.optimiser_cls = optimiser_cls
+        return self
 
     def with_optimiser_params(self, parameters: Optional[GraphOptimiserParameters] = None,
                               external_parameters: Optional[Dict] = None):
@@ -104,14 +105,14 @@ class ComposerBuilder:
                                                         advisor=PipelineChangeAdvisor(self.task),
                                                         rules_for_constraint=graph_constraint_rules)
 
-        if len(self.metrics) > 1:
+        # if len(self.metrics) > 1:
+        if self.optimiser_parameters.multi_objective:
             # TODO add possibility of using regularization in MO alg
             self.optimiser_parameters.regularization_type = RegularizationTypesEnum.none
-            self.optimiser_parameters.multi_objective = True
+            self.log.info("Regularisation is not supported for multi-objective optimisation.")
         else:
             # Add default complexity metric for supplementary comparison of individuals with equal fitness
             self.metrics = self.metrics + self._get_default_complexity_metrics()
-            self.optimiser_parameters.multi_objective = False
 
         objective = Objective(self.metrics, self.optimiser_parameters.multi_objective, log=self.log)
 

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -40,11 +40,11 @@ class ComposerBuilder:
         self.composer_requirements: PipelineComposerRequirements = self._get_default_composer_params()
         self.metrics: Sequence[MetricsEnum] = self._get_default_quality_metrics(task)
 
-    def with_optimiser(self, optimiser: Optional[GraphOptimiser] = None,
+    def with_optimiser(self, optimiser_cls: Optional[Type[GraphOptimiser]] = None,
                        parameters: Optional[GraphOptimiserParameters] = None,
                        optimizer_external_parameters: Optional[Dict] = None):
-        if optimiser is not None:
-            self.optimiser_cls = optimiser
+        if optimiser_cls is not None:
+            self.optimiser_cls = optimiser_cls
         if parameters is not None:
             self.optimiser_parameters = parameters
         if optimizer_external_parameters is not None:

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -40,11 +40,12 @@ class ComposerBuilder:
         self.composer_requirements: PipelineComposerRequirements = self._get_default_composer_params()
         self.metrics: Sequence[MetricsEnum] = self._get_default_quality_metrics(task)
 
-    def with_optimiser(self, optimiser_cls: Optional[Type[GraphOptimiser]] = None,
-                       parameters: Optional[GraphOptimiserParameters] = None,
-                       external_parameters: Optional[Dict] = None):
+    def with_optimiser(self, optimiser_cls: Optional[Type[GraphOptimiser]] = None):
         if optimiser_cls is not None:
             self.optimiser_cls = optimiser_cls
+
+    def with_optimiser_params(self, parameters: Optional[GraphOptimiserParameters] = None,
+                              external_parameters: Optional[Dict] = None):
         if parameters is not None:
             self.optimiser_parameters = parameters
         if external_parameters is not None:

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -42,13 +42,13 @@ class ComposerBuilder:
 
     def with_optimiser(self, optimiser_cls: Optional[Type[GraphOptimiser]] = None,
                        parameters: Optional[GraphOptimiserParameters] = None,
-                       optimizer_external_parameters: Optional[Dict] = None):
+                       external_parameters: Optional[Dict] = None):
         if optimiser_cls is not None:
             self.optimiser_cls = optimiser_cls
         if parameters is not None:
             self.optimiser_parameters = parameters
-        if optimizer_external_parameters is not None:
-            self.optimizer_external_parameters = optimizer_external_parameters
+        if external_parameters is not None:
+            self.optimizer_external_parameters = external_parameters
         return self
 
     def with_requirements(self, requirements: PipelineComposerRequirements):

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -29,7 +29,7 @@ class ComposerBuilder:
         self.task: Task = task
 
         self.optimiser_cls: Type[GraphOptimiser] = EvoGraphOptimiser
-        self.optimiser_parameters: GraphOptimiserParameters = GPGraphOptimiserParameters()
+        self.optimiser_parameters: GPGraphOptimiserParameters = GPGraphOptimiserParameters()
         self.optimizer_external_parameters: dict = {}
 
         self.composer_cls: Type[Composer] = GPComposer
@@ -105,13 +105,13 @@ class ComposerBuilder:
                                                         advisor=PipelineChangeAdvisor(self.task),
                                                         rules_for_constraint=graph_constraint_rules)
 
-        # if len(self.metrics) > 1:
-        if self.optimiser_parameters.multi_objective:
+        if len(self.metrics) > 1:
             # TODO add possibility of using regularization in MO alg
+            self.optimiser_parameters.multi_objective = True
             self.optimiser_parameters.regularization_type = RegularizationTypesEnum.none
-            self.log.info("Regularisation is not supported for multi-objective optimisation.")
         else:
             # Add default complexity metric for supplementary comparison of individuals with equal fitness
+            self.optimiser_parameters.multi_objective = False
             self.metrics = self.metrics + self._get_default_complexity_metrics()
 
         objective = Objective(self.metrics, self.optimiser_parameters.multi_objective, log=self.log)

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -1,4 +1,6 @@
 from functools import partial
+from multiprocessing import set_start_method
+from sys import platform
 from typing import Optional, Union, List, Dict, Sequence, Type, Iterable
 
 from fedot.core.composer.advisor import PipelineChangeAdvisor
@@ -23,6 +25,12 @@ from fedot.core.repository.quality_metrics_repository import (
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
 from fedot.core.optimisers.objective.objective import Objective
+
+
+def set_multiprocess_start_method():
+    system = platform.system()
+    if system == 'Linux':
+        set_start_method("spawn", force=True)
 
 
 class ComposerBuilder:
@@ -58,6 +66,8 @@ class ComposerBuilder:
 
     def with_requirements(self, requirements: PipelineComposerRequirements):
         self.composer_requirements = requirements
+        if self.composer_requirements.max_pipeline_fit_time:
+            set_multiprocess_start_method()
         return self
 
     def with_metrics(self, metrics: Union[MetricsEnum, List[MetricsEnum]]):

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, List, Dict, Sequence, Type
+from typing import Optional, Union, List, Dict, Sequence, Type, Iterable
 
 from fedot.core.composer.advisor import PipelineChangeAdvisor
 from fedot.core.composer.cache import OperationsCache
@@ -61,11 +61,12 @@ class ComposerBuilder:
 
     def with_initial_pipelines(self, initial_pipelines: Optional[Union[Pipeline, Sequence[Pipeline]]]):
         if isinstance(initial_pipelines, Pipeline):
-            initial_pipelines = [initial_pipelines]
-        elif not isinstance(initial_pipelines, list):
+            self.initial_pipelines = [initial_pipelines]
+        elif isinstance(initial_pipelines, Iterable):
+            self.initial_pipelines = list(initial_pipelines)
+        else:
             raise ValueError(f'Incorrect type of initial_assumption: '
                              f'Sequence[Pipeline] or Pipeline needed, but has {type(initial_pipelines)}')
-        self.initial_pipelines = initial_pipelines
         return self
 
     def with_logger(self, logger):
@@ -95,7 +96,7 @@ class ComposerBuilder:
 
     def build(self) -> Composer:
         graph_generation_params = GraphGenerationParams(adapter=PipelineAdapter(self.log),
-                                                        advisor=PipelineChangeAdvisor())
+                                                        advisor=PipelineChangeAdvisor(self.task))
 
         if len(self.metrics) > 1:
             # TODO add possibility of using regularization in MO alg

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -60,7 +60,6 @@ class ComposerBuilder:
         return self
 
     def with_initial_pipelines(self, initial_pipelines: Optional[Union[Pipeline, Sequence[Pipeline]]]):
-        # TODO (gkirgizov): remove union form optimiser type; handle it here
         if isinstance(initial_pipelines, Pipeline):
             initial_pipelines = [initial_pipelines]
         elif not isinstance(initial_pipelines, list):

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -86,12 +86,6 @@ class GPComposer(Composer):
                                                       cache, logger)
 
     def compose_pipeline(self, data: Union[InputData, MultiModalData]) -> Union[Pipeline, List[Pipeline]]:
-        # TODO: move this late-init logic to the point before optimiser is constructed
-        if data.task.task_type is TaskTypesEnum.ts_forecasting:
-            self.optimiser.graph_generation_params.rules_for_constraint = ts_rules + common_rules
-        else:
-            self.optimiser.graph_generation_params.rules_for_constraint = common_rules
-
         if self.composer_requirements.max_pipeline_fit_time:
             set_multiprocess_start_method()
 

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -1,7 +1,4 @@
-import platform
 from dataclasses import dataclass
-from functools import partial
-from multiprocessing import set_start_method
 from typing import List, Optional, Sequence, Union
 
 from fedot.core.composer.cache import OperationsCache
@@ -12,17 +9,9 @@ from fedot.core.log import Log
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationStrengthEnum
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective.data_objective_builder import DataObjectiveBuilder
-from fedot.core.optimisers.opt_history import OptHistory, log_to_history
+from fedot.core.optimisers.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphOptimiser
 from fedot.core.pipelines.pipeline import Pipeline
-from fedot.core.pipelines.validation import common_rules, ts_rules
-from fedot.core.repository.tasks import TaskTypesEnum
-
-
-def set_multiprocess_start_method():
-    system = platform.system()
-    if system == 'Linux':
-        set_start_method("spawn", force=True)
 
 
 @dataclass
@@ -87,9 +76,6 @@ class GPComposer(Composer):
                                                       cache, logger)
 
     def compose_pipeline(self, data: Union[InputData, MultiModalData]) -> Union[Pipeline, List[Pipeline]]:
-        if self.composer_requirements.max_pipeline_fit_time:
-            set_multiprocess_start_method()
-
         # shuffle data if necessary
         data.shuffle()
 

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -86,8 +86,6 @@ class GPComposer(Composer):
                                                       cache, logger)
 
     def compose_pipeline(self, data: Union[InputData, MultiModalData]) -> Union[Pipeline, List[Pipeline]]:
-        self.optimiser.graph_generation_params.advisor.task = data.task
-
         # TODO: move this late-init logic to the point before optimiser is constructed
         if data.task.task_type is TaskTypesEnum.ts_forecasting:
             self.optimiser.graph_generation_params.rules_for_constraint = ts_rules + common_rules

--- a/fedot/core/composer/random_composer.py
+++ b/fedot/core/composer/random_composer.py
@@ -1,6 +1,6 @@
 from copy import copy
 from random import randint
-from typing import (Any, Callable, List, Optional)
+from typing import (Any, Callable, List, Optional, Sequence)
 
 from numpy import random
 
@@ -28,7 +28,7 @@ class RandomSearchComposer(Composer):
             pipeline.fit(train_data)
             return self.optimiser.objective(pipeline, reference_data=test_data)
 
-        best_pipeline = self.optimiser.optimise(prepared_objective)
+        best_pipeline = self.optimiser.optimise(prepared_objective)[0]
         return best_pipeline
 
 
@@ -82,7 +82,7 @@ class RandomSearchOptimiser(GraphOptimiser):
         self._iter_num = iter_num
         super().__init__(objective)
 
-    def optimise(self, objective: ObjectiveFunction, show_progress: bool = True) -> Pipeline:
+    def optimise(self, objective: ObjectiveFunction, show_progress: bool = True) -> Sequence[Pipeline]:
         best_metric_value = 1000
         best_set = None
         history = []
@@ -98,4 +98,4 @@ class RandomSearchOptimiser(GraphOptimiser):
             if show_progress:
                 self.log.info(f'Iter {i}: best metric {best_metric_value},'
                               f'try {new_metric_value} with num nodes {len(new_pipeline.nodes)}')
-        return best_set
+        return [best_set]

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -34,18 +34,14 @@ from fedot.core.utilities.grouped_condition import GroupedCondition
 
 class GPGraphOptimiserParameters(GraphOptimiserParameters):
     """
-        This class is for defining the parameters of optimiser
+    This class is for defining the parameters of optimiser
 
-        :param selection_types: List of selection operators types
-        :param crossover_types: List of crossover operators types
-        :param mutation_types: List of mutation operators types
-        :param regularization_type: type of regularization operator
-        :param genetic_scheme_type: type of genetic evolutionary scheme
-        :param with_auto_depth_configuration: flag to enable option of automated tree depth configuration during
-        evolution. Default False.
-        :param depth_increase_step: the step of depth increase in automated depth configuration
-        :param multi_objective: flag used for algorithm of type definition (multi-objective if true and single-objective
-        if false). Value is defined in ComposerBuilder. Default False.
+    :param selection_types: List of selection operators types
+    :param crossover_types: List of crossover operators types
+    :param mutation_types: List of mutation operators types
+    :param regularization_type: type of regularization operator
+    :param genetic_scheme_type: type of genetic evolutionary scheme
+    evolution. Default False.
     """
 
     def set_default_params(self):
@@ -188,7 +184,7 @@ class EvoGraphOptimiser(GraphOptimiser):
             ind.ind_num = ind_id
 
     def optimise(self, objective: ObjectiveFunction,
-                 show_progress: bool = True) -> Union[OptGraph, List[OptGraph]]:
+                 show_progress: bool = True) -> Sequence[OptGraph]:
 
         # eval_dispatcher defines how to evaluate objective on the whole population
         evaluator = self.eval_dispatcher.dispatch(objective)
@@ -227,15 +223,8 @@ class EvoGraphOptimiser(GraphOptimiser):
 
                 self._next_population(new_population)
 
-        best = self.generations.best_individuals
-        return self.to_outputs(best)
-
-    def to_outputs(self, individuals: Iterable[Individual]) -> Union[OptGraph, List[OptGraph]]:
-        graphs = [ind.graph for ind in individuals]
-        # for single objective with single result return it directly
-        if not self.objective.is_multi_objective and len(graphs) == 1:
-            return graphs[0]
-        return graphs
+        all_best_graphs = [ind.graph for ind in self.generations.best_individuals]
+        return all_best_graphs
 
     def with_elitism(self, pop_size: int) -> bool:
         if self.objective.is_multi_objective:

--- a/fedot/core/optimisers/gp_comp/gp_optimiser.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimiser.py
@@ -233,12 +233,12 @@ class EvoGraphOptimiser(GraphOptimiser):
     def to_outputs(self, individuals: Iterable[Individual]) -> Union[OptGraph, List[OptGraph]]:
         graphs = [ind.graph for ind in individuals]
         # for single objective with single result return it directly
-        if not self.parameters.multi_objective and len(graphs) == 1:
+        if not self.objective.is_multi_objective and len(graphs) == 1:
             return graphs[0]
         return graphs
 
     def with_elitism(self, pop_size: int) -> bool:
-        if self.parameters.multi_objective:
+        if self.objective.is_multi_objective:
             return False
         else:
             return pop_size >= self._min_population_size_with_elitism

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -34,6 +34,9 @@ class OptHistory:
         self.archive_history: List[List[Individual]] = []
         self.save_folder: Optional[str] = save_folder
 
+    def is_empty(self) -> bool:
+        return not self.individuals
+
     def add_to_history(self, individuals: List[Individual]):
         new_inds = deepcopy(individuals)
         self.individuals.append(new_inds)

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import (Any, Callable, List, Optional, Sequence, Union)
+from typing import (Any, Callable, List, Optional, Union, Sequence, Collection)
 
 from fedot.core.composer.advisor import DefaultChangeAdvisor
 from fedot.core.dag.graph import Graph
@@ -97,12 +97,12 @@ class GraphOptimiser:
 
     @abstractmethod
     def optimise(self, objective: ObjectiveFunction,
-                 show_progress: bool = True) -> Union[OptGraph, List[OptGraph]]:
+                 show_progress: bool = True) -> Sequence[OptGraph]:
         """
         Method for running of optimization using specified algorithm.
         :param objective: objective function that specifies optimization target
         :param show_progress: print output the describes the progress during iterations
-        :return: best graph (or list of graph for multi-objective case)
+        :return: sequence of the best graphs
         """
         pass
 

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -38,7 +38,6 @@ class GraphOptimiserParameters:
         self.with_auto_depth_configuration = with_auto_depth_configuration
         self.depth_increase_step = depth_increase_step
         self.multi_objective = multi_objective
-        self.history_folder = history_folder
         self.stopping_after_n_generation = stopping_after_n_generation
 
 

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -13,6 +13,8 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
+from fedot.core.optimisers.fitness import Fitness
+from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.utilities.requirements_notificator import warn_requirement
 
 try:
@@ -221,29 +223,31 @@ class PipelineEvolutionVisualiser:
         plt.clf()
         plt.close('all')
 
-    def visualise_pareto(self, archive: Sequence[Any],
+    def visualise_pareto(self, front: Sequence[Individual],
                          objectives_numbers: Tuple[int, int] = (0, 1),
                          objectives_names: Sequence[str] = ('ROC-AUC', 'Complexity'),
                          file_name: str = 'result_pareto.png', show: bool = False, save: bool = True,
                          folder: str = f'../../tmp/pareto',
-                         generation_num: int = None, individuals: List[Any] = None, minmax_x: List[float] = None,
+                         generation_num: int = None,
+                         individuals: Sequence[Individual] = None,
+                         minmax_x: List[float] = None,
                          minmax_y: List[float] = None):
 
         pareto_obj_first, pareto_obj_second = [], []
-        for i in range(len(archive)):
-            fit_first = archive[i].fitness.values[objectives_numbers[0]]
+        for ind in front:
+            fit_first = ind.fitness.values[objectives_numbers[0]]
             pareto_obj_first.append(abs(fit_first))
-            fit_second = archive[i].fitness.values[objectives_numbers[1]]
+            fit_second = ind.fitness.values[objectives_numbers[1]]
             pareto_obj_second.append(abs(fit_second))
 
         fig, ax = plt.subplots()
 
         if individuals is not None:
             obj_first, obj_second = [], []
-            for i in range(len(individuals)):
-                fit_first = individuals[i].fitness.values[objectives_numbers[0]]
+            for ind in individuals:
+                fit_first = ind.fitness.values[objectives_numbers[0]]
                 obj_first.append(abs(fit_first))
-                fit_second = individuals[i].fitness.values[objectives_numbers[1]]
+                fit_second = ind.fitness.values[objectives_numbers[1]]
                 obj_second.append(abs(fit_second))
             ax.scatter(obj_first, obj_second, c='green')
 

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -263,7 +263,7 @@ def test_multiobj_for_api():
 
     assert len(prediction) == len(test_data.target)
     assert metric['f1'] > 0
-    assert model.best_models is not None
+    assert model.best_models is not None and len(model.best_models) > 0
 
 
 def test_categorical_preprocessing_unidata():

--- a/test/unit/api/test_presets.py
+++ b/test/unit/api/test_presets.py
@@ -18,10 +18,10 @@ def test_presets_classification():
     available_operations = list(filtered_operations)
 
     preset_best_quality = OperationsPreset(task=task, preset_name='best_quality')
-    operations_for_best_quality = preset_best_quality._filter_operations_by_preset()
+    operations_for_best_quality = preset_best_quality.filter_operations_by_preset()
 
     preset_fast_train = OperationsPreset(task=task, preset_name='fast_train')
-    operations_for_fast_train = preset_fast_train._filter_operations_by_preset()
+    operations_for_fast_train = preset_fast_train.filter_operations_by_preset()
 
     assert len(operations_for_fast_train) < len(operations_for_best_quality) == len(available_operations)
     assert {'dt', 'logit', 'knn'} <= set(operations_for_fast_train)
@@ -33,10 +33,10 @@ def test_presets_regression():
     regr_operations = get_operations_for_task(task=task, mode='all')
 
     preset_best_quality = OperationsPreset(task=task, preset_name='best_quality')
-    operations_for_best_quality = preset_best_quality._filter_operations_by_preset()
+    operations_for_best_quality = preset_best_quality.filter_operations_by_preset()
 
     preset_fast_train = OperationsPreset(task=task, preset_name='fast_train')
-    operations_for_fast_train = preset_fast_train._filter_operations_by_preset()
+    operations_for_fast_train = preset_fast_train.filter_operations_by_preset()
 
     assert len(operations_for_fast_train) < len(operations_for_best_quality) <= len(regr_operations)
     assert {'dtreg', 'lasso', 'ridge', 'linear'} <= set(operations_for_fast_train)

--- a/test/unit/api/test_presets.py
+++ b/test/unit/api/test_presets.py
@@ -65,10 +65,8 @@ def test_auto_preset_converted_correctly():
     data = data_with_binary_features_and_categorical_target()
 
     simple_init_assumption = Pipeline(PrimaryNode('logit'))
-    fedot_model = Fedot(problem='classification', preset='auto',
-                        timeout=0.01, composer_params={'initial_assumption': simple_init_assumption,
-                                                       'pop_size': 500})
+    fedot_model = Fedot(problem='classification', preset='auto', timeout=0.01,
+                        composer_params={'initial_assumption': simple_init_assumption, 'pop_size': 500})
     # API must return initial assumption without composing and tuning (due to population size is too large)
     fedot_model.fit(data)
-    assert fedot_model.history is None
     assert fedot_model.api_composer.preset_name == FAST_TRAIN_PRESET_NAME

--- a/test/unit/composer/test_builder.py
+++ b/test/unit/composer/test_builder.py
@@ -30,7 +30,7 @@ def prepare_builder_with_custom_params(return_all: bool):
 
     builder_with_custom_params = ComposerBuilder(task=task).with_requirements(
         composer_requirements).with_metrics(
-        metric_function).with_optimiser(parameters=optimiser_parameters)
+        metric_function).with_optimiser_params(parameters=optimiser_parameters)
 
     if return_all:
         return builder_with_custom_params, scheme_type, metric_function, task

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -146,7 +146,10 @@ def test_composition_time(data_fixture, request):
         pop_size=2, num_of_generations=5, crossover_prob=0.9,
         mutation_prob=0.9, timeout=datetime.timedelta(minutes=0.000001))
 
-    builder = ComposerBuilder(task).with_requirements(req_terminated_evolution).with_metrics(metric_function)
+    builder = ComposerBuilder(task) \
+        .with_history() \
+        .with_requirements(req_terminated_evolution) \
+        .with_metrics(metric_function)
 
     gp_composer_terminated_evolution = builder.build()
 
@@ -159,7 +162,10 @@ def test_composition_time(data_fixture, request):
         pop_size=2, num_of_generations=2, crossover_prob=0.4,
         mutation_prob=0.5)
 
-    builder = ComposerBuilder(task).with_requirements(req_completed_evolution).with_metrics(metric_function)
+    builder = ComposerBuilder(task) \
+        .with_history() \
+        .with_requirements(req_completed_evolution) \
+        .with_metrics(metric_function)
     gp_composer_completed_evolution = builder.build()
 
     _ = gp_composer_completed_evolution.compose_pipeline(data=data)
@@ -186,8 +192,11 @@ def test_parameter_free_composer_build_pipeline_correct(data_fixture, request):
                                        crossover_prob=0.4, mutation_prob=0.5)
 
     opt_params = GPGraphOptimiserParameters(genetic_scheme_type=GeneticSchemeTypesEnum.parameter_free)
-    builder = ComposerBuilder(task=Task(TaskTypesEnum.classification)).with_requirements(req).with_metrics(
-        metric_function).with_optimiser_params(parameters=opt_params)
+    builder = ComposerBuilder(task=Task(TaskTypesEnum.classification))\
+        .with_history() \
+        .with_requirements(req) \
+        .with_metrics(metric_function) \
+        .with_optimiser_params(parameters=opt_params)
     gp_composer = builder.build()
     pipeline_gp_composed = gp_composer.compose_pipeline(data=dataset_to_compose)
 
@@ -258,8 +267,10 @@ def test_gp_composer_with_start_depth(data_fixture, request):
     scheme_type = GeneticSchemeTypesEnum.steady_state
     optimiser_parameters = GPGraphOptimiserParameters(genetic_scheme_type=scheme_type,
                                                       with_auto_depth_configuration=True)
-    builder = ComposerBuilder(task=Task(TaskTypesEnum.classification)).with_requirements(req).with_metrics(
-        quality_metric).with_optimiser_params(parameters=optimiser_parameters)
+    builder = ComposerBuilder(task=Task(TaskTypesEnum.classification))\
+        .with_history() \
+        .with_requirements(req) \
+        .with_metrics(quality_metric).with_optimiser_params(parameters=optimiser_parameters)
     composer = builder.build()
     composer.compose_pipeline(data=dataset_to_compose)
     assert all([ind.graph.depth <= 3 for ind in composer.history.individuals[0]])

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -187,7 +187,7 @@ def test_parameter_free_composer_build_pipeline_correct(data_fixture, request):
 
     opt_params = GPGraphOptimiserParameters(genetic_scheme_type=GeneticSchemeTypesEnum.parameter_free)
     builder = ComposerBuilder(task=Task(TaskTypesEnum.classification)).with_requirements(req).with_metrics(
-        metric_function).with_optimiser(parameters=opt_params)
+        metric_function).with_optimiser_params(parameters=opt_params)
     gp_composer = builder.build()
     pipeline_gp_composed = gp_composer.compose_pipeline(data=dataset_to_compose)
 
@@ -223,7 +223,7 @@ def test_multi_objective_composer(data_fixture, request):
     optimiser_parameters = GPGraphOptimiserParameters(genetic_scheme_type=scheme_type,
                                                       selection_types=[SelectionTypesEnum.spea2])
     builder = ComposerBuilder(task=Task(TaskTypesEnum.classification)).with_requirements(req).with_metrics(
-        metrics).with_optimiser(parameters=optimiser_parameters)
+        metrics).with_optimiser_params(parameters=optimiser_parameters)
     composer = builder.build()
     pipelines_evo_composed = composer.compose_pipeline(data=dataset_to_compose)
     pipelines_roc_auc = []
@@ -259,7 +259,7 @@ def test_gp_composer_with_start_depth(data_fixture, request):
     optimiser_parameters = GPGraphOptimiserParameters(genetic_scheme_type=scheme_type,
                                                       with_auto_depth_configuration=True)
     builder = ComposerBuilder(task=Task(TaskTypesEnum.classification)).with_requirements(req).with_metrics(
-        quality_metric).with_optimiser(parameters=optimiser_parameters)
+        quality_metric).with_optimiser_params(parameters=optimiser_parameters)
     composer = builder.build()
     composer.compose_pipeline(data=dataset_to_compose)
     assert all([ind.graph.depth <= 3 for ind in composer.history.individuals[0]])
@@ -279,7 +279,7 @@ def test_gp_composer_saving_info_from_process(data_fixture, request):
     scheme_type = GeneticSchemeTypesEnum.steady_state
     optimiser_parameters = GPGraphOptimiserParameters(genetic_scheme_type=scheme_type)
     builder = ComposerBuilder(task=Task(TaskTypesEnum.classification)).with_requirements(req).with_metrics(
-        quality_metric).with_optimiser(parameters=optimiser_parameters).with_cache(OperationsCache())
+        quality_metric).with_optimiser_params(parameters=optimiser_parameters).with_cache(OperationsCache())
     composer = builder.build()
     composer.compose_pipeline(data=dataset_to_compose)
 

--- a/test/unit/optimizer/test_external.py
+++ b/test/unit/optimizer/test_external.py
@@ -32,12 +32,11 @@ class StaticOptimizer(GraphOptimiser):
                  **kwargs):
         super().__init__(objective, initial_graph, requirements, graph_generation_params, parameters, log)
         self.change_types = []
-        self.node_name = kwargs.get('node_name')
+        self.node_name = kwargs.get('node_name') or 'logit'
 
     def optimise(self, objective: ObjectiveFunction, show_progress: bool = True):
-        if self.node_name:
-            return OptGraph(OptNode(self.node_name))
-        return OptGraph(OptNode('logit'))
+        graph = OptGraph(OptNode(self.node_name))
+        return [graph]
 
 
 @pytest.mark.parametrize('data_fixture', ['classification_dataset'])

--- a/test/unit/tasks/test_custom.py
+++ b/test/unit/tasks/test_custom.py
@@ -72,9 +72,8 @@ def test_custom_graph_opt():
         requirements=requirements, initial_graph=None)
 
     objective_eval = ObjectiveEvaluate(objective)
-    optimized_graph = optimiser.optimise(objective_eval)
-
-    optimized_network = optimiser.graph_generation_params.adapter.restore(optimized_graph)
+    optimized_graphs = optimiser.optimise(objective_eval)
+    optimized_network = optimiser.graph_generation_params.adapter.restore(optimized_graphs[0])
 
     assert optimized_network is not None
     assert isinstance(optimized_network, CustomModel)


### PR DESCRIPTION
Many small changes in ApiComposer, mostly for readability and easier parameter passing:
- Simpler passing of initial assumptions
- Better separation between ApiComposer / Composre / ComposerBuilder (ApiComposer & Composer itself previously took some parts that better should be in ComposerBuilder)
- Some simplification of preset logic and code duplication removal
- Some simplification of tuner logic

Important changes in API:
- Optimisers now always return a sorted sequence of the best models (previously it could return 1 model for single-objective optimization, list for multi-objective). Instead, Composer can do that based on the best_models returned by Optimiser.
- API now doesn't have access to archive (HallOfFame) which I see as internal implementation detail. Instead, it has access just to the best_models and to the OptHistory, which actually stores best_individuals for each generation. 
