### PR TITLE
Improve repositories tags consistency

### DIFF
--- a/examples/simple/pipeline_and_history_visualization.py
+++ b/examples/simple/pipeline_and_history_visualization.py
@@ -14,7 +14,7 @@ def run_pipeline_and_history_visualization(with_pipeline_visualization=True):
 
     history.show('fitness_box', pct_best=0.5)
     history.show('operations_kde')
-    history.show('operations_animated_bar', save_path='example_animation.gif', show_fitness=False)
+    history.show('operations_animated_bar', save_path='example_animation.gif', show_fitness=True)
     if with_pipeline_visualization:
         pipeline.show()
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -125,7 +125,7 @@ class OptHistory:
             os.mkdir(path)
 
     def show(self, plot_type: Optional[Union[PlotTypesEnum, str]] = PlotTypesEnum.fitness_box,
-             save_path: Optional[str] = None,
+             save_path: Optional[Union[os.PathLike, str]] = None,
              pct_best: Optional[float] = None, show_fitness: Optional[bool] = True):
         """ Visualizes fitness values or operations used across generations.
 
@@ -152,6 +152,8 @@ class OptHistory:
                 raise ValueError(msg_if_not)
             warnings.warn(msg_if_not, stacklevel=3)
             return False
+
+        print('Visualizing optimization history... It may take some time, depending on the history size.')
 
         if isinstance(plot_type, str):
             try:

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -94,6 +94,40 @@
 				"non-default"
 			],
 			"description": "Preprocessing operations for text classification"
+		},
+		"text_preprocessing_sklearn": {
+			"description": "Text preprocessing sklearn",
+			"forbidden_node_types": "[]",
+			"input_type": "[DataTypesEnum.text]",
+			"output_type": "[DataTypesEnum.table]",
+			"strategies": [
+				"fedot.core.operations.evaluation.text",
+				"SkLearnTextVectorizeStrategy"
+			],
+			"tags": [
+				"text",
+				"nlp",
+				"non-default"
+			],
+			"tasks": "[TaskTypesEnum.classification]"
+		},
+		"text_classification_gensim": {
+			"description": "Text classification",
+			"forbidden_node_types": [
+				"secondary"
+			],
+			"input_type": "[DataTypesEnum.text]",
+			"output_type": "[DataTypesEnum.table]",
+			"strategies": [
+				"fedot.core.operations.evaluation.text",
+				"GensimTextVectorizeStrategy"
+			],
+			"tags": [
+				"text",
+				"nlp",
+				"non-default"
+			],
+			"tasks": "[TaskTypesEnum.classification]"
 		}
 	},
 	"operations": {
@@ -290,6 +324,18 @@
 		"text_clean": {
 			"meta": "text_preprocessing",
 			"tags": ["non_applicable_for_ts"]
+		},
+		"cntvect": {
+			"meta": "text_preprocessing_sklearn",
+			"tags": ["non-default"]
+		},
+		"tfidf": {
+			"meta": "text_preprocessing_sklearn",
+			"tags": ["non-default"]
+		},
+		"word2vec": {
+			"meta": "text_classification_gensim",
+			"tags": ["non-default"]
 		},
 		"decompose": {
 		  "meta": "regression_preprocessing",

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -135,23 +135,23 @@
 			"meta": "data_sources",
 			"input_type": "[DataTypesEnum.image]",
 			"output_type": "[DataTypesEnum.image]",
-			"tags": ["nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
+			"tags": ["data_source_img", "nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
 		},
 		"data_source_text": {
 			"meta": "data_sources",
 			"input_type": "[DataTypesEnum.text]",
 			"output_type": "[DataTypesEnum.text]",
-			"tags": ["nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
+			"tags": ["data_source_text", "nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
 		},
 		"data_source_table": {
 			"meta": "data_sources",
 			"input_type": "[DataTypesEnum.table]",
 			"output_type": "[DataTypesEnum.table]",
-			"tags": ["nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
+			"tags": ["data_source_table", "nans-ignore", "categorical-ignore", "non_applicable_for_ts"]
 		},
 		"data_source_ts": {
 		  "meta": "data_sources",
-		  "tags": ["non_lagged", "non-default", "nans-ignore", "categorical-ignore"],
+		  "tags": ["data_source_ts", "non_lagged", "non-default", "nans-ignore", "categorical-ignore"],
 		  "input_type": "[DataTypesEnum.ts]",
 		  "output_type": "[DataTypesEnum.ts]"
 		},

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -446,6 +446,7 @@
     "custom": {
 		"meta": "custom_model",
 		"tags": [
+          "custom_model",
           "all_purpose",
           "non-default"
         ]

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -91,40 +91,6 @@
       ],
       "tasks": "[TaskTypesEnum.regression, TaskTypesEnum.ts_forecasting]"
     },
-    "text_classification_sklearn": {
-      "description": "Text classification",
-      "forbidden_node_types": [
-        "secondary"
-      ],
-      "input_type": "[DataTypesEnum.text]",
-      "output_type": "[DataTypesEnum.table]",
-      "strategies": [
-        "fedot.core.operations.evaluation.text",
-        "SkLearnTextVectorizeStrategy"
-      ],
-      "tags": [
-        "nlp",
-        "non-default"
-      ],
-      "tasks": "[TaskTypesEnum.classification]"
-    },
-     "text_classification_gensim": {
-      "description": "Text classification",
-      "forbidden_node_types": [
-        "secondary"
-      ],
-      "input_type": "[DataTypesEnum.text]",
-      "output_type": "[DataTypesEnum.table]",
-      "strategies": [
-        "fedot.core.operations.evaluation.text",
-        "GensimTextVectorizeStrategy"
-      ],
-      "tags": [
-        "nlp",
-        "non-default"
-      ],
-      "tasks": "[TaskTypesEnum.classification]"
-    },
     "ts_model": {
       "description": "Implementations of the time series models",
       "input_type": "[DataTypesEnum.ts, DataTypesEnum.multi_ts]",
@@ -215,12 +181,6 @@
         "boosting", "non_multi", "non-default", "non_linear"
       ]
     },
-    "cntvect": {
-      "meta": "text_classification_sklearn",
-      "tags": [
-        "non-default", "text"
-      ]
-    },
     "dt": {
       "meta": "sklearn_class",
       "presets": ["fast_train", "*tree"],
@@ -250,7 +210,8 @@
     },
     "kmeans": {
       "meta": "sklearn_clust",
-      "presets": ["fast_train"]
+      "presets": ["fast_train"],
+      "tags": ["linear"]
     },
     "knn": {
       "meta": "custom_class",
@@ -419,6 +380,7 @@
       "meta": "ts_model",
       "presets": ["fast_train", "ts"],
       "tags": [
+        "non_linear",
         "simple",
         "interpretable",
         "non_lagged"
@@ -429,6 +391,7 @@
       "meta": "ts_model",
       "presets": ["fast_train", "ts"],
       "tags": [
+        "non_linear",
         "simple",
         "interpretable",
         "non_lagged"
@@ -450,25 +413,12 @@
         "non_linear"
       ]
     },
-    "tfidf": {
-      "meta": "text_classification_sklearn",
-      "tags": [
-        "non-default",
-        "text"
-      ]
-    },
     "treg": {
       "meta": "sklearn_regr",
       "presets": ["*tree"],
       "tags": [
         "tree",
         "non_linear"
-      ]
-    },
-    "word2vec": {
-      "meta": "text_classification_gensim",
-      "tags": [
-        "non-default", "text"
       ]
     },
     "xgboost": {

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -113,7 +113,6 @@
         "CustomModelStrategy"
       ],
       "tags": [
-        "all_purpose",
         "non-default"
       ],
       "tasks": "[TaskTypesEnum.regression, TaskTypesEnum.ts_forecasting, TaskTypesEnum.classification, TaskTypesEnum.clustering]"
@@ -447,7 +446,6 @@
 		"meta": "custom_model",
 		"tags": [
           "custom_model",
-          "all_purpose",
           "non-default"
         ]
 	}

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -52,12 +52,11 @@ class OperationTypesRepository:
     its descriptions and metadata"""
 
     __initialized_repositories__ = {}
-
-    DEFAULT_MODEL_TAGS = ['linear', 'non_linear', 'all_purpose']
+    # The later the tag, the higher its priority in case of intersection
+    DEFAULT_MODEL_TAGS = ['linear', 'non_linear', 'custom_model', 'tree', 'boosting', 'ts_model', 'deep']
     DEFAULT_DATA_OPERATION_TAGS = [
         'data_source', 'feature_scaling', 'imputation', 'feature_reduction', 'feature_engineering', 'encoding',
-        'filtering', 'feature_selection', 'ts_to_table', 'smoothing', 'ts_to_ts', 'text', 'decompose',
-        'imbalanced', 'all_purpose'
+        'filtering', 'feature_selection', 'ts_to_table', 'smoothing', 'ts_to_ts', 'text', 'decompose', 'imbalanced'
     ]
 
     __repository_dict__ = {

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -56,7 +56,8 @@ class OperationTypesRepository:
     DEFAULT_MODEL_TAGS = ['linear', 'non_linear', 'custom_model', 'tree', 'boosting', 'ts_model', 'deep']
     DEFAULT_DATA_OPERATION_TAGS = [
         'data_source', 'feature_scaling', 'imputation', 'feature_reduction', 'feature_engineering', 'encoding',
-        'filtering', 'feature_selection', 'ts_to_table', 'smoothing', 'ts_to_ts', 'text', 'decompose', 'imbalanced'
+        'filtering', 'feature_selection', 'ts_to_table', 'smoothing', 'ts_to_ts', 'text', 'decompose', 'imbalanced',
+        'data_source_img', 'data_source_text', 'data_source_table', 'data_source_ts'
     ]
 
     __repository_dict__ = {

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -298,7 +298,7 @@ class OperationTypesRepository:
         """ Finds the first suitable tag for the operation in the repository.
 
         :param operation: name of the operation.
-        :param tags_to_find: list of suitable tags.
+        :param tags_to_find: list of suitable tags. The later the tag, the higher its priority in case of intersection.
         :return: first suitable tag or None.
         """
         tags_to_find = tags_to_find or self.default_tags
@@ -306,7 +306,7 @@ class OperationTypesRepository:
         info = self.operation_info_by_id(operation)
         if info is None:
             return None
-        for tag in tags_to_find:
+        for tag in reversed(tags_to_find):
             if tag in info.tags:
                 return tag
         return None
@@ -319,7 +319,9 @@ def get_opt_node_tag(opt_node: Union[OptNode, str], tags_model: Optional[List[st
 
     :param opt_node: OptNode or its name.
     :param tags_model: tags for OperationTypesRepository('model') to map the history operations.
+        The later the tag, the higher its priority in case of intersection.
     :param tags_data: tags for OperationTypesRepository('data_operation') to map the history operations.
+        The later the tag, the higher its priority in case of intersection.
     :param repos_tags: dictionary mapping OperationTypesRepository with suitable tags. Can be used only if no tags_model
         and tags_data specified.
     :return: first suitable tag or None.

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -53,11 +53,11 @@ class OperationTypesRepository:
 
     __initialized_repositories__ = {}
 
-    DEFAULT_MODEL_TAGS = ['linear', 'non_linear']
+    DEFAULT_MODEL_TAGS = ['linear', 'non_linear', 'all_purpose']
     DEFAULT_DATA_OPERATION_TAGS = [
         'data_source', 'feature_scaling', 'imputation', 'feature_reduction', 'feature_engineering', 'encoding',
         'filtering', 'feature_selection', 'ts_to_table', 'smoothing', 'ts_to_ts', 'text', 'decompose',
-        'imbalanced'
+        'imbalanced', 'all_purpose'
     ]
 
     __repository_dict__ = {
@@ -328,7 +328,7 @@ def get_opt_node_tag(opt_node: Union[OptNode, str], tags_model: Optional[List[st
     if (tags_model or tags_data) and repos_tags:
         raise ValueError('Parameter repos_tags can not be set with any of these parameters: tags_model, tags_data.')
 
-    node_name = opt_node.content['name'] if isinstance(opt_node, OptNode) else opt_node
+    node_name = str(opt_node) if isinstance(opt_node, OptNode) else opt_node
 
     repos_tags = repos_tags or {
         OperationTypesRepository('model'): tags_model,

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -6,7 +6,7 @@ from glob import glob
 from os import remove
 from pathlib import Path
 from time import time
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -349,6 +349,18 @@ class PipelineEvolutionVisualiser:
 
         return df_history
 
+    @staticmethod
+    def __show_or_save_figure(figure: plt.Figure, save_path: Optional[Union[os.PathLike, str]]):
+        if not save_path:
+            figure.show()
+        else:
+            save_path = Path(save_path)
+            if not save_path.is_absolute():
+                save_path = Path(os.getcwd(), save_path)
+            figure.savefig(save_path, dpi=300)
+            print(f'The figure was saved to "{save_path}".')
+            plt.close()
+
     def visualise_fitness_box(self, history: 'OptHistory', save_path: Optional[str] = None,
                               pct_best: Optional[float] = None):
         """ Visualizes fitness values across generations in the form of boxplot.
@@ -383,17 +395,9 @@ class PipelineEvolutionVisualiser:
         ax.set_ylabel(f'Fitness of {str_fraction_of_pipelines} generation pipelines')
         ax.yaxis.grid(True)
 
-        if not save_path:
-            plt.show()
-        else:
-            save_path = Path(save_path)
-            if not save_path.is_absolute():
-                save_path = Path(os.getcwd(), save_path)
-            fig.savefig(save_path, dpi=300)
-            print(f'The figure was saved to "{save_path}".')
-            plt.close()
+        self.__show_or_save_figure(fig, save_path)
 
-    def visualize_operations_kde(self, history: 'OptHistory', save_path: Optional[str] = None,
+    def visualize_operations_kde(self, history: 'OptHistory', save_path: Optional[Union[os.PathLike, str]] = None,
                                  tags_model: Optional[List[str]] = None, tags_data: Optional[List[str]] = None,
                                  pct_best: Optional[float] = None):
         """ Visualizes operations used across generations in the form of KDE.
@@ -436,19 +440,10 @@ class PipelineEvolutionVisualiser:
         ax = plt.gca()
         str_fraction_of_pipelines = 'all' if pct_best is None else f'top {pct_best * 100}% of'
         ax.set_ylabel(f'Fraction in {str_fraction_of_pipelines} generation pipelines')
-        # ax.legend()
-        # plt.tight_layout()
 
-        if save_path:
-            save_path = Path(save_path)
-            if not save_path.is_absolute():
-                save_path = Path(os.getcwd(), save_path)
+        self.__show_or_save_figure(fig, save_path)
 
-            fig.savefig(save_path, dpi=300)
-            print(f'The figure was saved to "{save_path}".')
-            plt.close()
-
-    def visualize_operations_animated_bar(self, history: 'OptHistory', save_path: str,
+    def visualize_operations_animated_bar(self, history: 'OptHistory', save_path: Union[os.PathLike, str],
                                           tags_model: Optional[List[str]] = None,
                                           tags_data: Optional[List[str]] = None,
                                           pct_best: Optional[float] = None, show_fitness_color: bool = True):

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -402,7 +402,9 @@ class PipelineEvolutionVisualiser:
         :param save_path: path to save the visualization. If set, then the image will be saved,
             and if not, it will be displayed.
         :param tags_model: tags for OperationTypesRepository('model') to map the history operations.
+            The later the tag, the higher its priority in case of intersection.
         :param tags_data: tags for OperationTypesRepository('data_operation') to map the history operations.
+            The later the tag, the higher its priority in case of intersection.
         :param pct_best: fraction of the best individuals of each generation that included in the visualization.
             Must be in the interval (0, 1].
         """
@@ -455,7 +457,9 @@ class PipelineEvolutionVisualiser:
         :param history: OptHistory.
         :param save_path: path to save the visualization.
         :param tags_model: tags for OperationTypesRepository('model') to map the history operations.
+            The later the tag, the higher its priority in case of intersection.
         :param tags_data: tags for OperationTypesRepository('data_operation') to map the history operations.
+            The later the tag, the higher its priority in case of intersection.
         :param pct_best: fraction of the best individuals of each generation that included in the visualization.
             Must be in the interval (0, 1].
         :param show_fitness_color: if False, the bar colors will not correspond to fitness.

--- a/test/data/model_repository.json
+++ b/test/data/model_repository.json
@@ -70,7 +70,7 @@
 		"input_type": "[DataTypesEnum.ts, DataTypesEnum.table, DataTypesEnum.text]",
 		"output_type": "[DataTypesEnum.table]",
 		"strategies": ["fedot.core.operations.evaluation.custom","CustomModelStrategy"],
-		"tags": ["all_purpose", "non-default"],
+		"tags": ["non-default"],
 		"tasks": "[TaskTypesEnum.regression, TaskTypesEnum.ts_forecasting, TaskTypesEnum.classification, TaskTypesEnum.clustering]"
 	}
   },
@@ -178,7 +178,7 @@
 	},
     "custom": {
 		"meta": "custom_model",
-		"tags": ["all_purpose", "non-default"]
+		"tags": ["non-default"]
 	},
 	"xgboost": {
       "meta": "sklearn_class",

--- a/test/data/model_repository.json
+++ b/test/data/model_repository.json
@@ -176,10 +176,6 @@
 	  "meta": "sklearn_class",
 	  "tags": ["bayesian", "non-default"]
 	},
-    "tfidf": {
-      "meta": "text_classification",
-	  "tags": ["text", "non-default"]
-    },
     "custom": {
 		"meta": "custom_model",
 		"tags": ["all_purpose", "non-default"]

--- a/test/data/model_repository.json
+++ b/test/data/model_repository.json
@@ -178,7 +178,7 @@
 	},
     "custom": {
 		"meta": "custom_model",
-		"tags": ["all_purpose", "non-default"]
+		"tags": ["custom_model", "all_purpose", "non-default"]
 	},
 	"xgboost": {
       "meta": "sklearn_class",

--- a/test/data/model_repository.json
+++ b/test/data/model_repository.json
@@ -178,7 +178,7 @@
 	},
     "custom": {
 		"meta": "custom_model",
-		"tags": ["custom_model", "all_purpose", "non-default"]
+		"tags": ["all_purpose", "non-default"]
 	},
 	"xgboost": {
       "meta": "sklearn_class",

--- a/test/unit/models/test_repository.py
+++ b/test/unit/models/test_repository.py
@@ -95,3 +95,13 @@ def test_operation_types_repository_repr():
     repository = OperationTypesRepository().assign_repo('model', 'model_repository.json')
 
     assert repository.__repr__() == 'OperationTypesRepository for model_repository.json'
+
+
+def test_repositories_tags_consistency():
+    errors_found = []
+    for repository in (OperationTypesRepository('model'), OperationTypesRepository('data_operation')):
+        for operation in repository.operations:
+            if repository.get_first_suitable_operation_tag(operation.id) is None:
+                errors_found.append(f'{operation.id} in {repository} has no proper default tags!')
+
+    assert not errors_found, '\n'.join(errors_found)


### PR DESCRIPTION
It is hard to track consistency of tags in repositories.
The new test will help developers to maintain this consistency.

Changelist:
* Added test asserting that all operations have informative tags from ones listed in `OperationTypesRepository`;
* Moved text preprocessing tools from models repository to data operations repository;
* Added new default tags;
* Default tags are now prioritized in reversed way;
* Minor fix of `OptHistory` visualization.