### PR TITLE
Abstract RemoteEvaluator for any Serializable Graph

### DIFF
--- a/examples/advanced/automl/h2o_example.py
+++ b/examples/advanced/automl/h2o_example.py
@@ -41,8 +41,7 @@ def export_h2o(pipeline, pipeline_path, test_data):
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     results = new_pipeline.predict(input_data=test_data, output_mode="full_probs")
     prediction_after_export = results.predict[:, 0]

--- a/examples/advanced/automl/tpot_example.py
+++ b/examples/advanced/automl/tpot_example.py
@@ -53,8 +53,7 @@ def tpot_classification_pipeline_evaluation():
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     predicted_output_after_export = new_pipeline.predict(test_data, output_mode="full_probs")
     prediction_after_export = predicted_output_after_export.predict[:, 0]
@@ -85,8 +84,7 @@ def tpot_regression_pipeline_evaluation():
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     predicted_output_after_export = new_pipeline.predict(test_data)
     prediction_after_export = predicted_output_after_export.predict[:4]
@@ -112,8 +110,7 @@ def tpot_ts_pipeline_evaluation():
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     predicted_output_after_export = new_pipeline.predict(test_data)
     prediction_after_export = predicted_output_after_export.predict[:4]

--- a/examples/advanced/remote_execution/remote_fit_example.py
+++ b/examples/advanced/remote_execution/remote_fit_example.py
@@ -58,6 +58,6 @@ evaluator.init(
 )
 
 pipelines = [Pipeline(PrimaryNode('rf'))] * num_parallel
-fitted_pipelines = evaluator.compute_pipelines(pipelines)
+fitted_pipelines = evaluator.compute_graphs(pipelines)
 
 [print(p.is_fitted) for p in fitted_pipelines]

--- a/examples/advanced/sensitivity_analysis/pipeline_export_with_sa.py
+++ b/examples/advanced/sensitivity_analysis/pipeline_export_with_sa.py
@@ -45,8 +45,7 @@ def run_import_export_example(pipeline_path):
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     predicted_output_after_export = new_pipeline.predict(test_data)
     prediction_after_export = np.array(predicted_output_after_export.predict)

--- a/examples/simple/pipeline_import_export.py
+++ b/examples/simple/pipeline_import_export.py
@@ -63,8 +63,7 @@ def run_import_export_example(pipeline_path, pipeline):
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     predicted_output_after_export = new_pipeline.predict(predict_input)
     prediction_after_export = np.array(predicted_output_after_export.predict)
@@ -73,8 +72,7 @@ def run_import_export_example(pipeline_path, pipeline):
 
     dict_pipeline, dict_fitted_operations = pipeline.save()
     dict_pipeline = json.loads(dict_pipeline)
-    pipeline_from_dict = Pipeline()
-    pipeline_from_dict.load(dict_pipeline, dict_fitted_operations)
+    pipeline_from_dict = Pipeline.from_serialized(dict_pipeline, dict_fitted_operations)
 
     predicted_output = pipeline_from_dict.predict(predict_input)
     prediction = np.array(predicted_output.predict)

--- a/examples/simple/time_series_forecasting/clstm.py
+++ b/examples/simple/time_series_forecasting/clstm.py
@@ -69,8 +69,7 @@ def clstm_forecasting():
 
     # Import pipeline
     json_path_load = create_correct_path(pipeline_path)
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
 
     predicted_output_after_export = new_pipeline.predict(test_data)
     prediction_after_export = np.array(predicted_output_after_export.predict[0])
@@ -79,8 +78,7 @@ def clstm_forecasting():
 
     dict_pipeline, dict_fitted_operations = pipeline.save()
     dict_pipeline = json.loads(dict_pipeline)
-    pipeline_from_dict = Pipeline()
-    pipeline_from_dict.load(dict_pipeline, dict_fitted_operations)
+    pipeline_from_dict = Pipeline.from_serialized(dict_pipeline, dict_fitted_operations)
 
     predicted_output = pipeline_from_dict.predict(test_data)
     prediction = np.array(predicted_output.predict[0])

--- a/fedot/core/operations/atomized_template.py
+++ b/fedot/core/operations/atomized_template.py
@@ -18,8 +18,7 @@ class AtomizedModelTemplate(OperationTemplateAbstract):
         self.pipeline_template = None
 
         if path:
-            pipeline = Pipeline()
-            pipeline.load(path)
+            pipeline = Pipeline.from_serialized(path)
             self.next_pipeline_template = AtomizedModel(pipeline)
             self.pipeline_template = PipelineTemplate(pipeline)
 

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -14,6 +14,7 @@ from fedot.core.optimisers.gp_comp.operators.operator import EvaluationOperator,
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction
 from fedot.core.optimisers.timer import Timer, get_forever_timer
+from fedot.core.pipelines.verification import verifier_for_task
 from fedot.remote.remote_evaluator import RemoteEvaluator
 
 
@@ -132,7 +133,8 @@ class MultiprocessingDispatcher(ObjectiveEvaluationDispatcher):
         if fitter.use_remote:
             self.logger.info('Remote fit used')
             restored_graphs = [self._graph_adapter.restore(ind.graph) for ind in population]
-            computed_pipelines = fitter.compute_graphs(restored_graphs)
+            verifier = verifier_for_task(task_type=None, adapter=self._graph_adapter)
+            computed_pipelines = fitter.compute_graphs(restored_graphs, verifier)
             self.evaluation_cache = {ind.uid: graph for ind, graph in zip(population, computed_pipelines)}
 
 

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -132,7 +132,7 @@ class MultiprocessingDispatcher(ObjectiveEvaluationDispatcher):
         if fitter.use_remote:
             self.logger.info('Remote fit used')
             restored_graphs = [self._graph_adapter.restore(ind.graph) for ind in population]
-            computed_pipelines = fitter.compute_pipelines(restored_graphs)
+            computed_pipelines = fitter.compute_graphs(restored_graphs)
             self.evaluation_cache = {ind.uid: graph for ind, graph in zip(population, computed_pipelines)}
 
 

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -19,12 +19,13 @@ from fedot.core.pipelines.node import Node, PrimaryNode, SecondaryNode
 from fedot.core.pipelines.template import PipelineTemplate
 from fedot.core.pipelines.tuning.unified import PipelineTuner
 from fedot.core.repository.tasks import TaskTypesEnum
+from fedot.core.utilities.serializable import Serializable
 from fedot.preprocessing.preprocessing import DataPreprocessor, update_indices_for_time_series
 
 ERROR_PREFIX = 'Invalid pipeline configuration:'
 
 
-class Pipeline(Graph):
+class Pipeline(Graph, Serializable):
     """
     Base class used for composite model structure definition
 
@@ -39,11 +40,6 @@ class Pipeline(Graph):
         self.preprocessor = DataPreprocessor()
         super().__init__(nodes)
         self.operator = GraphOperator(self, self._graph_nodes_to_pipeline_nodes)
-
-    @classmethod
-    def from_serialized(cls, source: Union[str, dict], dict_fitted_operations: dict = None):
-        default_instance = cls()
-        return default_instance.load(source, dict_fitted_operations)
 
     def _graph_nodes_to_pipeline_nodes(self, nodes: List[Node] = None):
         """Method to update nodes types after performing some action on the pipeline
@@ -270,7 +266,7 @@ class Pipeline(Graph):
         :return: json containing a composite operation description
         """
         template = PipelineTemplate(self)
-        json_object, dict_fitted_operations = self.template.export_pipeline(path, root_node=self.root_node,
+        json_object, dict_fitted_operations = template.export_pipeline(path, root_node=self.root_node,
                                                                             datetime_in_path=datetime_in_path)
         return json_object, dict_fitted_operations
 

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -33,7 +33,6 @@ class Pipeline(Graph):
 
     def __init__(self, nodes: Optional[Union[Node, List[Node]]] = None):
         self.computation_time = None
-        self.template = None
         self.log = default_log(self)
 
         # Define data preprocessor
@@ -270,7 +269,7 @@ class Pipeline(Graph):
         :param datetime_in_path flag for addition of the datetime stamp to saving path
         :return: json containing a composite operation description
         """
-        self.template = PipelineTemplate(self)
+        template = PipelineTemplate(self)
         json_object, dict_fitted_operations = self.template.export_pipeline(path, root_node=self.root_node,
                                                                             datetime_in_path=datetime_in_path)
         return json_object, dict_fitted_operations
@@ -283,8 +282,8 @@ class Pipeline(Graph):
         :param dict_fitted_operations dictionary of the fitted operations
         """
         self.nodes = []
-        self.template = PipelineTemplate(self)
-        self.template.import_pipeline(source, dict_fitted_operations)
+        template = PipelineTemplate(self)
+        template.import_pipeline(source, dict_fitted_operations)
 
     def __eq__(self, other) -> bool:
         return self.root_node.descriptive_id == other.root_node.descriptive_id

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -41,6 +41,11 @@ class Pipeline(Graph):
         super().__init__(nodes)
         self.operator = GraphOperator(self, self._graph_nodes_to_pipeline_nodes)
 
+    @classmethod
+    def from_serialized(cls, source: Union[str, dict], dict_fitted_operations: dict = None):
+        default_instance = cls()
+        return default_instance.load(source, dict_fitted_operations)
+
     def _graph_nodes_to_pipeline_nodes(self, nodes: List[Node] = None):
         """Method to update nodes types after performing some action on the pipeline
         via GraphOperator, if any of them are GraphNode type"""

--- a/fedot/core/pipelines/template.py
+++ b/fedot/core/pipelines/template.py
@@ -59,7 +59,7 @@ class PipelineTemplate:
     def _pipeline_to_template(self, pipeline):
         try:
             # TODO improve for graph with several roots
-            self._extract_pipeline_structure(ensure_wrapped_in_sequence(pipeline.root_node)[0], 0, [])
+            self._extract_pipeline_structure(pipeline.root_node, 0, [])
         except Exception as ex:
             self.log.info(f'Cannot export to template: {ex}')
         self.link_to_empty_pipeline = pipeline

--- a/fedot/core/utilities/serializable.py
+++ b/fedot/core/utilities/serializable.py
@@ -7,6 +7,9 @@ class Serializable(ABC):
 
     @classmethod
     def from_serialized(cls, source: Union[str, dict], internal_state_data: Optional[dict] = None):
+        """
+        Static constructor for convenience. Creates default instance and calls .load() on it.
+        """
         default_instance = cls()
         default_instance.load(source, internal_state_data)
         return default_instance

--- a/fedot/core/utilities/serializable.py
+++ b/fedot/core/utilities/serializable.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+from typing import Tuple, Union, Optional
+
+
+class Serializable(ABC):
+
+    @classmethod
+    def from_serialized(cls, source: Union[str, dict], internal_state_data: Optional[dict] = None):
+        default_instance = cls()
+        default_instance.load(source, internal_state_data)
+        return default_instance
+
+    @abstractmethod
+    def save(self, path: str = None, datetime_in_path: bool = True) -> Tuple[str, dict]:
+        """
+        Save the graph to a json representation
+        with pickled custom data (e.g. fitted models).
+
+        :param path: path to json file with operation
+        :param datetime_in_path: flag for addition of the datetime stamp to saving path
+        :return: json containing a composite operation description
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def load(self, source: Union[str, dict], internal_state_data: Optional[dict] = None):
+        """
+        Load the graph from json representation, optionally
+        with pickled custom internal data (e.g. fitted models).
+
+        :param source: path to json file with operation or json dictionary itself
+        :param internal_state_data: dictionary of the internal state
+        """
+        raise NotImplementedError()

--- a/fedot/remote/infrastructure/clients/client.py
+++ b/fedot/remote/infrastructure/clients/client.py
@@ -1,8 +1,13 @@
 import os
-from typing import Optional
+from datetime import timedelta
+from typing import Optional, Type, TypeVar
 
 from fedot.core.log import default_log
+from fedot.core.utilities.serializable import Serializable
 from fedot.core.utils import default_fedot_data_dir
+
+
+G = TypeVar('G', bound=Serializable)
 
 
 class Client:
@@ -22,7 +27,7 @@ class Client:
             os.path.join(default_fedot_data_dir(), 'remote_fit_results')
         self._logger = default_log(prefix='ClientLog')
 
-    def create_task(self, config):
+    def create_task(self, config: dict):
         """
         Create task for execution
         :param config - configuration of pipeline fitting
@@ -30,16 +35,17 @@ class Client:
         """
         raise NotImplementedError()
 
-    def wait_until_ready(self) -> float:
+    def wait_until_ready(self) -> timedelta:
         """
         Delay execution until all remote tasks are ready
         :return: waiting time
         """
         raise NotImplementedError()
 
-    def download_result(self, execution_id):
+    def download_result(self, execution_id: int, result_cls: Type[G]) -> G:
         """
         :param execution_id: id of remote task
+        :param result_cls: result
         :return: fitted pipeline downloaded from the remote server
         """
         raise NotImplementedError()

--- a/fedot/remote/infrastructure/clients/datamall_client.py
+++ b/fedot/remote/infrastructure/clients/datamall_client.py
@@ -230,9 +230,8 @@ class DataMallClient(Client):
                                         f'execution-{execution_id}',
                                         'out')
         results_folder = os.listdir(results_path_out)[0]
-        pipeline = Pipeline()
-        pipeline.load(os.path.join(results_path_out, results_folder,
-                                   'fitted_pipeline.json'))
+        pipeline = Pipeline.from_serialized(os.path.join(results_path_out, results_folder,
+                                            'fitted_pipeline.json'))
 
         clean_dir(results_path_out)
         return pipeline

--- a/fedot/remote/infrastructure/clients/test_client.py
+++ b/fedot/remote/infrastructure/clients/test_client.py
@@ -27,6 +27,5 @@ class TestClient(Client):
     def download_result(self, execution_id: int):
         results_path_out = os.path.join(self.output_path)
         results_folder = os.listdir(results_path_out)[0]
-        pipeline = Pipeline()
-        pipeline.load(os.path.join(results_path_out, results_folder, 'fitted_pipeline.json'))
+        pipeline = Pipeline.from_serialized(os.path.join(results_path_out, results_folder, 'fitted_pipeline.json'))
         return pipeline

--- a/fedot/remote/infrastructure/clients/test_client.py
+++ b/fedot/remote/infrastructure/clients/test_client.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 from typing import Optional
 from uuid import uuid4
 
@@ -21,11 +22,11 @@ class TestClient(Client):
         fit_pipeline(config)
         return str(uuid4())
 
-    def wait_until_ready(self):
-        return 0
+    def wait_until_ready(self) -> timedelta:
+        return timedelta()
 
-    def download_result(self, execution_id: int):
+    def download_result(self, execution_id: int, result_cls=Pipeline) -> Pipeline:
         results_path_out = os.path.join(self.output_path)
         results_folder = os.listdir(results_path_out)[0]
-        pipeline = Pipeline.from_serialized(os.path.join(results_path_out, results_folder, 'fitted_pipeline.json'))
+        pipeline = result_cls.from_serialized(os.path.join(results_path_out, results_folder, 'fitted_pipeline.json'))
         return pipeline

--- a/fedot/remote/infrastructure/clients/test_client.py
+++ b/fedot/remote/infrastructure/clients/test_client.py
@@ -1,6 +1,6 @@
 import os
 from datetime import timedelta
-from typing import Optional
+from typing import Optional, Callable
 from uuid import uuid4
 
 from fedot.core.pipelines.pipeline import Pipeline
@@ -15,7 +15,6 @@ class TestClient(Client):
         self.exec_params = exec_params
         self.output_path = output_path if output_path else \
             os.path.join(default_fedot_data_dir(), 'remote_fit_results')
-        self.pipelines = []
         super().__init__(connect_params, exec_params, output_path)
 
     def create_task(self, config) -> str:

--- a/fedot/remote/remote_evaluator.py
+++ b/fedot/remote/remote_evaluator.py
@@ -95,9 +95,7 @@ class RemoteEvaluator:
                 task_id = execution_ids.get(id(pipeline), None)
                 if task_id:
                     try:
-                        pipelines_part[p_id] = client.download_result(
-                            execution_id=task_id
-                        )
+                        pipelines_part[p_id] = client.download_result(task_id)
                     except Exception as ex:
                         self._logger.warning(f'{p_id}, {ex}')
             final_pipelines.extend(pipelines_part)

--- a/fedot/remote/run_pipeline.py
+++ b/fedot/remote/run_pipeline.py
@@ -81,8 +81,7 @@ def fit_pipeline(config_file: Union[str, bytes]) -> bool:
 
 def pipeline_from_json(json_str: str):
     json_dict = json.loads(json_str)
-    pipeline = Pipeline()
-    pipeline.load(json_dict)
+    pipeline = Pipeline.from_serialized(json_dict)
 
     return pipeline
 

--- a/fedot/utilities/project_import_export.py
+++ b/fedot/utilities/project_import_export.py
@@ -77,8 +77,7 @@ def import_project_from_zip(zip_path: str) -> Tuple[Pipeline, InputData, InputDa
     for root, dirs, files in os.walk(folder_path):
         for file in files:
             if file == 'pipeline.json':
-                pipeline = Pipeline()
-                pipeline.load(os.path.join(root, file))
+                pipeline = Pipeline.from_serialized(os.path.join(root, file))
             elif file == 'train_data.csv':
                 train_data = InputData.from_csv(os.path.join(root, file))
             elif file == 'test_data.csv':

--- a/test/unit/models/test_atomized_model.py
+++ b/test/unit/models/test_atomized_model.py
@@ -115,8 +115,7 @@ def test_save_load_atomized_pipeline_correctly():
     with open(json_path_load, 'r') as json_file:
         json_expected = json.load(json_file)
 
-    pipeline_loaded = Pipeline()
-    pipeline_loaded.load(json_path_load)
+    pipeline_loaded = Pipeline.from_serialized(json_path_load)
 
     assert pipeline.length == pipeline_loaded.length
     assert json_actual == json.dumps(json_expected, indent=4)
@@ -133,8 +132,7 @@ def test_save_load_fitted_atomized_pipeline_correctly():
 
     json_path_load = create_correct_path('test_save_load_fitted_atomized_pipeline_correctly')
 
-    pipeline_loaded = Pipeline()
-    pipeline_loaded.load(json_path_load)
+    pipeline_loaded = Pipeline.from_serialized(json_path_load)
     json_expected, _ = pipeline_loaded.save('test_save_load_fitted_atomized_pipeline_correctly_loaded')
 
     assert pipeline.length == pipeline_loaded.length

--- a/test/unit/models/test_custom_model_introduction.py
+++ b/test/unit/models/test_custom_model_introduction.py
@@ -193,8 +193,7 @@ def test_save_pipeline_with_custom():
 
     pipeline.save(path='test_pipeline')
     json_path_load = create_correct_path('test_pipeline')
-    new_pipeline = Pipeline()
-    new_pipeline.load(json_path_load)
+    new_pipeline = Pipeline.from_serialized(json_path_load)
     predicted_output_after_export = new_pipeline.predict(predict_input)
     prediction_after_export = np.array(predicted_output_after_export.predict)
 

--- a/test/unit/remote/test_remote_custom.py
+++ b/test/unit/remote/test_remote_custom.py
@@ -1,0 +1,91 @@
+import json
+import uuid
+from datetime import timedelta
+from typing import Tuple, Union, Optional, Sequence
+import pytest
+
+from fedot.core.utilities.serializable import Serializable
+from fedot.remote.infrastructure.clients.client import Client
+from fedot.remote.remote_evaluator import RemoteEvaluator, RemoteTaskParams
+
+
+class MockSerializableGraph(Serializable):
+
+    def __init__(self, evaluated: bool = False):
+        self.evaluated = evaluated
+        self.id = str(uuid.uuid4())
+
+    def evaluate(self):
+        self.evaluated = True
+
+    def save(self, path: str = None, datetime_in_path: bool = True) -> Tuple[str, dict]:
+        data = {'evaluated': self.evaluated, 'id': self.id}
+        saved = json.dumps(data)
+        return saved, {}
+
+    def load(self, source: Union[str, dict], internal_state_data: Optional[dict] = None):
+        data = json.loads(source)
+        self.__dict__.update(data)
+
+
+class TestLocalClient(Client):
+    def __init__(self):
+        self.graphs = []
+        super().__init__(connect_params={}, exec_params={}, output_path=None)
+
+    def create_task(self, config):
+        # here config is just a json dump of the graph
+        graph = MockSerializableGraph.from_serialized(config)
+        graph.evaluate()
+        dumped = graph.save()
+
+        task_id = str(len(self.graphs))
+        self.graphs.append(dumped)
+        return task_id
+
+    def wait_until_ready(self) -> timedelta:
+        return timedelta()
+
+    def download_result(self, execution_id: str, result_cls=MockSerializableGraph) -> MockSerializableGraph:
+        index = int(execution_id)
+        graph_json, additional_data = self.graphs[index]
+        graph = MockSerializableGraph.from_serialized(graph_json, additional_data)
+        return graph
+
+
+def mock_config(graph_json, *args, **kwargs):
+    return graph_json
+
+
+@pytest.fixture(autouse=True)
+def init_remote_evaluator():
+    # runs around tests thanks to 'yield'
+
+    evaluator = RemoteEvaluator()
+    evaluator.init(TestLocalClient(), RemoteTaskParams(mode='remote'), mock_config)
+
+    # marks the ned of test startup and beginning of test shutdown
+    yield
+
+    # return evaluator to local mode
+    evaluator = RemoteEvaluator()
+    evaluator.init(None, RemoteTaskParams(mode='local'))
+
+
+def get_many_graphs(number: int = 1) -> Sequence[MockSerializableGraph]:
+    graphs = []
+    for i in range(number):
+        graphs.append(MockSerializableGraph())
+    return graphs
+
+
+@pytest.mark.parametrize('num_of_graphs', [0, 1, 2, 10])
+def test_remote_composer_custom_graph(num_of_graphs):
+    graphs = get_many_graphs(num_of_graphs)
+
+    assert not any(graph.evaluated for graph in graphs)
+
+    evaluated_graphs = RemoteEvaluator().compute_graphs(graphs)
+
+    assert len(graphs) == len(evaluated_graphs)
+    assert all(graph.evaluated for graph in evaluated_graphs)

--- a/test/unit/utilities/test_pipeline_import_export.py
+++ b/test/unit/utilities/test_pipeline_import_export.py
@@ -193,8 +193,8 @@ def test_fitted_pipeline_cache_correctness_after_export_and_import():
     pipeline.save('test_fitted_pipeline_cache_correctness_after_export_and_import')
     prediction = pipeline.predict(test_data)
 
-    new_pipeline = Pipeline()
-    new_pipeline.load(create_correct_path('test_fitted_pipeline_cache_correctness_after_export_and_import'))
+    json_load_path = create_correct_path('test_fitted_pipeline_cache_correctness_after_export_and_import')
+    new_pipeline = Pipeline.from_serialized(json_load_path)
 
     new_prediction = new_pipeline.predict(test_data)
 
@@ -205,8 +205,7 @@ def test_fitted_pipeline_cache_correctness_after_export_and_import():
 def test_import_json_to_pipeline_correctly():
     json_path_load = create_correct_path('test_pipeline_convert_to_json')
 
-    pipeline = Pipeline()
-    pipeline.load(json_path_load)
+    pipeline = Pipeline.from_serialized(json_path_load)
     json_actual, _ = pipeline.save('test_import_json_to_pipeline_correctly_1')
 
     pipeline_expected = create_pipeline()
@@ -233,8 +232,7 @@ def test_import_json_template_to_pipeline_correctly():
 def test_import_json_to_fitted_pipeline_correctly():
     json_path_load = create_correct_path('test_fitted_pipeline_convert_to_json')
 
-    pipeline = Pipeline()
-    pipeline.load(json_path_load)
+    pipeline = Pipeline.from_serialized(json_path_load)
     json_actual, _ = pipeline.save('test_import_json_to_fitted_pipeline_correctly')
 
     with open(json_path_load, 'r') as json_file:
@@ -321,8 +319,7 @@ def test_import_custom_json_object_to_pipeline_and_fit_correctly_no_exception():
 
     train_data, _ = get_classification_data()
 
-    pipeline = Pipeline()
-    pipeline.load(json_path_load)
+    pipeline = Pipeline.from_serialized(json_path_load)
 
     pipeline.fit(train_data)
 
@@ -400,8 +397,7 @@ def test_one_hot_encoder_serialization():
 
     pipeline.save('test_export_one_hot_encoding_operation')
 
-    pipeline_after = Pipeline()
-    pipeline_after.load(create_correct_path('test_export_one_hot_encoding_operation'))
+    pipeline_after = Pipeline.from_serialized(create_correct_path('test_export_one_hot_encoding_operation'))
     prediction_after_export = pipeline_after.predict(test_data)
 
     assert np.array_equal(prediction_before_export.features, prediction_after_export.features)
@@ -434,8 +430,7 @@ def test_pipeline_with_preprocessing_serialized_correctly():
 
     single_node_pipeline.save(path=save_path)
 
-    pipeline_after = Pipeline()
-    pipeline_after.load(create_correct_path(save_path))
+    pipeline_after = Pipeline.from_serialized(create_correct_path(save_path))
 
     after_output = pipeline_after.predict(mixed_input)
     mae_after = mean_absolute_error(mixed_input.target, after_output.predict)
@@ -455,8 +450,7 @@ def test_multimodal_pipeline_serialized_correctly():
     before_save_predicted_labels = pipeline.predict(mm_data, output_mode='labels')
     pipeline.save(path=save_path)
 
-    pipeline_loaded = Pipeline()
-    pipeline_loaded.load(create_correct_path(save_path))
+    pipeline_loaded = Pipeline.from_serialized(create_correct_path(save_path))
     after_load_predicted_labels = pipeline_loaded.predict(mm_data, output_mode='labels')
 
     assert np.array_equal(before_save_predicted_labels.predict, after_load_predicted_labels.predict)
@@ -470,8 +464,7 @@ def test_old_serialized_paths_load_correctly():
     """
     path = os.path.join(fedot_project_root(), 'test', 'data', 'pipeline_with_old_paths', 'pipeline_with_old_paths.json')
 
-    pipeline_loaded = Pipeline()
-    pipeline_loaded.load(path)
+    pipeline_loaded = Pipeline.from_serialized(path)
 
     assert pipeline_loaded.nodes is not None
 


### PR DESCRIPTION
Minor PR with the following changes:
- Change RemoteEvaluator interface to accept any Serializable Graph instead of Pipeline
- Drop `pipeline.template` field because it's unused and creates unnecessary cycle between pipeline & its template
- Introduce `Serializable` interface with `save()` & `load()` methods. Pipeline now it is subclass.
- Replace loading of serialized pipeline with direct classmethod call `Pipeline.from_serialized`
Fixes #679 