### PR TITLE
`OptHistory` visualizations improvement

### DIFF
--- a/examples/simple/pipeline_and_history_visualization.py
+++ b/examples/simple/pipeline_and_history_visualization.py
@@ -11,11 +11,13 @@ def run_pipeline_and_history_visualization(with_pipeline_visualization=True):
     history = OptHistory.load(Path(fedot_project_root(), 'examples', 'data', 'history', 'opt_history.json'))
     pipeline = PipelineAdapter().restore(history.individuals[-1][-1].graph)
 
+    history.show('fitness_line')
     history.show('fitness_box', pct_best=0.5)
     history.show('operations_kde')
     history.show('operations_animated_bar', save_path='example_animation.gif', show_fitness=True)
     if with_pipeline_visualization:
         pipeline.show()
+    history.show('fitness_line_interactive')
 
 
 if __name__ == '__main__':

--- a/examples/simple/pipeline_and_history_visualization.py
+++ b/examples/simple/pipeline_and_history_visualization.py
@@ -1,4 +1,3 @@
-import os.path
 from pathlib import Path
 
 from fedot.core.optimisers.adapters import PipelineAdapter
@@ -9,7 +8,7 @@ from fedot.core.utils import fedot_project_root
 def run_pipeline_and_history_visualization(with_pipeline_visualization=True):
     """ Function run visualization of composing history and pipeline """
     # Generate pipeline and history
-    history = OptHistory.load(os.path.join(fedot_project_root(), 'examples', 'data', 'history', 'opt_history.json'))
+    history = OptHistory.load(Path(fedot_project_root(), 'examples', 'data', 'history', 'opt_history.json'))
     pipeline = PipelineAdapter().restore(history.individuals[-1][-1].graph)
 
     history.show('fitness_box', pct_best=0.5)

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -123,7 +123,7 @@ class MultiprocessingDispatcher(ObjectiveEvaluationDispatcher):
 
         end_time = timeit.default_timer()
         ind.metadata['computation_time_in_seconds'] = end_time - start_time
-        ind.metadata['evaluation_moment'] = datetime.now().isoformat()
+        ind.metadata['evaluation_time_iso'] = datetime.now().isoformat()
         return ind if ind.fitness.valid else None
 
     def _reset_eval_cache(self):
@@ -182,7 +182,7 @@ class SimpleDispatcher(ObjectiveEvaluationDispatcher):
         ind.set_evaluation_result(ind_fitness, ind_graph)
         end_time = timeit.default_timer()
         ind.metadata['computation_time_in_seconds'] = end_time - start_time
-        ind.metadata['evaluation_moment'] = datetime.now().isoformat()
+        ind.metadata['evaluation_time_iso'] = datetime.now().isoformat()
         return ind if ind.fitness.valid else None
 
 

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -3,6 +3,7 @@ import multiprocessing
 import timeit
 from abc import ABC, abstractmethod
 from contextlib import closing
+from datetime import datetime
 from random import choice
 from typing import Dict, Optional
 
@@ -122,6 +123,7 @@ class MultiprocessingDispatcher(ObjectiveEvaluationDispatcher):
 
         end_time = timeit.default_timer()
         ind.metadata['computation_time_in_seconds'] = end_time - start_time
+        ind.metadata['evaluation_moment'] = datetime.now().isoformat()
         return ind if ind.fitness.valid else None
 
     def _reset_eval_cache(self):
@@ -180,6 +182,7 @@ class SimpleDispatcher(ObjectiveEvaluationDispatcher):
         ind.set_evaluation_result(ind_fitness, ind_graph)
         end_time = timeit.default_timer()
         ind.metadata['computation_time_in_seconds'] = end_time - start_time
+        ind.metadata['evaluation_moment'] = datetime.now().isoformat()
         return ind if ind.fitness.valid else None
 
 

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -1,3 +1,4 @@
+import os
 from copy import deepcopy
 from typing import Any, Iterable, List, Optional, Union, Tuple
 from uuid import uuid4
@@ -197,7 +198,7 @@ class OptGraph:
         """ Returns all available edges in a given graph """
         return self._operator.get_edges()
 
-    def show(self, path: str = None):
+    def show(self, path: Optional[Union[os.PathLike, str]] = None):
         GraphVisualiser().visualise(self, path)
 
     def __eq__(self, other) -> bool:

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -151,7 +151,7 @@ class OptHistory:
                      stacklevel=3)
             # Check plot_type-specific cases
             if plot_type in (PlotTypesEnum.fitness_line, PlotTypesEnum.fitness_line_interactive) and \
-                    per_time and self.individuals[0][0].metadata.get('evaluation_moment') is None:
+                    per_time and self.individuals[0][0].metadata.get('evaluation_time_iso') is None:
                 warn('Evaluation time not found in optimization history. Showing fitness plot per generations...',
                      stacklevel=3)
                 per_time = False

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -30,7 +30,7 @@ class OptHistory:
         self._objective = objective or Objective([])
         self.individuals: List[List[Individual]] = []
         self.archive_history: List[List[Individual]] = []
-        self.save_folder: Optional[Union[str, os.PathLike]] = save_folder
+        self.save_folder = save_folder
 
     def is_empty(self) -> bool:
         return not self.individuals

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -3,16 +3,15 @@ import itertools
 import json
 import os
 import shutil
-import warnings
-from copy import deepcopy
+from pathlib import Path
 from typing import Any, List, Optional, Sequence, Union
+from warnings import warn
 
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.archive import GenerationKeeper
 # ParentOperator is needed for backward compatibility with older optimization histories.
 # This is a temporary solution until the issue #699 (https://github.com/nccr-itmo/FEDOT/issues/699) is closed.
 from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator  # noqa
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.objective import Objective
 from fedot.core.optimisers.utils.population_utils import get_metric_position
@@ -44,7 +43,7 @@ class OptHistory:
 
     def write_composer_history_to_csv(self, file='history.csv'):
         history_dir = self._get_save_path()
-        file = os.path.join(history_dir, file)
+        file = Path(history_dir, file)
         if not os.path.isdir(history_dir):
             os.mkdir(history_dir)
         self._write_header_to_csv(file)
@@ -84,7 +83,7 @@ class OptHistory:
                 last_gen = self.individuals[last_gen_id]
                 last_gen_history = self.historical_fitness[last_gen_id]
                 for individual, ind_fitness in zip(last_gen, last_gen_history):
-                    ind_path = os.path.join(path, str(last_gen_id), str(individual.uid))
+                    ind_path = Path(path, str(last_gen_id), str(individual.uid))
                     additional_info = \
                         {'fitness_name': self._objective.metric_names,
                          'fitness_value': ind_fitness}
@@ -119,14 +118,14 @@ class OptHistory:
 
     def clean_results(self, path: Optional[str] = None):
         if not path and self.save_folder is not None:
-            path = os.path.join(default_fedot_data_dir(), self.save_folder)
+            path = Path(default_fedot_data_dir(), self.save_folder)
         if path is not None:
             shutil.rmtree(path, ignore_errors=True)
             os.mkdir(path)
 
-    def show(self, plot_type: Optional[Union[PlotTypesEnum, str]] = PlotTypesEnum.fitness_box,
+    def show(self, plot_type: Union[PlotTypesEnum, str] = PlotTypesEnum.fitness_box,
              save_path: Optional[Union[os.PathLike, str]] = None,
-             pct_best: Optional[float] = None, show_fitness: Optional[bool] = True):
+             pct_best: Optional[float] = None, show_fitness: bool = True, per_time: bool = True):
         """ Visualizes fitness values or operations used across generations.
 
         :param plot_type: visualization to show. Expected values are listed in
@@ -136,24 +135,29 @@ class OptHistory:
         :param pct_best: fraction of individuals with the best fitness per generation. The value should be in the
             interval (0, 1]. The other individuals are filtered out. The fraction will also be mentioned on the plot.
         :param show_fitness: if False, visualizations that support this parameter will not display fitness.
+        :param per_time: Shows time axis instead of generations axis.
+            Currently, supported for plot_type = 'show_fitness_line'.
         """
 
-        def is_history_contains_fitness(msg_if_not: Optional[str] = None, raise_exception: bool = False) -> bool:
-            if all_historical_fitness is not None:
-                return True
-
-            msg_prefix = 'The history has no fitness data.'
-            if msg_if_not:
-                msg_if_not = ' '.join([msg_prefix, msg_if_not])
-            else:
-                msg_if_not = msg_prefix
-
-            if raise_exception:
-                raise ValueError(msg_if_not)
-            warnings.warn(msg_if_not, stacklevel=3)
-            return False
-
-        print('Visualizing optimization history... It may take some time, depending on the history size.')
+        def check_args_constraints():
+            nonlocal per_time
+            # Check supported cases for `pct_best`.
+            if pct_best is not None:
+                if pct_best <= 0 or pct_best > 1:
+                    raise ValueError('`pct_best` parameter should be in the interval (0, 1].')
+            # Check supported cases for show_fitness == False.
+            if not show_fitness and plot_type is not PlotTypesEnum.operations_animated_bar:
+                warn(f'Argument `show_fitness` is not supported for "{plot_type.name}". It is ignored.',
+                     stacklevel=2)
+            # Check plot_type-specific cases
+            if plot_type is PlotTypesEnum.fitness_line:
+                if per_time and self.individuals[0][0].metadata.get('evaluation_moment') is None:
+                    warn('Evaluation time not found in optimization history. Showing fitness plot per generations...',
+                         stacklevel=2)
+                    per_time = False
+            elif plot_type is PlotTypesEnum.operations_animated_bar:
+                if not save_path:
+                    raise ValueError('Argument `save_path` is required to save the animation.')
 
         if isinstance(plot_type, str):
             try:
@@ -163,30 +167,18 @@ class OptHistory:
                     f'Visualization "{plot_type}" is not supported. Expected values: '
                     f'{", ".join(PlotTypesEnum.member_names())}.')
 
-        all_historical_fitness = self.all_historical_fitness
-        # Check supported cases for `pct_best`.
-        if pct_best is not None:
-            if pct_best <= 0 or pct_best > 1:
-                raise ValueError('`pct_best` parameter should be in the interval (0, 1].')
-            if not is_history_contains_fitness(msg_if_not='`pct_best` parameter is ignored.'):
-                pct_best = None
-        # Check supported cases for show_fitness == False.
-        if not show_fitness and plot_type is not PlotTypesEnum.operations_animated_bar:
-            warnings.warn(f'Argument `show_fitness` is not supported for "{plot_type.name}". It is ignored.',
-                          stacklevel=2)
+        check_args_constraints()
+
+        print('Visualizing optimization history... It may take some time, depending on the history size.')
 
         viz = PipelineEvolutionVisualiser()
-        if plot_type is PlotTypesEnum.fitness_box:
-            is_history_contains_fitness(
-                msg_if_not=f'Visualization "{plot_type.name}" is not supported.', raise_exception=True)
+        if plot_type is PlotTypesEnum.fitness_line:
+            viz.visualize_fitness_line(self, per_time, save_path)
+        elif plot_type is PlotTypesEnum.fitness_box:
             viz.visualise_fitness_box(self, save_path=save_path, pct_best=pct_best)
         elif plot_type is PlotTypesEnum.operations_kde:
             viz.visualize_operations_kde(self, save_path=save_path, pct_best=pct_best)
         elif plot_type is PlotTypesEnum.operations_animated_bar:
-            if not save_path:
-                raise ValueError('Argument `save_path` is required to save the animation.')
-            if not is_history_contains_fitness(msg_if_not='Fitness is not displayed.'):
-                show_fitness = False
             viz.visualize_operations_animated_bar(
                 self, save_path=save_path, pct_best=pct_best, show_fitness_color=show_fitness)
         else:
@@ -244,7 +236,7 @@ class OptHistory:
                     os.makedirs(self.save_folder)
                 return self.save_folder
             else:
-                return os.path.join(default_fedot_data_dir(), self.save_folder)
+                return Path(default_fedot_data_dir(), self.save_folder)
         return None
 
     def print_leaderboard(self, top_n: int = 10):

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -45,18 +45,20 @@ class GraphVisualiser:
         inv_map = {v: k for k, v in node_labels.items()}
         if type(graph).__name__ == 'Pipeline':
             root = inv_map[graph.root_node]
+            color_kwargs = {'node_color': colors_by_node_labels(node_labels)}
         else:
             root = 0
+            color_kwargs = {'cmap': 'Set3'}
+
         minimum_spanning_tree = nx.minimum_spanning_tree(nx_graph.to_undirected())
         pos = hierarchy_pos(minimum_spanning_tree, root=root)
         min_size = 3000
         node_sizes = [min_size for _ in word_labels]
         if title:
             plt.title(title)
-        colors = colors_by_node_labels(node_labels)
         nx.draw(nx_graph, pos=pos, with_labels=False,
-                node_size=node_sizes, width=2.0,
-                node_color=colors, cmap='Set3', ax=ax)
+                node_size=node_sizes, width=2.0, ax=ax,
+                **color_kwargs)
         return pos, node_labels
 
     def _draw_dag(self, graph: 'Graph', ax=None, title=None,
@@ -85,7 +87,11 @@ class GraphVisualiser:
 
 
 def colors_by_node_labels(node_labels: dict):
-    colors = [color for color in range(len(node_labels.keys()))]
+    from fedot.core.visualisation.opt_viz import get_palette_based_on_default_tags
+    from fedot.core.repository.operation_types_repository import get_opt_node_tag
+
+    palette = get_palette_based_on_default_tags()
+    colors = [palette[get_opt_node_tag(str(label))] for label in node_labels.values()]
     return colors
 
 

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -373,38 +373,38 @@ class PipelineEvolutionVisualiser:
         best_individuals = {}
 
         start_time = datetime.fromisoformat(
-            min(generations[0], key=lambda ind: ind.metadata['evaluation_moment']).metadata[
-                'evaluation_moment'])
+            min(generations[0], key=lambda ind: ind.metadata['evaluation_time_iso']).metadata[
+                'evaluation_time_iso'])
         end_time_seconds = (datetime.fromisoformat(
-            max(generations[-1], key=lambda ind: ind.metadata['evaluation_moment']).metadata[
-                'evaluation_moment']) - start_time).seconds
+            max(generations[-1], key=lambda ind: ind.metadata['evaluation_time_iso']).metadata[
+                'evaluation_time_iso']) - start_time).seconds
 
         for gen_num, gen in enumerate(generations):
             gen_start_times.append(1e10)
-            gen_sorted = sorted(gen, key=lambda ind: ind.metadata['evaluation_moment'])
+            gen_sorted = sorted(gen, key=lambda ind: ind.metadata['evaluation_time_iso'])
             for ind in gen_sorted:
                 if ind.native_generation != gen_num:
                     continue
-                evaluation_moment = (datetime.fromisoformat(ind.metadata['evaluation_moment']) - start_time).seconds
-                if evaluation_moment < gen_start_times[gen_num]:
-                    gen_start_times[gen_num] = evaluation_moment
+                evaluation_time = (datetime.fromisoformat(ind.metadata['evaluation_time_iso']) - start_time).seconds
+                if evaluation_time < gen_start_times[gen_num]:
+                    gen_start_times[gen_num] = evaluation_time
                 if ind.fitness > best_fitness:
-                    best_individuals[evaluation_moment] = ind
+                    best_individuals[evaluation_time] = ind
                     best_fitness = ind.fitness
 
-        best_eval_moments, best_fitnesses = np.transpose(
-            [(evaluation_moment, abs(individual.fitness.value))
-             for evaluation_moment, individual in best_individuals.items()])
+        best_eval_times, best_fitnesses = np.transpose(
+            [(evaluation_time, abs(individual.fitness.value))
+             for evaluation_time, individual in best_individuals.items()])
 
-        best_eval_moments = list(best_eval_moments)
+        best_eval_times = list(best_eval_times)
         best_fitnesses = list(best_fitnesses)
 
-        if best_eval_moments[-1] != end_time_seconds:
+        if best_eval_times[-1] != end_time_seconds:
             best_fitnesses.append(abs(best_fitness.value))
-            best_eval_moments.append(end_time_seconds)
+            best_eval_times.append(end_time_seconds)
         gen_start_times.append(end_time_seconds)
 
-        axis.step(best_eval_moments, best_fitnesses, where='post', label=label)
+        axis.step(best_eval_times, best_fitnesses, where='post', label=label)
 
         if with_generation_limits:
             prev_time = gen_start_times[0]

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -604,7 +604,7 @@ class PipelineEvolutionVisualiser:
             animate,
             frames=len(bar_data),
             interval=animation_interval_between_frames_ms,
-            repeat=False
+            repeat=True
         )
         ani.save(str(save_path), dpi=animation_dpi)
         print(f'The animation was saved to "{save_path}".')

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -123,7 +123,7 @@ def test_newly_generated_history():
     dumped_history = history.save()
     loaded_history = OptHistory.load(dumped_history).save()
     assert dumped_history is not None
-    assert dumped_history == loaded_history, 'History does not equal to itself after reloading!'
+    assert dumped_history == loaded_history, 'The history is not equal to itself after reloading!'
 
 
 def assert_intermediate_metrics(pipeline: Graph):
@@ -210,4 +210,4 @@ def test_history_correct_serialization():
     reloaded_history = OptHistory.load(dumped_history)
 
     assert history.individuals == reloaded_history.individuals
-    assert dumped_history == reloaded_history.save(), 'History does not equal to itself after reloading!'
+    assert dumped_history == reloaded_history.save(), 'The history is not equal to itself after reloading!'

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -24,10 +24,11 @@ def create_individual():
 
 def generate_history(generations_quantity, pop_size):
     history = OptHistory()
-    for _ in range(generations_quantity):
+    for gen_num in range(generations_quantity):
         new_pop = []
         for _ in range(pop_size):
             ind = create_individual()
+            ind.set_native_generation(gen_num)
             new_pop.append(ind)
         history.add_to_history(new_pop)
     return history

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -97,4 +97,5 @@ def test_history_show_saving_plots(tmp_path, plot_type: PlotTypesEnum):
         else save_path.with_suffix('.png')
     history = generate_history(generations_quantity, pop_size)
     history.show(plot_type=plot_type, save_path=str(save_path), pct_best=0.1)
-    assert save_path.exists()
+    if plot_type is not PlotTypesEnum.fitness_line_interactive:
+        assert save_path.exists()


### PR DESCRIPTION
* Colors of models in visualizations are picked by repository tags.
* Tags-based visualizations provide list of operations per tag.

![image](https://user-images.githubusercontent.com/57573631/181264311-984819ae-c49f-4bcb-a21f-bf7cf3acbdb3.png)
![image](https://user-images.githubusercontent.com/57573631/181236245-c02bc116-d46c-4c49-85c7-097285991978.png)
![example_animation](https://user-images.githubusercontent.com/57573631/181279080-d308b8b9-2cda-4129-9abd-768e755a79a0.gif)

* New visualizations: `fitness_line` and `fitness_line_interactive`.

![image](https://user-images.githubusercontent.com/57573631/181235895-5a189af0-0dac-4dc0-bc47-00f0f4444638.png)
![Figure_1](https://user-images.githubusercontent.com/57573631/181236869-7985c45a-6351-4085-9847-ca3f6f6e034b.png)

The last one can be saved, then it shows the last pipeline without buttons.
![image](https://user-images.githubusercontent.com/57573631/181236348-a09eca3a-93b1-4df7-a7e7-64d363955df9.png)

- New histories gather time of evaluation for each individual. By default, such histories are visualized per time axis.

![image](https://user-images.githubusercontent.com/57573631/181265387-e72d9c7e-9707-45f5-959e-03cad8749eae.png)

