### PR TITLE
Fix readme encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ NAME = 'fedot'
 VERSION = '0.5.2'
 AUTHOR = 'NSS Lab'
 SHORT_DESCRIPTION = 'Automated machine learning framework for composite pipelines'
-README = Path(HERE, 'README.rst').read_text()
+README = Path(HERE, 'README.rst').read_text(encoding='utf-8')
 URL = 'https://github.com/nccr-itmo/FEDOT'
 REQUIRES_PYTHON = '>=3.7'
 LICENSE = 'BSD 3-Clause'


### PR DESCRIPTION
Cyrillic and chinese symbols causes an error while installing FEDOT 


![image](https://user-images.githubusercontent.com/32017472/178705433-567ff8b5-5c56-42a6-9e5e-93cd45651916.png)


This pr fixes it by setting encoding type for readme on utf-8