### PR TITLE
743 refactor usages of graph

### DIFF
--- a/examples/advanced/fedot_based_solutions/graph_model_optimization.py
+++ b/examples/advanced/fedot_based_solutions/graph_model_optimization.py
@@ -55,7 +55,7 @@ def custom_mutation(graph: OptGraph, **kwargs):
     num_mut = 10
     try:
         for _ in range(num_mut):
-            rid = random.choice(range(len(graph.nodes)))
+            rid = random.choice(range(graph.length))
             random_node = graph.nodes[rid]
             other_random_node = graph.nodes[random.choice(range(len(graph.nodes)))]
             nodes_not_cycling = (random_node.descriptive_id not in

--- a/examples/advanced/fedot_based_solutions/graph_model_optimization.py
+++ b/examples/advanced/fedot_based_solutions/graph_model_optimization.py
@@ -65,7 +65,7 @@ def custom_mutation(graph: OptGraph, **kwargs):
             if random_node.nodes_from is not None and len(random_node.nodes_from) == 0:
                 random_node.nodes_from = None
             if nodes_not_cycling:
-                graph.operator.connect_nodes(random_node, other_random_node)
+                graph.connect_nodes(random_node, other_random_node)
     except Exception as ex:
         graph.log.warning(f'Incorrect connection: {ex}')
     return graph

--- a/fedot/core/composer/random_composer.py
+++ b/fedot/core/composer/random_composer.py
@@ -96,5 +96,5 @@ class RandomSearchOptimiser(GraphOptimiser):
             history.append((new_pipeline, new_metric_value))
             if show_progress:
                 self.log.info(f'Iter {i}: best metric {best_metric_value},'
-                              f'try {new_metric_value} with num nodes {len(new_pipeline.nodes)}')
+                              f'try {new_metric_value} with num nodes {new_pipeline.length}')
         return [best_set]

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -77,6 +77,9 @@ class Graph:
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
         return self.operator.nodes_from_layer(layer_number=layer_number)
 
+    def actualise_old_node_children(self, old_node: 'GraphNode', new_node: 'GraphNode'):
+        self.operator.actualise_old_node_children(old_node=old_node, new_node=new_node)
+
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)
 

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -102,13 +102,9 @@ class Graph:
          k = k(in) + k(out) """
         return self._operator.get_nodes_degrees()
 
-    def get_all_edges(self) -> List[Tuple['GraphNode', 'GraphNode']]:
+    def get_edges(self) -> List[Tuple['GraphNode', 'GraphNode']]:
         """ Returns all available edges in a given graph """
-        return self._operator.get_all_edges()
-
-    def distance_to(self, other_graph: 'Graph') -> int:
-        """ Returns distance to specified graph """
-        return self._operator.distance_to(other_graph=other_graph)
+        return self._operator.get_edges()
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -17,7 +17,7 @@ class Graph:
     """
 
     def __init__(self, nodes: Optional[Union['GraphNode', List['GraphNode']]] = None):
-        self.nodes = []
+        self._nodes = []
         self.operator = GraphOperator(self, self._empty_postproc)
 
         if nodes:
@@ -26,6 +26,10 @@ class Graph:
 
     def _empty_postproc(self, nodes=None):
         pass
+
+    @property
+    def nodes(self):
+        return self._nodes
 
     def add_node(self, new_node: 'GraphNode'):
         """

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, Any
 
 from fedot.core.dag.graph_operator import GraphOperator
 from fedot.core.visualisation.graph_viz import GraphVisualiser
@@ -73,6 +73,9 @@ class Graph:
 
     def distance_to_root_level(self, node: 'GraphNode') -> int:
         return self.operator.distance_to_root_level(node=node)
+
+    def nodes_from_layer(self, layer_number: int) -> List[Any]:
+        return self.operator.nodes_from_layer(layer_number=layer_number)
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -72,25 +72,24 @@ class Graph:
         self.operator.delete_subtree(subroot)
 
     def distance_to_root_level(self, node: 'GraphNode') -> int:
+        """ Returns distance to root level """
         return self.operator.distance_to_root_level(node=node)
 
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
+        """ Returns all nodes from specified layer """
         return self.operator.nodes_from_layer(layer_number=layer_number)
 
-    def actualise_old_node_children(self, old_node: 'GraphNode', new_node: 'GraphNode'):
-        self.operator.actualise_old_node_children(old_node=old_node, new_node=new_node)
-
-    def sort_nodes(self):
-        self.operator.sort_nodes()
-
     def node_children(self, node: 'GraphNode') -> List[Optional['GraphNode']]:
+        """ Returns all node's children """
         return self.operator.node_children(node=node)
 
-    def connect_nodes(self, parent: 'GraphNode', child: 'GraphNode'):
-        self.operator.connect_nodes(parent=parent, child=child)
+    def connect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode'):
+        """ Add an edge from node_parent to node_child """
+        self.operator.connect_nodes(parent=node_parent, child=node_child)
 
     def disconnect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode',
                          is_clean_up_leftovers: bool = True):
+        """ Delete an edge from node_parent to node_child """
         self.operator.disconnect_nodes(node_parent=node_parent, node_child=node_child,
                                        is_clean_up_leftovers=is_clean_up_leftovers)
 
@@ -101,6 +100,7 @@ class Graph:
         return self.operator.get_all_edges()
 
     def distance_to(self, other_graph: 'Graph') -> int:
+        """ Returns distance to specified graph """
         return self.operator.distance_to(other_graph=other_graph)
 
     def show(self, path: str = None):

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -18,7 +18,7 @@ class Graph:
 
     def __init__(self, nodes: Optional[Union['GraphNode', List['GraphNode']]] = None):
         self._nodes = []
-        self.operator = GraphOperator(self, self._empty_postproc)
+        self._operator = GraphOperator(self, self._empty_postproc)
 
         if nodes:
             for node in ensure_wrapped_in_sequence(nodes):
@@ -37,7 +37,7 @@ class Graph:
 
         :param new_node: new GraphNode object
         """
-        self.operator.add_node(new_node)
+        self._operator.add_node(new_node)
 
     def update_node(self, old_node: 'GraphNode', new_node: 'GraphNode'):
         """
@@ -47,7 +47,7 @@ class Graph:
         :param new_node: 'GraphNode' new object
         """
 
-        self.operator.update_node(old_node, new_node)
+        self._operator.update_node(old_node, new_node)
 
     def delete_node(self, node: 'GraphNode'):
         """
@@ -56,7 +56,7 @@ class Graph:
         :param node: 'GraphNode' object to delete
         """
 
-        self.operator.delete_node(node)
+        self._operator.delete_node(node)
 
     def update_subtree(self, old_subroot: 'GraphNode', new_subroot: 'GraphNode'):
         """
@@ -65,7 +65,7 @@ class Graph:
         :param old_subroot: 'GraphNode' object to replace
         :param new_subroot: 'GraphNode' new object
         """
-        self.operator.update_subtree(old_subroot, new_subroot)
+        self._operator.update_subtree(old_subroot, new_subroot)
 
     def delete_subtree(self, subroot: 'GraphNode'):
         """
@@ -73,60 +73,60 @@ class Graph:
 
         :param subroot:
         """
-        self.operator.delete_subtree(subroot)
+        self._operator.delete_subtree(subroot)
 
     def distance_to_root_level(self, node: 'GraphNode') -> int:
         """ Returns distance to root level """
-        return self.operator.distance_to_root_level(node=node)
+        return self._operator.distance_to_root_level(node=node)
 
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
         """ Returns all nodes from specified layer """
-        return self.operator.nodes_from_layer(layer_number=layer_number)
+        return self._operator.nodes_from_layer(layer_number=layer_number)
 
     def node_children(self, node: 'GraphNode') -> List[Optional['GraphNode']]:
         """ Returns all node's children """
-        return self.operator.node_children(node=node)
+        return self._operator.node_children(node=node)
 
     def connect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode'):
         """ Add an edge from node_parent to node_child """
-        self.operator.connect_nodes(parent=node_parent, child=node_child)
+        self._operator.connect_nodes(parent=node_parent, child=node_child)
 
     def disconnect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode',
                          is_clean_up_leftovers: bool = True):
         """ Delete an edge from node_parent to node_child """
-        self.operator.disconnect_nodes(node_parent=node_parent, node_child=node_child,
-                                       is_clean_up_leftovers=is_clean_up_leftovers)
+        self._operator.disconnect_nodes(node_parent=node_parent, node_child=node_child,
+                                        is_clean_up_leftovers=is_clean_up_leftovers)
 
     def get_nodes_degrees(self):
-        return self.operator.get_nodes_degrees()
+        return self._operator.get_nodes_degrees()
 
     def get_all_edges(self) -> List[Tuple['GraphNode', 'GraphNode']]:
-        return self.operator.get_all_edges()
+        return self._operator.get_all_edges()
 
     def distance_to(self, other_graph: 'Graph') -> int:
         """ Returns distance to specified graph """
-        return self.operator.distance_to(other_graph=other_graph)
+        return self._operator.distance_to(other_graph=other_graph)
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)
 
     def __eq__(self, other) -> bool:
-        return self.operator.is_graph_equal(other)
+        return self._operator.is_graph_equal(other)
 
     def __str__(self):
-        return self.operator.graph_description()
+        return self._operator.graph_description()
 
     def __repr__(self):
         return self.__str__()
 
     @property
     def root_node(self):
-        roots = self.operator.root_node()
+        roots = self._operator.root_node()
         return roots
 
     @property
     def descriptive_id(self):
-        return self.operator.descriptive_id
+        return self._operator.descriptive_id
 
     @property
     def length(self) -> int:
@@ -134,4 +134,4 @@ class Graph:
 
     @property
     def depth(self) -> int:
-        return self.operator.graph_depth()
+        return self._operator.graph_depth()

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -98,9 +98,12 @@ class Graph:
                                         is_clean_up_leftovers=is_clean_up_leftovers)
 
     def get_nodes_degrees(self):
+        """ Nodes degree as the number of edges the node has:
+         k = k(in) + k(out) """
         return self._operator.get_nodes_degrees()
 
     def get_all_edges(self) -> List[Tuple['GraphNode', 'GraphNode']]:
+        """ Returns all available edges in a given graph """
         return self._operator.get_all_edges()
 
     def distance_to(self, other_graph: 'Graph') -> int:

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Union, Any
+from typing import TYPE_CHECKING, List, Optional, Union, Any, Tuple
 
 from fedot.core.dag.graph_operator import GraphOperator
 from fedot.core.visualisation.graph_viz import GraphVisualiser
@@ -80,6 +80,29 @@ class Graph:
     def actualise_old_node_children(self, old_node: 'GraphNode', new_node: 'GraphNode'):
         self.operator.actualise_old_node_children(old_node=old_node, new_node=new_node)
 
+    def sort_nodes(self):
+        self.operator.sort_nodes()
+
+    def node_children(self, node: 'GraphNode') -> List[Optional['GraphNode']]:
+        return self.operator.node_children(node=node)
+
+    def connect_nodes(self, parent: 'GraphNode', child: 'GraphNode'):
+        self.operator.connect_nodes(parent=parent, child=child)
+
+    def disconnect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode',
+                         is_clean_up_leftovers: bool = True):
+        self.operator.disconnect_nodes(node_parent=node_parent, node_child=node_child,
+                                       is_clean_up_leftovers=is_clean_up_leftovers)
+
+    def get_nodes_degrees(self):
+        return self.operator.get_nodes_degrees()
+
+    def get_all_edges(self) -> List[Tuple['GraphNode', 'GraphNode']]:
+        return self.operator.get_all_edges()
+
+    def distance_to(self, other_graph: 'Graph') -> int:
+        return self.operator.distance_to(other_graph=other_graph)
+
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)
 
@@ -96,6 +119,10 @@ class Graph:
     def root_node(self):
         roots = self.operator.root_node()
         return roots
+
+    @property
+    def descriptive_id(self):
+        return self.operator.descriptive_id
 
     @property
     def length(self) -> int:

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -1,10 +1,8 @@
-from typing import TYPE_CHECKING, List, Optional, Union, Any, Tuple
+from typing import List, Optional, Union, Any, Tuple
 
+from fedot.core.dag.graph_node import GraphNode
 from fedot.core.dag.graph_operator import GraphOperator
 from fedot.core.visualisation.graph_viz import GraphVisualiser
-
-if TYPE_CHECKING:
-    from fedot.core.dag.graph_node import GraphNode
 
 from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
 
@@ -16,7 +14,7 @@ class Graph:
     :param nodes: 'GraphNode' object(s)
     """
 
-    def __init__(self, nodes: Optional[Union['GraphNode', List['GraphNode']]] = None):
+    def __init__(self, nodes: Optional[Union[GraphNode, List[GraphNode]]] = None):
         self._nodes = []
         self._operator = GraphOperator(self, self._empty_postproc)
 
@@ -31,7 +29,7 @@ class Graph:
     def nodes(self):
         return self._nodes
 
-    def add_node(self, new_node: 'GraphNode'):
+    def add_node(self, new_node: GraphNode):
         """
         Add new node to the Pipeline
 
@@ -39,7 +37,7 @@ class Graph:
         """
         self._operator.add_node(new_node)
 
-    def update_node(self, old_node: 'GraphNode', new_node: 'GraphNode'):
+    def update_node(self, old_node: GraphNode, new_node: GraphNode):
         """
         Replace old_node with new one.
 
@@ -49,7 +47,7 @@ class Graph:
 
         self._operator.update_node(old_node, new_node)
 
-    def delete_node(self, node: 'GraphNode'):
+    def delete_node(self, node: GraphNode):
         """
         Delete chosen node redirecting all its parents to the child.
 
@@ -58,7 +56,7 @@ class Graph:
 
         self._operator.delete_node(node)
 
-    def update_subtree(self, old_subroot: 'GraphNode', new_subroot: 'GraphNode'):
+    def update_subtree(self, old_subroot: GraphNode, new_subroot: GraphNode):
         """
         Replace the subtrees with old and new nodes as subroots
 
@@ -67,7 +65,7 @@ class Graph:
         """
         self._operator.update_subtree(old_subroot, new_subroot)
 
-    def delete_subtree(self, subroot: 'GraphNode'):
+    def delete_subtree(self, subroot: GraphNode):
         """
         Delete the subtree with node as subroot.
 
@@ -75,7 +73,7 @@ class Graph:
         """
         self._operator.delete_subtree(subroot)
 
-    def distance_to_root_level(self, node: 'GraphNode') -> int:
+    def distance_to_root_level(self, node: GraphNode) -> int:
         """ Returns distance to root level """
         return self._operator.distance_to_root_level(node=node)
 
@@ -83,15 +81,15 @@ class Graph:
         """ Returns all nodes from specified layer """
         return self._operator.nodes_from_layer(layer_number=layer_number)
 
-    def node_children(self, node: 'GraphNode') -> List[Optional['GraphNode']]:
+    def node_children(self, node: GraphNode) -> List[Optional[GraphNode]]:
         """ Returns all node's children """
         return self._operator.node_children(node=node)
 
-    def connect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode'):
+    def connect_nodes(self, node_parent: GraphNode, node_child: GraphNode):
         """ Add an edge from node_parent to node_child """
         self._operator.connect_nodes(parent=node_parent, child=node_child)
 
-    def disconnect_nodes(self, node_parent: 'GraphNode', node_child: 'GraphNode',
+    def disconnect_nodes(self, node_parent: GraphNode, node_child: GraphNode,
                          is_clean_up_leftovers: bool = True):
         """ Delete an edge from node_parent to node_child """
         self._operator.disconnect_nodes(node_parent=node_parent, node_child=node_child,
@@ -102,7 +100,7 @@ class Graph:
          k = k(in) + k(out) """
         return self._operator.get_nodes_degrees()
 
-    def get_edges(self) -> List[Tuple['GraphNode', 'GraphNode']]:
+    def get_edges(self) -> List[Tuple[GraphNode, GraphNode]]:
         """ Returns all available edges in a given graph """
         return self._operator.get_edges()
 

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -45,15 +45,6 @@ class Graph:
 
         self.operator.update_node(old_node, new_node)
 
-    def update_subtree(self, old_subroot: 'GraphNode', new_subroot: 'GraphNode'):
-        """
-        Replace the subtrees with old and new nodes as subroots
-
-        :param old_subroot: 'GraphNode' object to replace
-        :param new_subroot: 'GraphNode' new object
-        """
-        self.operator.update_subtree(old_subroot, new_subroot)
-
     def delete_node(self, node: 'GraphNode'):
         """
         Delete chosen node redirecting all its parents to the child.
@@ -63,6 +54,15 @@ class Graph:
 
         self.operator.delete_node(node)
 
+    def update_subtree(self, old_subroot: 'GraphNode', new_subroot: 'GraphNode'):
+        """
+        Replace the subtrees with old and new nodes as subroots
+
+        :param old_subroot: 'GraphNode' object to replace
+        :param new_subroot: 'GraphNode' new object
+        """
+        self.operator.update_subtree(old_subroot, new_subroot)
+
     def delete_subtree(self, subroot: 'GraphNode'):
         """
         Delete the subtree with node as subroot.
@@ -70,6 +70,9 @@ class Graph:
         :param subroot:
         """
         self.operator.delete_subtree(subroot)
+
+    def distance_to_root_level(self, node: 'GraphNode') -> int:
+        return self.operator.distance_to_root_level(node=node)
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -219,7 +219,7 @@ class GraphOperator:
         node_degrees = [node_degree[1] for node_degree in index_degree_pairs]
         return node_degrees
 
-    def get_all_edges(self) -> List[Tuple[GraphNode, GraphNode]]:
+    def get_edges(self) -> List[Tuple[GraphNode, GraphNode]]:
         """ Returns all available edges in a given graph """
         edges = []
         for node in self._graph.nodes:
@@ -228,22 +228,24 @@ class GraphOperator:
                     edges.append((parent_node, node))
         return edges
 
-    def distance_to(self, other_graph: 'Graph') -> int:
-        """ Returns distance to specified graph """
-        def node_match(node_data_1: Dict[str, GraphNode], node_data_2: Dict[str, GraphNode]) -> bool:
-            node_1, node_2 = node_data_1.get('node'), node_data_2.get('node')
 
-            is_operation_match = str(node_1) == str(node_2)
-            is_params_match = node_1.content.get('params') == node_2.content.get('params')
-            is_match = is_operation_match and is_params_match
-            return is_match
+def get_distance_between(graph_1: 'Graph', graph_2: 'Graph') -> int:
+    """ Returns distance between specified graphs """
 
-        graphs = (self._graph, other_graph)
-        nx_graphs = []
-        for graph in graphs:
-            nx_graph, nodes = graph_structure_as_nx_graph(graph)
-            set_node_attributes(nx_graph, nodes, name='node')
-            nx_graphs.append(nx_graph)
+    def node_match(node_data_1: Dict[str, GraphNode], node_data_2: Dict[str, GraphNode]) -> bool:
+        node_1, node_2 = node_data_1.get('node'), node_data_2.get('node')
 
-        distance = graph_edit_distance(*nx_graphs, node_match=node_match)
-        return int(distance)
+        is_operation_match = str(node_1) == str(node_2)
+        is_params_match = node_1.content.get('params') == node_2.content.get('params')
+        is_match = is_operation_match and is_params_match
+        return is_match
+
+    graphs = (graph_1, graph_2)
+    nx_graphs = []
+    for graph in graphs:
+        nx_graph, nodes = graph_structure_as_nx_graph(graph)
+        set_node_attributes(nx_graph, nodes, name='node')
+        nx_graphs.append(nx_graph)
+
+    distance = graph_edit_distance(*nx_graphs, node_match=node_match)
+    return int(distance)

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -23,7 +23,7 @@ class GraphOperator:
         if node.nodes_from and len(node_children_cached) == 1:
             for node_from in node.nodes_from:
                 node_children_cached[0].nodes_from.append(node_from)
-        self._graph.nodes.clear()
+        self._graph._nodes.clear()
         self.add_node(self_root_node_cached)
         self._postproc_nodes()
 
@@ -31,7 +31,7 @@ class GraphOperator:
         """Delete node with all the parents it has.
         and delete all edges from removed nodes to remaining graph nodes."""
         subtree_nodes = node.ordered_subnodes_hierarchy()
-        self._graph.nodes = remove_items(self._graph.nodes, subtree_nodes)
+        self._graph._nodes = remove_items(self._graph.nodes, subtree_nodes)
         # prune all edges coming from the removed subtree
         for node in self._graph.nodes:
             node.nodes_from = remove_items(node.nodes_from, subtree_nodes)
@@ -108,7 +108,7 @@ class GraphOperator:
             nodes = self._graph.nodes
         else:
             nodes = self._graph.root_node.ordered_subnodes_hierarchy()
-        self._graph.nodes = nodes
+        self._graph._nodes = nodes
 
     def node_children(self, node: GraphNode) -> List[Optional[GraphNode]]:
         return [other_node for other_node in self._graph.nodes

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -220,10 +220,7 @@ class GraphOperator:
         return node_degrees
 
     def get_all_edges(self) -> List[Tuple[GraphNode, GraphNode]]:
-        """
-        Method to get all available edges in a given graph
-        """
-
+        """ Returns all available edges in a given graph """
         edges = []
         for node in self._graph.nodes:
             if node.nodes_from:
@@ -232,6 +229,7 @@ class GraphOperator:
         return edges
 
     def distance_to(self, other_graph: 'Graph') -> int:
+        """ Returns distance to specified graph """
         def node_match(node_data_1: Dict[str, GraphNode], node_data_2: Dict[str, GraphNode]) -> bool:
             node_1, node_2 = node_data_1.get('node'), node_data_2.get('node')
 

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -116,15 +116,16 @@ class GraphOperator:
                 node in other_node.nodes_from]
 
     def connect_nodes(self, parent: GraphNode, child: GraphNode):
-        if child.descriptive_id not in [p.descriptive_id for p in parent.ordered_subnodes_hierarchy()]:
-            if child.nodes_from:
-                # if not already connected
-                child.nodes_from.append(parent)
-            else:
-                # add parent to initial node
-                new_child = GraphNode(nodes_from=[], content=child.content)
-                new_child.nodes_from.append(parent)
-                self.update_node(child, new_child)
+        if child in self.node_children(parent):
+            return
+        # if not already connected
+        if child.nodes_from:
+            child.nodes_from.append(parent)
+        else:
+            # add parent to initial node
+            new_child = GraphNode(nodes_from=[], content=child.content)
+            new_child.nodes_from.append(parent)
+            self.update_node(child, new_child)
 
     def _clean_up_leftovers(self, node: GraphNode):
         """

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -103,7 +103,7 @@ class GraphOperator:
             old_node_child.nodes_from[updated_index] = new_node
 
     def sort_nodes(self):
-        """layer by layer sorting"""
+        """ Layer by layer sorting """
         if isinstance(self._graph.root_node, list):
             nodes = self._graph.nodes
         else:
@@ -213,7 +213,7 @@ class GraphOperator:
 
     def get_nodes_degrees(self):
         """ Nodes degree as the number of edges the node has:
-         k = k(in) + k(out)"""
+         k = k(in) + k(out) """
         graph, _ = graph_structure_as_nx_graph(self._graph)
         index_degree_pairs = graph.degree
         node_degrees = [node_degree[1] for node_degree in index_degree_pairs]

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -110,7 +110,7 @@ class GraphOperator:
             nodes = self._graph.root_node.ordered_subnodes_hierarchy()
         self._graph.nodes = nodes
 
-    def node_children(self, node) -> List[Optional[GraphNode]]:
+    def node_children(self, node: GraphNode) -> List[Optional[GraphNode]]:
         return [other_node for other_node in self._graph.nodes
                 if other_node.nodes_from and
                 node in other_node.nodes_from]
@@ -169,7 +169,7 @@ class GraphOperator:
         if not self._graph.nodes:
             return []
         roots = [node for node in self._graph.nodes
-                 if not any(self._graph.operator.node_children(node))]
+                 if not any(self._graph.node_children(node))]
         if len(roots) == 1:
             return roots[0]
         return roots

--- a/fedot/core/dag/graph_operator.py
+++ b/fedot/core/dag/graph_operator.py
@@ -23,7 +23,7 @@ class GraphOperator:
         if node.nodes_from and len(node_children_cached) == 1:
             for node_from in node.nodes_from:
                 node_children_cached[0].nodes_from.append(node_from)
-        self._graph._nodes.clear()
+        self._graph.nodes.clear()
         self.add_node(self_root_node_cached)
         self._postproc_nodes()
 

--- a/fedot/core/optimisers/gp_comp/gp_operators.py
+++ b/fedot/core/optimisers/gp_comp/gp_operators.py
@@ -56,7 +56,7 @@ def graph_growth(graph: OptGraph,
     offspring_size = randint(requirements.min_arity, requirements.max_arity)
 
     for offspring_node in range(offspring_size):
-        height = graph.operator.distance_to_root_level(node_parent)
+        height = graph.distance_to_root_level(node_parent)
         is_max_depth_exceeded = height >= max_depth - 2
         is_primary_node_selected = height < max_depth - 1 and randint(0, 1)
         if is_max_depth_exceeded or is_primary_node_selected:

--- a/fedot/core/optimisers/gp_comp/operators/crossover.py
+++ b/fedot/core/optimisers/gp_comp/operators/crossover.py
@@ -93,8 +93,8 @@ def subtree_crossover(graph_first: Any, graph_second: Any, max_depth: int) -> An
     min_second_layer = 1 if random_layer_in_graph_first == 0 and graph_second.depth > 1 else 0
     random_layer_in_graph_second = choice(range(min_second_layer, graph_second.depth))
 
-    node_from_graph_first = choice(graph_first.operator.nodes_from_layer(random_layer_in_graph_first))
-    node_from_graph_second = choice(graph_second.operator.nodes_from_layer(random_layer_in_graph_second))
+    node_from_graph_first = choice(graph_first.nodes_from_layer(random_layer_in_graph_first))
+    node_from_graph_second = choice(graph_second.nodes_from_layer(random_layer_in_graph_second))
 
     replace_subtrees(graph_first, graph_second, node_from_graph_first, node_from_graph_second,
                      random_layer_in_graph_first, random_layer_in_graph_second, max_depth)

--- a/fedot/core/optimisers/gp_comp/operators/mutation.py
+++ b/fedot/core/optimisers/gp_comp/operators/mutation.py
@@ -313,9 +313,9 @@ class Mutation:
             is_primary_node_selected = (not node_from_graph.nodes_from) or (node_from_graph != graph.root_node and
                                                                             randint(0, 1))
         else:
-            max_depth = self.requirements.max_depth - graph.operator.distance_to_root_level(node_from_graph)
+            max_depth = self.requirements.max_depth - graph.distance_to_root_level(node_from_graph)
             is_primary_node_selected = \
-                graph.operator.distance_to_root_level(node_from_graph) >= self.requirements.max_depth and randint(0, 1)
+                graph.distance_to_root_level(node_from_graph) >= self.requirements.max_depth and randint(0, 1)
         if is_primary_node_selected:
             new_subtree = self.graph_generation_params.node_factory.get_node(primary=True)
             if not new_subtree:

--- a/fedot/core/optimisers/gp_comp/operators/mutation.py
+++ b/fedot/core/optimisers/gp_comp/operators/mutation.py
@@ -192,7 +192,7 @@ class Mutation:
             nodes_not_cycling = (target_node.descriptive_id not in
                                  [n.descriptive_id for n in source_node.ordered_subnodes_hierarchy()])
             if nodes_not_cycling and (target_node.nodes_from is None or source_node not in target_node.nodes_from):
-                graph.operator.connect_nodes(source_node, target_node)
+                graph.connect_nodes(source_node, target_node)
                 break
 
         if graph.depth > self.requirements.max_depth:
@@ -228,9 +228,12 @@ class Mutation:
         new_node = self.graph_generation_params.node_factory.get_node(primary=False)
         if not new_node:
             return graph
-        new_node.nodes_from = [node_to_mutate]
-        graph.actualise_old_node_children(node_to_mutate, new_node)
-        graph.nodes.append(new_node)
+        parents_node_to_mutate = node_to_mutate.nodes_from or []
+        graph.update_node(old_node=node_to_mutate, new_node=new_node)
+        graph.add_node(node_to_mutate)
+        graph.connect_nodes(node_parent=node_to_mutate, node_child=new_node)
+        for node_parent in parents_node_to_mutate:
+            graph.disconnect_nodes(node_parent=node_parent, node_child=new_node)
         return graph
 
     def _single_add_mutation(self, graph: Any, *args, **kwargs):
@@ -289,7 +292,7 @@ class Mutation:
         elif removal_type != RemoveType.forbidden:
             graph.delete_node(node_to_del)
             if node_to_del.nodes_from:
-                children = graph.operator.node_children(node_to_del)
+                children = graph.node_children(node_to_del)
                 for child in children:
                     if child.nodes_from:
                         child.nodes_from.extend(node_to_del.nodes_from)
@@ -355,7 +358,7 @@ class Mutation:
 
         nodes = [node for node in graph.nodes if node is not graph.root_node]
         node_to_del = choice(nodes)
-        children = graph.operator.node_children(node_to_del)
+        children = graph.node_children(node_to_del)
         is_possible_to_delete = all([len(child.nodes_from) - 1 >= self.requirements.min_arity for child in children])
         if is_possible_to_delete:
             graph.delete_subtree(node_to_del)

--- a/fedot/core/optimisers/gp_comp/operators/mutation.py
+++ b/fedot/core/optimisers/gp_comp/operators/mutation.py
@@ -229,7 +229,7 @@ class Mutation:
         if not new_node:
             return graph
         new_node.nodes_from = [node_to_mutate]
-        graph.operator.actualise_old_node_children(node_to_mutate, new_node)
+        graph.actualise_old_node_children(node_to_mutate, new_node)
         graph.nodes.append(new_node)
         return graph
 

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -163,6 +163,10 @@ class OptGraph:
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
         return self.operator.nodes_from_layer(layer_number=layer_number)
 
+    def actualise_old_node_children(self, old_node: OptNode, new_node: OptNode):
+        self.operator.actualise_old_node_children(old_node=self._node_adapter.restore(old_node),
+                                                  new_node=self._node_adapter.restore(new_node))
+
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)
 

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -160,6 +160,9 @@ class OptGraph:
     def distance_to_root_level(self, node: OptNode) -> int:
         return self.operator.distance_to_root_level(node=self._node_adapter.restore(node))
 
+    def nodes_from_layer(self, layer_number: int) -> List[Any]:
+        return self.operator.nodes_from_layer(layer_number=layer_number)
+
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)
 

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -189,9 +189,12 @@ class OptGraph:
                                         is_clean_up_leftovers=is_clean_up_leftovers)
 
     def get_nodes_degrees(self):
+        """ Nodes degree as the number of edges the node has:
+         k = k(in) + k(out) """
         return self._operator.get_nodes_degrees()
 
     def get_all_edges(self):
+        """ Returns all available edges in a given graph """
         return self._operator.get_all_edges()
 
     def distance_to(self, other_graph: 'OptGraph') -> int:

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -178,7 +178,7 @@ class OptGraph:
     def connect_nodes(self, node_parent: OptNode, node_child: OptNode):
         """ Add an edge from node_parent to node_child """
         self._operator.connect_nodes(parent=self._node_adapter.restore(node_parent),
-                                    child=self._node_adapter.restore(node_child))
+                                     child=self._node_adapter.restore(node_child))
 
     @node_ops_adaptation
     def disconnect_nodes(self, node_parent: OptNode, node_child: OptNode,

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -93,7 +93,7 @@ class OptGraph:
         self.log = default_log(self)
 
         self._nodes = []
-        self.operator = GraphOperator(self, self._empty_postproc)
+        self._operator = GraphOperator(self, self._empty_postproc)
 
         if nodes:
             for node in ensure_wrapped_in_sequence(nodes):
@@ -117,7 +117,7 @@ class OptGraph:
 
         :param new_node: new OptNode object
         """
-        self.operator.add_node(self._node_adapter.restore(new_node))
+        self._operator.add_node(self._node_adapter.restore(new_node))
 
     @node_ops_adaptation
     def update_node(self, old_node: OptNode, new_node: OptNode):
@@ -128,8 +128,8 @@ class OptGraph:
         :param new_node: OptNode object to replace
         """
 
-        self.operator.update_node(self._node_adapter.restore(old_node),
-                                  self._node_adapter.restore(new_node))
+        self._operator.update_node(self._node_adapter.restore(old_node),
+                                   self._node_adapter.restore(new_node))
 
     @node_ops_adaptation
     def delete_node(self, node: OptNode):
@@ -139,7 +139,7 @@ class OptGraph:
         :param node: OptNode object to delete
         """
 
-        self.operator.delete_node(self._node_adapter.restore(node))
+        self._operator.delete_node(self._node_adapter.restore(node))
 
     @node_ops_adaptation
     def update_subtree(self, old_subroot: OptNode, new_subroot: OptNode):
@@ -149,8 +149,8 @@ class OptGraph:
         :param old_subroot: OptNode object to replace
         :param new_subroot: OptNode object to replace
         """
-        self.operator.update_subtree(self._node_adapter.restore(old_subroot),
-                                     self._node_adapter.restore(new_subroot))
+        self._operator.update_subtree(self._node_adapter.restore(old_subroot),
+                                      self._node_adapter.restore(new_subroot))
 
     @node_ops_adaptation
     def delete_subtree(self, subroot: OptNode):
@@ -159,65 +159,65 @@ class OptGraph:
 
         :param subroot:
         """
-        self.operator.delete_subtree(self._node_adapter.restore(subroot))
+        self._operator.delete_subtree(self._node_adapter.restore(subroot))
 
     def distance_to_root_level(self, node: OptNode) -> int:
         """ Returns distance to root level """
-        return self.operator.distance_to_root_level(node=self._node_adapter.restore(node))
+        return self._operator.distance_to_root_level(node=self._node_adapter.restore(node))
 
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
         """ Returns all nodes from specified layer """
-        return self.operator.nodes_from_layer(layer_number=layer_number)
+        return self._operator.nodes_from_layer(layer_number=layer_number)
 
     @node_ops_adaptation
     def node_children(self, node: OptNode) -> List[Optional[OptNode]]:
         """ Returns all node's children """
-        return self.operator.node_children(node=self._node_adapter.restore(node))
+        return self._operator.node_children(node=self._node_adapter.restore(node))
 
     @node_ops_adaptation
     def connect_nodes(self, node_parent: OptNode, node_child: OptNode):
         """ Add an edge from node_parent to node_child """
-        self.operator.connect_nodes(parent=self._node_adapter.restore(node_parent),
+        self._operator.connect_nodes(parent=self._node_adapter.restore(node_parent),
                                     child=self._node_adapter.restore(node_child))
 
     @node_ops_adaptation
     def disconnect_nodes(self, node_parent: OptNode, node_child: OptNode,
                          is_clean_up_leftovers: bool = True):
         """ Delete an edge from node_parent to node_child """
-        self.operator.disconnect_nodes(node_parent=self._node_adapter.restore(node_parent),
-                                       node_child=self._node_adapter.restore(node_child),
-                                       is_clean_up_leftovers=is_clean_up_leftovers)
+        self._operator.disconnect_nodes(node_parent=self._node_adapter.restore(node_parent),
+                                        node_child=self._node_adapter.restore(node_child),
+                                        is_clean_up_leftovers=is_clean_up_leftovers)
 
     def get_nodes_degrees(self):
-        return self.operator.get_nodes_degrees()
+        return self._operator.get_nodes_degrees()
 
     def get_all_edges(self):
-        return self.operator.get_all_edges()
+        return self._operator.get_all_edges()
 
     def distance_to(self, other_graph: 'OptGraph') -> int:
         """ Returns distance to specified graph """
-        return self.operator.distance_to(other_graph=other_graph)
+        return self._operator.distance_to(other_graph=other_graph)
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)
 
     def __eq__(self, other) -> bool:
-        return self.operator.is_graph_equal(other)
+        return self._operator.is_graph_equal(other)
 
     def __str__(self):
-        return self.operator.graph_description()
+        return self._operator.graph_description()
 
     def __repr__(self):
         return self.__str__()
 
     @property
     def root_node(self):
-        roots = self.operator.root_node()
+        roots = self._operator.root_node()
         return roots
 
     @property
     def descriptive_id(self):
-        return self.operator.descriptive_id
+        return self._operator.descriptive_id
 
     @property
     def length(self) -> int:
@@ -225,7 +225,7 @@ class OptGraph:
 
     @property
     def depth(self) -> int:
-        return self.operator.graph_depth()
+        return self._operator.graph_depth()
 
     def __copy__(self):
         cls = self.__class__

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -193,13 +193,9 @@ class OptGraph:
          k = k(in) + k(out) """
         return self._operator.get_nodes_degrees()
 
-    def get_all_edges(self):
+    def get_edges(self):
         """ Returns all available edges in a given graph """
-        return self._operator.get_all_edges()
-
-    def distance_to(self, other_graph: 'OptGraph') -> int:
-        """ Returns distance to specified graph """
-        return self._operator.distance_to(other_graph=other_graph)
+        return self._operator.get_edges()
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -19,7 +19,7 @@ def node_ops_adaptation(func):
 
     def _decorator(self, *args, **kwargs):
         func_result = func(self, *args, **kwargs)
-        self.nodes = [_adapt(self._node_adapter, node) for node in self.nodes]
+        self._nodes = [_adapt(self._node_adapter, node) for node in self.nodes]
         return func_result
 
     return _decorator
@@ -92,7 +92,7 @@ class OptGraph:
     def __init__(self, nodes: Optional[Union[OptNode, List[OptNode]]] = None):
         self.log = default_log(self)
 
-        self.nodes = []
+        self._nodes = []
         self.operator = GraphOperator(self, self._empty_postproc)
 
         if nodes:
@@ -101,6 +101,10 @@ class OptGraph:
 
     def _empty_postproc(self, nodes=None):
         pass
+
+    @property
+    def nodes(self):
+        return self._nodes
 
     @property
     def _node_adapter(self):

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -128,6 +128,16 @@ class OptGraph:
                                   self._node_adapter.restore(new_node))
 
     @node_ops_adaptation
+    def delete_node(self, node: OptNode):
+        """
+        Delete chosen node redirecting all its parents to the child.
+
+        :param node: OptNode object to delete
+        """
+
+        self.operator.delete_node(self._node_adapter.restore(node))
+
+    @node_ops_adaptation
     def update_subtree(self, old_subroot: OptNode, new_subroot: OptNode):
         """
         Replace the subtrees with old and new nodes as subroots
@@ -139,16 +149,6 @@ class OptGraph:
                                      self._node_adapter.restore(new_subroot))
 
     @node_ops_adaptation
-    def delete_node(self, node: OptNode):
-        """
-        Delete chosen node redirecting all its parents to the child.
-
-        :param node: OptNode object to delete
-        """
-
-        self.operator.delete_node(self._node_adapter.restore(node))
-
-    @node_ops_adaptation
     def delete_subtree(self, subroot: OptNode):
         """
         Delete the subtree with node as subroot.
@@ -156,6 +156,9 @@ class OptGraph:
         :param subroot:
         """
         self.operator.delete_subtree(self._node_adapter.restore(subroot))
+
+    def distance_to_root_level(self, node: OptNode) -> int:
+        return self.operator.distance_to_root_level(node=self._node_adapter.restore(node))
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Iterable, List, Optional, Union
+from typing import Any, Iterable, List, Optional, Union, Tuple
 from uuid import uuid4
 
 from fedot.core.dag.graph_node import GraphNode
@@ -163,9 +163,38 @@ class OptGraph:
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
         return self.operator.nodes_from_layer(layer_number=layer_number)
 
+    @node_ops_adaptation
     def actualise_old_node_children(self, old_node: OptNode, new_node: OptNode):
         self.operator.actualise_old_node_children(old_node=self._node_adapter.restore(old_node),
                                                   new_node=self._node_adapter.restore(new_node))
+
+    def sort_nodes(self):
+        self.operator.sort_nodes()
+
+    @node_ops_adaptation
+    def node_children(self, node: OptNode) -> List[Optional[OptNode]]:
+        return self.operator.node_children(node=self._node_adapter.restore(node))
+
+    @node_ops_adaptation
+    def connect_nodes(self, node_parent: OptNode, node_child: OptNode):
+        self.operator.connect_nodes(parent=self._node_adapter.restore(node_parent),
+                                    child=self._node_adapter.restore(node_child))
+
+    @node_ops_adaptation
+    def disconnect_nodes(self, node_parent: OptNode, node_child: OptNode,
+                         is_clean_up_leftovers: bool = True):
+        self.operator.disconnect_nodes(node_parent=self._node_adapter.restore(node_parent),
+                                       node_child=self._node_adapter.restore(node_child),
+                                       is_clean_up_leftovers=is_clean_up_leftovers)
+
+    def get_nodes_degrees(self):
+        return self.operator.get_nodes_degrees()
+
+    def get_all_edges(self):
+        return self.operator.get_all_edges()
+
+    def distance_to(self, other_graph: 'OptGraph') -> int:
+        return self.operator.distance_to(other_graph=other_graph)
 
     def show(self, path: str = None):
         GraphVisualiser().visualise(self, path)

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -158,31 +158,28 @@ class OptGraph:
         self.operator.delete_subtree(self._node_adapter.restore(subroot))
 
     def distance_to_root_level(self, node: OptNode) -> int:
+        """ Returns distance to root level """
         return self.operator.distance_to_root_level(node=self._node_adapter.restore(node))
 
     def nodes_from_layer(self, layer_number: int) -> List[Any]:
+        """ Returns all nodes from specified layer """
         return self.operator.nodes_from_layer(layer_number=layer_number)
 
     @node_ops_adaptation
-    def actualise_old_node_children(self, old_node: OptNode, new_node: OptNode):
-        self.operator.actualise_old_node_children(old_node=self._node_adapter.restore(old_node),
-                                                  new_node=self._node_adapter.restore(new_node))
-
-    def sort_nodes(self):
-        self.operator.sort_nodes()
-
-    @node_ops_adaptation
     def node_children(self, node: OptNode) -> List[Optional[OptNode]]:
+        """ Returns all node's children """
         return self.operator.node_children(node=self._node_adapter.restore(node))
 
     @node_ops_adaptation
     def connect_nodes(self, node_parent: OptNode, node_child: OptNode):
+        """ Add an edge from node_parent to node_child """
         self.operator.connect_nodes(parent=self._node_adapter.restore(node_parent),
                                     child=self._node_adapter.restore(node_child))
 
     @node_ops_adaptation
     def disconnect_nodes(self, node_parent: OptNode, node_child: OptNode,
                          is_clean_up_leftovers: bool = True):
+        """ Delete an edge from node_parent to node_child """
         self.operator.disconnect_nodes(node_parent=self._node_adapter.restore(node_parent),
                                        node_child=self._node_adapter.restore(node_child),
                                        is_clean_up_leftovers=is_clean_up_leftovers)
@@ -194,6 +191,7 @@ class OptGraph:
         return self.operator.get_all_edges()
 
     def distance_to(self, other_graph: 'OptGraph') -> int:
+        """ Returns distance to specified graph """
         return self.operator.distance_to(other_graph=other_graph)
 
     def show(self, path: str = None):

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -276,7 +276,7 @@ class Pipeline(Graph, Serializable):
         :param source path to json file with operation
         :param dict_fitted_operations dictionary of the fitted operations
         """
-        self.nodes = []
+        self._nodes = []
         template = PipelineTemplate(self)
         template.import_pipeline(source, dict_fitted_operations)
 

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -39,7 +39,7 @@ class Pipeline(Graph, Serializable):
         # Define data preprocessor
         self.preprocessor = DataPreprocessor()
         super().__init__(nodes)
-        self.operator = GraphOperator(self, self._graph_nodes_to_pipeline_nodes)
+        self._operator = GraphOperator(self, self._graph_nodes_to_pipeline_nodes)
 
     def _graph_nodes_to_pipeline_nodes(self, nodes: List[Node] = None):
         """Method to update nodes types after performing some action on the pipeline

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -59,8 +59,7 @@ class Pipeline(Graph, Serializable):
                 self.nodes.remove(node)
             elif not node.nodes_from and not isinstance(node, PrimaryNode):
                 self.update_node(old_node=node,
-                                 new_node=PrimaryNode(nodes_from=node.nodes_from,
-                                                      content=node.content))
+                                 new_node=PrimaryNode(content=node.content))
 
     def fit_from_scratch(self, input_data: Union[InputData, MultiModalData] = None):
         """

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -52,15 +52,15 @@ class Pipeline(Graph, Serializable):
             if not isinstance(node, GraphNode):
                 continue
             if node.nodes_from and not isinstance(node, SecondaryNode):
-                self.operator.update_node(old_node=node,
-                                          new_node=SecondaryNode(nodes_from=node.nodes_from,
-                                                                 content=node.content))
-            elif not node.nodes_from and not self.operator.node_children(node) and node != self.root_node:
+                self.update_node(old_node=node,
+                                 new_node=SecondaryNode(nodes_from=node.nodes_from,
+                                                        content=node.content))
+            elif not node.nodes_from and not self.node_children(node) and node != self.root_node:
                 self.nodes.remove(node)
             elif not node.nodes_from and not isinstance(node, PrimaryNode):
-                self.operator.update_node(old_node=node,
-                                          new_node=PrimaryNode(nodes_from=node.nodes_from,
-                                                               content=node.content))
+                self.update_node(old_node=node,
+                                 new_node=PrimaryNode(nodes_from=node.nodes_from,
+                                                      content=node.content))
 
     def fit_from_scratch(self, input_data: Union[InputData, MultiModalData] = None):
         """
@@ -297,7 +297,7 @@ class Pipeline(Graph, Serializable):
         if len(self.nodes) == 0:
             return None
         root = [node for node in self.nodes
-                if not any(self.operator.node_children(node))]
+                if not any(self.node_children(node))]
         if len(root) > 1:
             raise ValueError(f'{ERROR_PREFIX} More than 1 root_nodes in pipeline')
         return root[0]

--- a/fedot/core/pipelines/tuning/sequential.py
+++ b/fedot/core/pipelines/tuning/sequential.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from functools import partial
-from typing import Callable, ClassVar, Optional
+from typing import Callable, ClassVar
 
 from hyperopt import fmin, space_eval, tpe
 
@@ -40,7 +40,7 @@ class SequentialTuner(HyperoptTuner):
         self.init_check(input_data, loss_function, loss_params)
 
         # Calculate amount of iterations we can apply per node
-        nodes_amount = len(self.pipeline.nodes)
+        nodes_amount = self.pipeline.length
         iterations_per_node = round(self.iterations / nodes_amount)
         iterations_per_node = int(iterations_per_node)
         if iterations_per_node == 0:

--- a/fedot/core/pipelines/verification_rules.py
+++ b/fedot/core/pipelines/verification_rules.py
@@ -231,7 +231,7 @@ def has_parent_contain_single_resample(pipeline: Pipeline):
 
     for node in pipeline.nodes:
         if node.operation.operation_type == 'resample':
-            children_nodes = pipeline.operator.node_children(node)
+            children_nodes = pipeline.node_children(node)
             for child_node in children_nodes:
                 if len(child_node.nodes_from) > 1:
                     raise ValueError(f'{ERROR_PREFIX} Resample node is not single parent node for child operation')

--- a/fedot/core/serializers/coders/graph_serialization.py
+++ b/fedot/core/serializers/coders/graph_serialization.py
@@ -22,7 +22,12 @@ def graph_from_json(cls: Type[Graph], json_obj: Dict[str, Any]) -> Graph:
         (cause each node from "nodes_from" in fact should point to the same node from "nodes")
     """
     obj = cls()
-    nodes = json_obj['nodes']
+
+    # TODO: generate new test history with _nodes instead of nodes when PR will be approved
+    try:
+        nodes = json_obj['nodes']
+    except KeyError:
+        nodes = json_obj['_nodes']
 
     lookup_dict = {node.uid: node for node in nodes}
 
@@ -30,6 +35,6 @@ def graph_from_json(cls: Type[Graph], json_obj: Dict[str, Any]) -> Graph:
         if node.nodes_from:
             for parent_node_idx, parent_node_uid in enumerate(node.nodes_from):
                 node.nodes_from[parent_node_idx] = lookup_dict.get(parent_node_uid, None)
-    obj.nodes = nodes
+    obj._nodes = nodes
     vars(obj).update(**{k: v for k, v in json_obj.items() if k != 'nodes'})
     return obj

--- a/fedot/core/serializers/coders/graph_serialization.py
+++ b/fedot/core/serializers/coders/graph_serialization.py
@@ -11,7 +11,7 @@ def graph_to_json(obj: Graph) -> Dict[str, Any]:
     serialized_obj = {
         k: v
         for k, v in any_to_json(obj).items()
-        if k != 'operator'  # to prevent circular reference
+        if k != '_operator'  # to prevent circular reference
     }
     return serialized_obj
 

--- a/fedot/sensitivity/deletion_methods/multi_times_analysis.py
+++ b/fedot/sensitivity/deletion_methods/multi_times_analysis.py
@@ -70,7 +70,7 @@ class MultiTimesAnalyze:
         total_nodes_deleted = 0
         iteration_index = 1
         worst_node_score = meta_params.worst_node_score
-        while worst_node_score > 1.0 + meta_params.delta and len(self.pipeline.nodes) > 2:
+        while worst_node_score > 1.0 + meta_params.delta and self.pipeline.length > 2:
             self.log.info('new iteration of MTA deletion analysis')
             iteration_result_path = join(self.path_to_save, f'iter_{iteration_index}')
             pipeline_analysis_result = self._pipeline_analysis(result_path=iteration_result_path,

--- a/test/unit/dag/test_graph.py
+++ b/test/unit/dag/test_graph.py
@@ -69,7 +69,7 @@ def test_delete_primary_node():
     new_primary_node = [node for node in graph.nodes if node.content['name'] == 'n2'][0]
 
     # then
-    assert len(graph.nodes) == 3
+    assert graph.length == 3
     assert isinstance(new_primary_node, GraphNode)
 
 

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -45,7 +45,7 @@ def test_nodes_from_layer():
     desired_layer = 2
 
     # when
-    nodes_from_desired_layer = pipeline.operator.nodes_from_layer(desired_layer)
+    nodes_from_desired_layer = pipeline.nodes_from_layer(desired_layer)
 
     # then
     assert len(nodes_from_desired_layer) == 2

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -33,7 +33,7 @@ def test_distance_to_root_level():
     selected_node = pipeline.nodes[2]
 
     # when
-    height = pipeline.operator.distance_to_root_level(selected_node)
+    height = pipeline.distance_to_root_level(selected_node)
 
     # then
     assert height == 2

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -76,7 +76,7 @@ def test_sort_nodes():
 
     # when
     selected_node.nodes_from.append(new_subroot)
-    pipeline.operator.sort_nodes()
+    pipeline.sort_nodes()
 
     # then
     assert pipeline.length == original_length + 2
@@ -90,7 +90,7 @@ def test_node_children():
     selected_node = pipeline.nodes[2]
 
     # when
-    children = pipeline.operator.node_children(selected_node)
+    children = pipeline.node_children(selected_node)
 
     # then
     assert len(children) == 1
@@ -107,7 +107,7 @@ def test_distance_to_same_pipeline_restored():
     opt_graph = adapter.adapt(pipeline)
 
     # when
-    distance = pipeline.operator.distance_to(adapter.restore(opt_graph))
+    distance = pipeline.distance_to(adapter.restore(opt_graph))
 
     # then
     assert distance == 0
@@ -121,12 +121,12 @@ def test_known_distances():
     pipeline_knn_alternate_params = PipelineBuilder().add_node('scaling').\
         add_node('knn', params={'metric': 'euclidean'}).to_pipeline()  # scaling -> knn_alternate_params
 
-    assert pipeline_knn.operator.distance_to(pipeline_knn) == 0  # the same pipeline
-    assert pipeline_knn.operator.distance_to(pipeline_scaling) == 2  # changes: 1 node (operation) + 1 edge
-    assert pipeline_knn.operator.distance_to(pipeline_linear) == 1  # changes: 1 node (operation)
-    assert pipeline_knn.operator.distance_to(pipeline_knn_alternate_params) == 1  # changes: 1 node (params)
-    assert pipeline_knn.operator.distance_to(pipeline_xgboost) == 3  # changes: 2 nodes (operations) + 1 edge
-    assert pipeline_linear.operator.distance_to(pipeline_knn_alternate_params) == 1  # changes: 1 operation + params
+    assert pipeline_knn.distance_to(pipeline_knn) == 0  # the same pipeline
+    assert pipeline_knn.distance_to(pipeline_scaling) == 2  # changes: 1 node (operation) + 1 edge
+    assert pipeline_knn.distance_to(pipeline_linear) == 1  # changes: 1 node (operation)
+    assert pipeline_knn.distance_to(pipeline_knn_alternate_params) == 1  # changes: 1 node (params)
+    assert pipeline_knn.distance_to(pipeline_xgboost) == 3  # changes: 2 nodes (operations) + 1 edge
+    assert pipeline_linear.distance_to(pipeline_knn_alternate_params) == 1  # changes: 1 operation + params
 
 
 # ------------------------------------------------------------------------------
@@ -203,7 +203,7 @@ def test_disconnect_nodes_method_first():
     knn_node = pipeline.nodes[4]
     knn_root_node = pipeline.nodes[0]
 
-    pipeline.operator.disconnect_nodes(knn_node, knn_root_node)
+    pipeline.disconnect_nodes(knn_node, knn_root_node)
 
     assert res_pipeline == pipeline
 
@@ -217,7 +217,7 @@ def test_disconnect_nodes_method_second():
     rf_node = pipeline.nodes[5]
     knn_node = pipeline.nodes[4]
 
-    pipeline.operator.disconnect_nodes(rf_node, knn_node)
+    pipeline.disconnect_nodes(rf_node, knn_node)
 
     assert res_pipeline == pipeline
 
@@ -231,7 +231,7 @@ def test_disconnect_nodes_method_third():
     qda_node = pipeline.nodes[1]
     knn_root_node = pipeline.nodes[0]
 
-    pipeline.operator.disconnect_nodes(qda_node, knn_root_node)
+    pipeline.disconnect_nodes(qda_node, knn_root_node)
 
     assert res_pipeline == pipeline
 
@@ -245,7 +245,7 @@ def test_disconnect_nodes_method_fourth():
     rf_node = res_pipeline.nodes[2]
     knn_root_node = res_pipeline.nodes[0]
 
-    res_pipeline.operator.disconnect_nodes(rf_node, knn_root_node)
+    res_pipeline.disconnect_nodes(rf_node, knn_root_node)
     assert res_pipeline == pipeline
 
 
@@ -258,7 +258,7 @@ def test_disconnect_nodes_method_fifth():
     rf_node = PrimaryNode('rf')
     knn_root_node = SecondaryNode('knn', nodes_from=[rf_node])
 
-    res_pipeline.operator.disconnect_nodes(rf_node, knn_root_node)
+    res_pipeline.disconnect_nodes(rf_node, knn_root_node)
     assert res_pipeline == pipeline
 
 
@@ -276,7 +276,7 @@ def test_get_all_edges():
 
     res_edges = [(knn, logit), (qda_second, knn), (qda_first, knn), (lda, qda_second)]
 
-    edges = pipeline.operator.get_all_edges()
+    edges = pipeline.get_all_edges()
     assert res_edges == edges
 
 
@@ -294,7 +294,7 @@ def test_postproc_nodes():
     lda_node = pipeline.nodes[-2]
     qda_node = pipeline.nodes[-1]
 
-    pipeline.operator.connect_nodes(lda_node, qda_node)
+    pipeline.connect_nodes(lda_node, qda_node)
 
     for node in pipeline.nodes:
         assert(isinstance(node, PrimaryNode) or isinstance(node, SecondaryNode))
@@ -312,11 +312,11 @@ def test_postproc_opt_nodes():
     lda_node = pipeline.nodes[-2]
     qda_node = pipeline.nodes[-1]
 
-    pipeline.operator.connect_nodes(lda_node, qda_node)
+    pipeline.connect_nodes(lda_node, qda_node)
 
     # Check that the postproc_nodes method does not change the type of OptNode type nodes
     new_node = OptNode({'name': "opt"})
-    pipeline.operator.update_node(old_node=lda_node,
-                                  new_node=new_node)
+    pipeline.update_node(old_node=lda_node,
+                         new_node=new_node)
     opt_node = pipeline.nodes[3]
     assert (isinstance(opt_node, OptNode))

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -121,12 +121,18 @@ def test_known_distances():
     pipeline_knn_alternate_params = PipelineBuilder().add_node('scaling').\
         add_node('knn', params={'metric': 'euclidean'}).to_pipeline()  # scaling -> knn_alternate_params
 
-    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_knn) == 0  # the same pipeline
-    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_scaling) == 2  # changes: 1 node (operation) + 1 edge
-    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_linear) == 1  # changes: 1 node (operation)
-    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_knn_alternate_params) == 1  # changes: 1 node (params)
-    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_xgboost) == 3  # changes: 2 nodes (operations) + 1 edge
-    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_knn_alternate_params) == 1  # changes: 1 operation + params
+    assert get_distance_between(graph_1=pipeline_knn,
+                                graph_2=pipeline_knn) == 0  # the same pipeline
+    assert get_distance_between(graph_1=pipeline_knn,
+                                graph_2=pipeline_scaling) == 2  # changes: 1 node (operation) + 1 edge
+    assert get_distance_between(graph_1=pipeline_knn,
+                                graph_2=pipeline_linear) == 1  # changes: 1 node (operation)
+    assert get_distance_between(graph_1=pipeline_knn,
+                                graph_2=pipeline_knn_alternate_params) == 1  # changes: 1 node (params)
+    assert get_distance_between(graph_1=pipeline_knn,
+                                graph_2=pipeline_xgboost) == 3  # changes: 2 nodes (operations) + 1 edge
+    assert get_distance_between(graph_1=pipeline_knn,
+                                graph_2=pipeline_knn_alternate_params) == 1  # changes: 1 operation + params
 
 
 # ------------------------------------------------------------------------------
@@ -263,9 +269,9 @@ def test_disconnect_nodes_method_fifth():
 
 
 # ------------------------------------------------------------------------------
-# Test for get_all_edges method
+# Test for get_edges method
 
-def test_get_all_edges():
+def test_get_edges():
     pipeline = get_pipeline()
 
     lda = pipeline.nodes[3]

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from fedot.core.dag.graph_operator import GraphOperator
+from fedot.core.dag.graph_operator import GraphOperator, get_distance_between
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.graph import OptNode
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
@@ -107,7 +107,7 @@ def test_distance_to_same_pipeline_restored():
     opt_graph = adapter.adapt(pipeline)
 
     # when
-    distance = pipeline.distance_to(adapter.restore(opt_graph))
+    distance = get_distance_between(graph_1=pipeline, graph_2=adapter.restore(opt_graph))
 
     # then
     assert distance == 0
@@ -121,12 +121,12 @@ def test_known_distances():
     pipeline_knn_alternate_params = PipelineBuilder().add_node('scaling').\
         add_node('knn', params={'metric': 'euclidean'}).to_pipeline()  # scaling -> knn_alternate_params
 
-    assert pipeline_knn.distance_to(pipeline_knn) == 0  # the same pipeline
-    assert pipeline_knn.distance_to(pipeline_scaling) == 2  # changes: 1 node (operation) + 1 edge
-    assert pipeline_knn.distance_to(pipeline_linear) == 1  # changes: 1 node (operation)
-    assert pipeline_knn.distance_to(pipeline_knn_alternate_params) == 1  # changes: 1 node (params)
-    assert pipeline_knn.distance_to(pipeline_xgboost) == 3  # changes: 2 nodes (operations) + 1 edge
-    assert pipeline_linear.distance_to(pipeline_knn_alternate_params) == 1  # changes: 1 operation + params
+    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_knn) == 0  # the same pipeline
+    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_scaling) == 2  # changes: 1 node (operation) + 1 edge
+    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_linear) == 1  # changes: 1 node (operation)
+    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_knn_alternate_params) == 1  # changes: 1 node (params)
+    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_xgboost) == 3  # changes: 2 nodes (operations) + 1 edge
+    assert get_distance_between(graph_1=pipeline_knn, graph_2=pipeline_knn_alternate_params) == 1  # changes: 1 operation + params
 
 
 # ------------------------------------------------------------------------------
@@ -276,7 +276,7 @@ def test_get_all_edges():
 
     res_edges = [(knn, logit), (qda_second, knn), (qda_first, knn), (lda, qda_second)]
 
-    edges = pipeline.get_all_edges()
+    edges = pipeline.get_edges()
     assert res_edges == edges
 
 

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -24,7 +24,7 @@ def get_pipeline() -> Pipeline:
 
 def test_pipeline_operator_init():
     pipeline = get_pipeline()
-    assert type(pipeline.operator) is GraphOperator
+    assert type(pipeline._operator) is GraphOperator
 
 
 def test_distance_to_root_level():
@@ -58,8 +58,8 @@ def test_actualise_old_node_children():
     new_node = PrimaryNode('knnreg')
 
     # when
-    pipeline.operator.actualise_old_node_children(old_node=selected_node,
-                                                  new_node=new_node)
+    pipeline._operator.actualise_old_node_children(old_node=selected_node,
+                                                   new_node=new_node)
     updated_parent = pipeline.nodes[1]
 
     # then
@@ -76,7 +76,7 @@ def test_sort_nodes():
 
     # when
     selected_node.nodes_from.append(new_subroot)
-    pipeline.operator.sort_nodes()
+    pipeline._operator.sort_nodes()
 
     # then
     assert pipeline.length == original_length + 2

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -58,8 +58,8 @@ def test_actualise_old_node_children():
     new_node = PrimaryNode('knnreg')
 
     # when
-    pipeline.actualise_old_node_children(old_node=selected_node,
-                                         new_node=new_node)
+    pipeline.operator.actualise_old_node_children(old_node=selected_node,
+                                                  new_node=new_node)
     updated_parent = pipeline.nodes[1]
 
     # then
@@ -76,7 +76,7 @@ def test_sort_nodes():
 
     # when
     selected_node.nodes_from.append(new_subroot)
-    pipeline.sort_nodes()
+    pipeline.operator.sort_nodes()
 
     # then
     assert pipeline.length == original_length + 2

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -58,8 +58,8 @@ def test_actualise_old_node_children():
     new_node = PrimaryNode('knnreg')
 
     # when
-    pipeline.operator.actualise_old_node_children(old_node=selected_node,
-                                                  new_node=new_node)
+    pipeline.actualise_old_node_children(old_node=selected_node,
+                                         new_node=new_node)
     updated_parent = pipeline.nodes[1]
 
     # then

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -101,7 +101,7 @@ def pipeline_with_custom_parameters(alpha_value):
 
 def test_nodes_from_height():
     graph = graph_example()
-    found_nodes = graph.operator.nodes_from_layer(1)
+    found_nodes = graph.nodes_from_layer(1)
     true_nodes = [node for node in graph.root_node.nodes_from]
     assert all([node_model == found_node for node_model, found_node in
                 zip(true_nodes, found_nodes)])

--- a/test/unit/pipelines/test_pipeline.py
+++ b/test/unit/pipelines/test_pipeline.py
@@ -319,7 +319,7 @@ def test_delete_node_with_redirection():
 
     pipeline.delete_node(third)
 
-    assert len(pipeline.nodes) == 3
+    assert pipeline.length == 3
     assert first in pipeline.root_node.nodes_from
 
 
@@ -338,7 +338,7 @@ def test_delete_primary_node():
     new_primary_node = [node for node in pipeline.nodes if node.operation.operation_type == 'knn'][0]
 
     # then
-    assert len(pipeline.nodes) == 3
+    assert pipeline.length == 3
     assert isinstance(new_primary_node, PrimaryNode)
 
 

--- a/test/unit/serialization/mocks/serialization_mocks.py
+++ b/test/unit/serialization/mocks/serialization_mocks.py
@@ -32,8 +32,12 @@ class MockNode:
 
 class MockGraph:
     def __init__(self, nodes: list = None):
-        self.nodes = nodes if nodes else []
+        self._nodes = nodes if nodes else []
         self.operator = 'operator'
+
+    @property
+    def nodes(self):
+        return self._nodes
 
     def __eq__(self, other):
         return (

--- a/test/unit/serialization/mocks/serialization_mocks.py
+++ b/test/unit/serialization/mocks/serialization_mocks.py
@@ -33,7 +33,7 @@ class MockNode:
 class MockGraph:
     def __init__(self, nodes: list = None):
         self._nodes = nodes if nodes else []
-        self.operator = 'operator'
+        self._operator = '_operator'
 
     @property
     def nodes(self):
@@ -41,6 +41,6 @@ class MockGraph:
 
     def __eq__(self, other):
         return (
-            self.operator == other.operator and
+            self._operator == other._operator and
             self.nodes == other.nodes
         )

--- a/test/unit/serialization/test_encoder.py
+++ b/test/unit/serialization/test_encoder.py
@@ -81,7 +81,7 @@ ENCODER_CASES.extend([
     EncoderTestCase(
         test_input=MockGraph([MOCK_NODE_1_COPY, MOCK_NODE_2_COPY, MOCK_NODE_3_COPY]),
         test_answer={
-            'nodes': [
+            '_nodes': [
                 MOCK_NODE_1_COPY,
                 MOCK_NODE_2_COPY,
                 MOCK_NODE_3_COPY

--- a/test/unit/tasks/test_custom.py
+++ b/test/unit/tasks/test_custom.py
@@ -81,5 +81,5 @@ def test_custom_graph_opt():
     assert optimized_network is not None
     assert isinstance(optimized_network, CustomModel)
     assert isinstance(optimized_network.nodes[0], CustomNode)
-    assert len(optimized_network.nodes) > 1
+    assert optimized_network.length > 1
     assert optimized_network.depth > 1

--- a/test/unit/utilities/test_pipeline_import_export.py
+++ b/test/unit/utilities/test_pipeline_import_export.py
@@ -347,7 +347,7 @@ def test_data_model_types_forecasting_pipeline_fit():
     pipeline.fit(train_data)
     pipeline.save('data_model_forecasting')
 
-    expected_len_nodes = len(pipeline.nodes)
+    expected_len_nodes = pipeline.length
     actual_len_nodes = len(PipelineTemplate(pipeline).operation_templates)
 
     assert actual_len_nodes == expected_len_nodes
@@ -360,7 +360,7 @@ def test_data_model_type_classification_pipeline_fit():
     pipeline.fit(train_data)
     pipeline.save('data_model_classification')
 
-    expected_len_nodes = len(pipeline.nodes)
+    expected_len_nodes = pipeline.length
     actual_len_nodes = len(PipelineTemplate(pipeline).operation_templates)
 
     assert actual_len_nodes == expected_len_nodes

--- a/test/unit/visualization/test_visualisation_utils.py
+++ b/test/unit/visualization/test_visualisation_utils.py
@@ -38,7 +38,7 @@ def test_pipeline_template_as_nx_graph():
     pipeline_template = PipelineTemplate(pipeline)
     graph, node_labels = pipeline_template_as_nx_graph(pipeline=pipeline_template)
 
-    assert len(graph.nodes) == len(pipeline.nodes)  # check node quantity
+    assert len(graph.nodes) == pipeline.length  # check node quantity
     assert node_labels[0] == str(pipeline.root_node)  # check root node
 
 

--- a/test/unit/visualization/test_visualisation_utils.py
+++ b/test/unit/visualization/test_visualisation_utils.py
@@ -38,7 +38,7 @@ def test_pipeline_template_as_nx_graph():
     pipeline_template = PipelineTemplate(pipeline)
     graph, node_labels = pipeline_template_as_nx_graph(pipeline=pipeline_template)
 
-    assert len(graph.nodes) == pipeline.length  # check node quantity
+    assert len(graph) == pipeline.length  # check node quantity
     assert node_labels[0] == str(pipeline.root_node)  # check root node
 
 


### PR DESCRIPTION
Refactor Graph (& OptGraph) usages:

- Now `graph.operator` can not be used outside of graph
- Remove direct usaged of `graph.nodes`: now there is a private field `_nodes` and property `nodes`. However users can still modify nodes using this property
- Some methods (`sort_nodes` and `actualise_old_node_children`) were not moved to graph interface since they are not in use anywhere