### PR TITLE
`Graph` visualizations improvement

### DIFF
--- a/examples/advanced/pipeline_sensitivity.py
+++ b/examples/advanced/pipeline_sensitivity.py
@@ -105,7 +105,7 @@ def run_analysis_case(train_data: InputData, test_data: InputData,
         if not exists(result_path):
             makedirs(result_path)
 
-    pipeline.show(path=result_path)
+    pipeline.show(save_path=result_path)
 
     pipeline_analysis_result = NodesAnalysis(pipeline=pipeline, train_data=train_data,
                                              test_data=test_data, path_to_save=result_path,

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -91,7 +91,7 @@ class Graph:
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
              nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
-             edges_curvature: float = 0.25):
+             edges_curvature: float = 0.3):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -90,7 +90,7 @@ class Graph:
         return self._operator.get_edges()
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Any] = None, edges_curvature: float = 0.25):
+             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, edges_curvature: float = 0.25):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -88,12 +88,12 @@ class Graph:
         """ Returns all available edges in a given graph """
         return self._operator.get_edges()
 
-    def show(self, path: Optional[str] = None):
+    def show(self, save_path: Optional[str] = None):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param path: optional, save location of the graph visualization image
         """
-        GraphVisualiser().visualise(self, path)
+        GraphVisualiser().visualise(self, save_path)
 
     def __eq__(self, other_graph: 'Graph') -> bool:
         """Compares this graph with the ``other_graph``

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -1,3 +1,4 @@
+import os
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 from fedot.core.dag.graph_node import GraphNode
@@ -88,12 +89,16 @@ class Graph:
         """ Returns all available edges in a given graph """
         return self._operator.get_edges()
 
-    def show(self, save_path: Optional[str] = None):
+    def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
+             nodes_color: Optional[Any] = None, edges_curvature: float = 0.35):
         """Visualizes graph or saves its picture to the specified ``path``
 
-        :param path: optional, save location of the graph visualization image
+        :param save_path: optional, save location of the graph visualization image.
+        :param engine: engine to visualize the graph.
+        :param nodes_color: color of nodes to use.
+        :param edges_curvature: used make edges more or less curved.
         """
-        GraphVisualiser().visualise(self, save_path)
+        GraphVisualiser().visualise(self, save_path, engine, nodes_color, edges_curvature)
 
     def __eq__(self, other_graph: 'Graph') -> bool:
         """Compares this graph with the ``other_graph``

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -90,15 +90,17 @@ class Graph:
         return self._operator.get_edges()
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, edges_curvature: float = 0.25):
+             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
+             edges_curvature: float = 0.25):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.
         :param engine: engine to visualize the graph.
         :param nodes_color: color of nodes to use.
         :param edges_curvature: used make edges more or less curved.
+        :param dpi: DPI of the output image. Not used if engine='pyvis'.
         """
-        GraphVisualiser().visualise(self, save_path, engine, nodes_color, edges_curvature)
+        GraphVisualiser().visualise(self, save_path, engine, nodes_color, dpi, edges_curvature)
 
     def __eq__(self, other_graph: 'Graph') -> bool:
         """Compares this graph with the ``other_graph``

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -90,7 +90,7 @@ class Graph:
         return self._operator.get_edges()
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Any] = None, edges_curvature: float = 0.35):
+             nodes_color: Optional[Any] = None, edges_curvature: float = 0.25):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -235,7 +235,7 @@ class OptGraph:
 
     @copy_doc(Graph.show)
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Any] = None, edges_curvature: float = 0.25):
+             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, edges_curvature: float = 0.25):
         GraphVisualiser().visualise(self, save_path, engine, nodes_color, edges_curvature)
 
     @copy_doc(Graph.__eq__)

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -235,8 +235,9 @@ class OptGraph:
 
     @copy_doc(Graph.show)
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, edges_curvature: float = 0.25):
-        GraphVisualiser().visualise(self, save_path, engine, nodes_color, edges_curvature)
+             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
+             edges_curvature: float = 0.25):
+        GraphVisualiser().visualise(self, save_path, engine, nodes_color, dpi, edges_curvature)
 
     @copy_doc(Graph.__eq__)
     def __eq__(self, other_graph: 'OptGraph') -> bool:

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -234,8 +234,9 @@ class OptGraph:
         return self._operator.get_edges()
 
     @copy_doc(Graph.show)
-    def show(self, path: Optional[Union[os.PathLike, str]] = None):
-        GraphVisualiser().visualise(self, path)
+    def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
+             nodes_color: Optional[Any] = None, edges_curvature: float = 0.25):
+        GraphVisualiser().visualise(self, save_path, engine, nodes_color, edges_curvature)
 
     @copy_doc(Graph.__eq__)
     def __eq__(self, other_graph: 'OptGraph') -> bool:

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -1,7 +1,7 @@
 import os
 
 from copy import deepcopy
-from typing import Any, Callable, Iterable, List, Optional, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from fedot.core.dag.graph import Graph

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -236,7 +236,7 @@ class OptGraph:
     @copy_doc(Graph.show)
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
              nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
-             edges_curvature: float = 0.25):
+             edges_curvature: float = 0.3):
         GraphVisualiser().visualise(self, save_path, engine, nodes_color, dpi, edges_curvature)
 
     @copy_doc(Graph.__eq__)

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -124,7 +124,7 @@ class OptHistory:
             os.mkdir(dir_path)
 
     def show(self, plot_type: Union[PlotTypesEnum, str] = PlotTypesEnum.fitness_box,
-             save_path: Optional[Union[os.PathLike, str]] = None,
+             save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
              pct_best: Optional[float] = None, show_fitness: bool = True, per_time: bool = True):
         """ Visualizes fitness values or operations used across generations.
 
@@ -132,11 +132,12 @@ class OptHistory:
             'fedot.core.visualisation.opt_viz.PlotTypesEnum'.
         :param save_path: path to save the visualization. If set, then the image will be saved,
             and if not, it will be displayed. Essential for animations.
+        :param dpi: DPI of the output figure.
         :param pct_best: fraction of individuals with the best fitness per generation. The value should be in the
             interval (0, 1]. The other individuals are filtered out. The fraction will also be mentioned on the plot.
         :param show_fitness: if False, visualizations that support this parameter will not display fitness.
-        :param per_time: Shows time axis instead of generations axis.
-            Currently, supported for plot_type = 'show_fitness_line'.
+        :param per_time: Shows time axis instead of generations axis. Currently, supported for plot types:
+            'show_fitness_line', 'show_fitness_line_interactive'.
         """
 
         def check_args_constraints():
@@ -172,16 +173,15 @@ class OptHistory:
 
         viz = PipelineEvolutionVisualiser()
         if plot_type is PlotTypesEnum.fitness_line:
-            viz.visualize_fitness_line(self, per_time, save_path)
+            viz.visualize_fitness_line(self, per_time, save_path, dpi)
         elif plot_type is PlotTypesEnum.fitness_line_interactive:
-            viz.visualize_fitness_line_interactive(self, per_time, save_path)
+            viz.visualize_fitness_line_interactive(self, per_time, save_path, dpi)
         elif plot_type is PlotTypesEnum.fitness_box:
-            viz.visualise_fitness_box(self, save_path=save_path, pct_best=pct_best)
+            viz.visualise_fitness_box(self, save_path, dpi, pct_best)
         elif plot_type is PlotTypesEnum.operations_kde:
-            viz.visualize_operations_kde(self, save_path=save_path, pct_best=pct_best)
+            viz.visualize_operations_kde(self, save_path, dpi, pct_best)
         elif plot_type is PlotTypesEnum.operations_animated_bar:
-            viz.visualize_operations_animated_bar(
-                self, save_path=save_path, pct_best=pct_best, show_fitness_color=show_fitness)
+            viz.visualize_operations_animated_bar(self, save_path, dpi, pct_best, show_fitness_color=show_fitness)
         else:
             raise NotImplementedError(f'Oops, plot type {plot_type.name} has no function to show!')
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -181,7 +181,7 @@ class OptHistory:
         elif plot_type is PlotTypesEnum.operations_kde:
             viz.visualize_operations_kde(self, save_path, dpi, pct_best)
         elif plot_type is PlotTypesEnum.operations_animated_bar:
-            viz.visualize_operations_animated_bar(self, save_path, dpi, pct_best, show_fitness_color=show_fitness)
+            viz.visualize_operations_animated_bar(self, save_path, dpi, pct_best, show_fitness)
         else:
             raise NotImplementedError(f'Oops, plot type {plot_type.name} has no function to show!')
 

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -90,7 +90,7 @@ class GraphVisualiser:
             net.add_edge(str(u), str(v))
 
         if save_path:
-            net.save_graph(save_path)
+            net.save_graph(str(save_path))
             return
         save_path = Path(default_fedot_data_dir(), 'graph_plots', str(uuid4()) + '.html')
         save_path.parent.mkdir(exist_ok=True)

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -25,21 +25,21 @@ class GraphVisualiser:
 
     def visualise(self, graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
                   engine: str = 'matplotlib', nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
-                  edges_curvature: float = 0.25):
+                  dpi: int = 300, edges_curvature: float = 0.25):
         if len(graph.nodes) == 0:
             raise ValueError('Empty graph can not be visualized.')
         if engine == 'matplotlib':
-            self.draw_with_networkx(graph, save_path, nodes_color, edges_curvature)
+            self.draw_with_networkx(graph, save_path, nodes_color, dpi, edges_curvature)
         elif engine == 'pyvis':
             self.draw_with_pyvis(graph, save_path, nodes_color)
         elif engine == 'graphviz':
-            self.draw_with_graphviz(graph, save_path, nodes_color)
+            self.draw_with_graphviz(graph, save_path, nodes_color, dpi)
         else:
             raise NotImplementedError(f'Unexpected visualization engine: {engine}. '
                                       'Possible values: matplotlib, pyvis, graphviz.')
 
     @staticmethod
-    def draw_with_graphviz(graph, save_path, nodes_color=None):
+    def draw_with_graphviz(graph, save_path, nodes_color=None, dpi=300):
         nx_graph, nodes = graph_structure_as_nx_graph(graph)
         colors = get_colors_by_node_labels([str(n) for n in nodes.values()])
         for n, data in nx_graph.nodes(data=True):
@@ -48,7 +48,7 @@ class GraphVisualiser:
             data['color'] = to_hex(nodes_color or colors[label])
 
         gv_graph = nx.nx_agraph.to_agraph(nx_graph)
-        kwargs = {'prog': 'dot', 'args': '-Gnodesep=0.5 -Gdpi=300 -Grankdir="LR"'}
+        kwargs = {'prog': 'dot', 'args': f'-Gnodesep=0.5 -Gdpi={dpi} -Grankdir="LR"'}
 
         if save_path:
             gv_graph.draw(save_path, **kwargs)
@@ -60,7 +60,7 @@ class GraphVisualiser:
             img = plt.imread(str(save_path))
             plt.imshow(img)
             plt.gca().axis('off')
-            plt.gcf().set_dpi(300)
+            plt.gcf().set_dpi(dpi)
             plt.tight_layout()
             plt.show()
             remove_old_files_from_dir(save_path.parent)
@@ -99,15 +99,15 @@ class GraphVisualiser:
 
     def draw_with_networkx(self, graph: Union['Graph', 'OptGraph'], save_path=None,
                            nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
-                           edges_curvature: float = 0.25,
+                           dpi: int = 300, edges_curvature: float = 0.25,
                            in_graph_converter_function: Callable = graph_structure_as_nx_graph):
         fig, ax = plt.subplots()
-        fig.set_dpi(150)
+        fig.set_dpi(dpi)
         self.draw_nx_dag(graph, ax, nodes_color, edges_curvature, in_graph_converter_function)
         if not save_path:
             plt.show()
         else:
-            plt.savefig(save_path, dpi=300)
+            plt.savefig(save_path, dpi=dpi)
             plt.close()
 
     def draw_nx_dag(self, graph: Union['Graph', 'OptGraph'], ax: Optional[plt.Axes] = None,

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -133,8 +133,8 @@ class GraphVisualiser:
             edge_colors = nodes_color or 'k'
         # Define hierarchy_level
         for u, v, e in nx_graph.edges(data=True):
-            for n in (u, v):
-                nx_graph.nodes[n]['hierarchy_level'] = nodes[n].distance_to_primary_level
+            for node_id in (u, v):
+                nx_graph.nodes[node_id]['hierarchy_level'] = nodes[node_id].distance_to_primary_level
         # Get nodes positions
         pos, longest_sequence = get_hierarchy_pos(nx_graph)
         node_size = get_scaled_node_size(longest_sequence)
@@ -148,11 +148,11 @@ class GraphVisualiser:
             e['connectionstyle'] = connection_style
             p1, p2 = np.array(pos[u]), np.array(pos[v])
             min_distance = 1
-            closest_node = None
-            for n in nx_graph.nodes:
-                if n in (u, v):
+            closest_node_id = None
+            for node_id in nx_graph.nodes:
+                if node_id in (u, v):
                     continue
-                p3 = np.array(pos[n])
+                p3 = np.array(pos[node_id])
                 distance = abs(np.cross(p2 - p1, p1 - p3) / np.linalg.norm(p2 - p1))
                 if distance > 0.15:
                     continue
@@ -163,11 +163,11 @@ class GraphVisualiser:
                 if distance > min_distance:
                     continue
                 min_distance = distance
-                closest_node = n
+                closest_node_id = node_id
 
-            if closest_node is None:
+            if closest_node_id is None:
                 continue
-            p3 = pos[closest_node]
+            p3 = pos[closest_node_id]
             curvature_factor = (1 / (min_distance + 1)) ** 2
             if p1[1] == p2[1]:
                 curvature_sign = -1

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-from math import log2
 from pathlib import Path
 from textwrap import wrap
 from typing import Optional, Union, Callable, Any, Tuple, List, Dict
@@ -11,7 +10,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_hex
 from matplotlib.patches import ArrowStyle
-from numpy.linalg import norm
 from pyvis.network import Network
 
 from fedot.core.log import default_log
@@ -120,7 +118,7 @@ class GraphVisualiser:
         def get_scaled_node_size(nodes_amount):
             min_size = 1000
             max_size = 4000
-            size = min_size + int((max_size - min_size) / log2(max(nodes_amount, 2)))
+            size = min_size + int((max_size - min_size) / np.log2(max(nodes_amount, 2)))
             return size
 
         if ax is None:
@@ -204,7 +202,7 @@ class GraphVisualiser:
             min_size = 6
             max_size = 16
 
-            size = min_size + int((max_size - min_size) / log2(max(nodes_amount, 2)))
+            size = min_size + int((max_size - min_size) / np.log2(max(nodes_amount, 2)))
             return size
 
         if ax is None:

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -142,7 +142,7 @@ class GraphVisualiser:
                                edgecolors=edge_colors)
         # Define edges curvature
         connection_style = 'arc3'
-        curved_connection_style = 'arc3,rad={}'
+        curved_connection_style = connection_style + ',rad={}'
         for u, v, e in nx_graph.edges(data=True):
             e['connectionstyle'] = connection_style
             p1, p2 = np.array(pos[u]), np.array(pos[v])
@@ -248,8 +248,7 @@ def get_hierarchy_pos(graph: nx.DiGraph, max_line_length: int = 6) -> Tuple[Dict
     return pos, longest_sequence
 
 
-def remove_old_files_from_dir(dir, time_interval=datetime.timedelta(minutes=10)):
-    for path in os.listdir(dir):
-        path = Path(dir, path)
-        if datetime.datetime.now() - datetime.datetime.fromtimestamp(os.path.getctime(path)) > time_interval:
-            os.remove(path)
+def remove_old_files_from_dir(dir: Path, time_interval=datetime.timedelta(minutes=10)):
+    for path in dir.iterdir():
+        if datetime.datetime.now() - datetime.datetime.fromtimestamp(path.stat().st_ctime) > time_interval:
+            path.unlink()

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -27,7 +27,7 @@ class GraphVisualiser:
     def visualise(self, graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
                   engine: str = 'matplotlib', nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
                   dpi: int = 300, edges_curvature: float = 0.3):
-        if graph.nodes:
+        if not graph.nodes:
             raise ValueError('Empty graph can not be visualized.')
         # Define colors
         if not nodes_color:

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -75,6 +75,10 @@ class GraphVisualiser:
             label = str(operation)
             data['n_id'] = str(n)
             data['label'] = label.replace('_', ' ')
+            params = operation.content.get('params')
+            if isinstance(params, dict):
+                params = str(params)[1:-1]
+            data['title'] = params
             data['level'] = operation.distance_to_primary_level
             data['color'] = to_hex(nodes_color or colors[label])
             data['font'] = '20px'

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -27,7 +27,7 @@ class GraphVisualiser:
     def visualise(self, graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
                   engine: str = 'matplotlib', nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
                   dpi: int = 300, edges_curvature: float = 0.3):
-        if len(graph.nodes) == 0:
+        if graph.nodes:
             raise ValueError('Empty graph can not be visualized.')
         # Define colors
         if not nodes_color:
@@ -60,7 +60,8 @@ class GraphVisualiser:
         return {label: palette[unique_labels.index(label)] for label in labels}
 
     @staticmethod
-    def draw_with_graphviz(graph, save_path, nodes_color=None, dpi=300):
+    def draw_with_graphviz(graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
+                           nodes_color=__get_colors_by_tags.__func__, dpi=300):
         nx_graph, nodes = graph_structure_as_nx_graph(graph)
         # Define colors
         if callable(nodes_color):
@@ -91,7 +92,8 @@ class GraphVisualiser:
             remove_old_files_from_dir(save_path.parent)
 
     @staticmethod
-    def draw_with_pyvis(graph, save_path, nodes_color=__get_colors_by_tags):
+    def draw_with_pyvis(graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
+                        nodes_color=__get_colors_by_tags.__func__):
         net = Network('500px', '1000px', directed=True)
         nx_graph, nodes = graph_structure_as_nx_graph(graph)
         # Define colors

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -25,7 +25,7 @@ class GraphVisualiser:
 
     def visualise(self, graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
                   engine: str = 'matplotlib', nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
-                  dpi: int = 300, edges_curvature: float = 0.25):
+                  dpi: int = 300, edges_curvature: float = 0.3):
         if len(graph.nodes) == 0:
             raise ValueError('Empty graph can not be visualized.')
         if engine == 'matplotlib':
@@ -99,7 +99,7 @@ class GraphVisualiser:
 
     def draw_with_networkx(self, graph: Union['Graph', 'OptGraph'], save_path=None,
                            nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
-                           dpi: int = 300, edges_curvature: float = 0.25,
+                           dpi: int = 300, edges_curvature: float = 0.3,
                            in_graph_converter_function: Callable = graph_structure_as_nx_graph):
         fig, ax = plt.subplots()
         fig.set_dpi(dpi)
@@ -112,7 +112,7 @@ class GraphVisualiser:
 
     def draw_nx_dag(self, graph: Union['Graph', 'OptGraph'], ax: Optional[plt.Axes] = None,
                     nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
-                    edges_curvature: float = 0.25,
+                    edges_curvature: float = 0.3,
                     in_graph_converter_function: Callable = graph_structure_as_nx_graph):
 
         def get_scaled_node_size(nodes_amount):

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -18,20 +18,6 @@ from fedot.core.pipelines.convert import graph_structure_as_nx_graph
 from fedot.core.utils import default_fedot_data_dir
 
 
-def get_colors_by_tags(labels: List[str]) -> Dict[str, Tuple[float, float, float]]:
-    from fedot.core.visualisation.opt_viz import get_palette_based_on_default_tags
-    from fedot.core.repository.operation_types_repository import get_opt_node_tag
-
-    palette = get_palette_based_on_default_tags()
-    return {label: palette[get_opt_node_tag(label)] for label in labels}
-
-
-def get_colors_by_labels(labels: List[str]) -> Dict[str, Tuple[float, float, float]]:
-    unique_labels = list(set(labels))
-    palette = color_palette('tab10', len(unique_labels))
-    return {label: palette[unique_labels.index(label)] for label in labels}
-
-
 class GraphVisualiser:
     def __init__(self):
         default_data_dir = default_fedot_data_dir()
@@ -46,9 +32,9 @@ class GraphVisualiser:
         # Define colors
         if not nodes_color:
             if type(graph).__name__ in ('Pipeline', 'OptGraph'):
-                nodes_color = get_colors_by_tags
+                nodes_color = self.__get_colors_by_tags
             else:
-                nodes_color = get_colors_by_labels
+                nodes_color = self.__get_colors_by_labels
         if engine == 'matplotlib':
             self.draw_with_networkx(graph, save_path, nodes_color, dpi, edges_curvature)
         elif engine == 'pyvis':
@@ -58,6 +44,20 @@ class GraphVisualiser:
         else:
             raise NotImplementedError(f'Unexpected visualization engine: {engine}. '
                                       'Possible values: matplotlib, pyvis, graphviz.')
+
+    @staticmethod
+    def __get_colors_by_tags(labels: List[str]) -> Dict[str, Tuple[float, float, float]]:
+        from fedot.core.visualisation.opt_viz import get_palette_based_on_default_tags
+        from fedot.core.repository.operation_types_repository import get_opt_node_tag
+
+        palette = get_palette_based_on_default_tags()
+        return {label: palette[get_opt_node_tag(label)] for label in labels}
+
+    @staticmethod
+    def __get_colors_by_labels(labels: List[str]) -> Dict[str, Tuple[float, float, float]]:
+        unique_labels = list(set(labels))
+        palette = color_palette('tab10', len(unique_labels))
+        return {label: palette[unique_labels.index(label)] for label in labels}
 
     @staticmethod
     def draw_with_graphviz(graph, save_path, nodes_color=None, dpi=300):
@@ -91,7 +91,7 @@ class GraphVisualiser:
             remove_old_files_from_dir(save_path.parent)
 
     @staticmethod
-    def draw_with_pyvis(graph, save_path, nodes_color=get_colors_by_tags):
+    def draw_with_pyvis(graph, save_path, nodes_color=__get_colors_by_tags):
         net = Network('500px', '1000px', directed=True)
         nx_graph, nodes = graph_structure_as_nx_graph(graph)
         # Define colors

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -26,7 +26,8 @@ class GraphVisualiser:
         self.log = default_log(self)
 
     def visualise(self, graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
-                  engine: str = 'matplotlib', nodes_color: Optional[Any] = None, edges_curvature: float = 0.25):
+                  engine: str = 'matplotlib', nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
+                  edges_curvature: float = 0.25):
         if len(graph.nodes) == 0:
             raise ValueError('Empty graph can not be visualized.')
         if engine == 'matplotlib':
@@ -98,7 +99,8 @@ class GraphVisualiser:
         net.show(str(save_path))
         remove_old_files_from_dir(save_path.parent)
 
-    def draw_with_networkx(self, graph: Union['Graph', 'OptGraph'], save_path=None, nodes_color: Any = None,
+    def draw_with_networkx(self, graph: Union['Graph', 'OptGraph'], save_path=None,
+                           nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
                            edges_curvature: float = 0.25,
                            in_graph_converter_function: Callable = graph_structure_as_nx_graph):
         fig, ax = plt.subplots()
@@ -110,7 +112,8 @@ class GraphVisualiser:
             plt.savefig(save_path, dpi=300)
             plt.close()
 
-    def draw_nx_dag(self, graph: Union['Graph', 'OptGraph'], ax: Optional[plt.Axes] = None, nodes_color: Any = None,
+    def draw_nx_dag(self, graph: Union['Graph', 'OptGraph'], ax: Optional[plt.Axes] = None,
+                    nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None,
                     edges_curvature: float = 0.25,
                     in_graph_converter_function: Callable = graph_structure_as_nx_graph):
 

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -84,9 +84,8 @@ class PipelineEvolutionVisualiser:
         prev_fit = fitnesses[0]
         fig = plt.figure(figsize=(10, 10))
         for ch_id, pipeline in enumerate(pipelines):
-            self.graph_visualizer.draw_single_graph(pipeline,
-                                                    title='Current graph',
-                                                    in_graph_converter_function=pipeline_template_as_nx_graph)
+            self.graph_visualizer.draw_nx_dag(pipeline,
+                                              in_graph_converter_function=pipeline_template_as_nx_graph)
             fig.canvas.draw()
             img = figure_to_array(fig)
             self.pipelines_imgs.append(img)
@@ -97,9 +96,8 @@ class PipelineEvolutionVisualiser:
                 last_best_pipeline = pipeline
             prev_fit = fitnesses[ch_id]
             plt.clf()
-            self.graph_visualizer.draw_single_graph(last_best_pipeline,
-                                                    title=f'Best graph after {round(ch_id)} evals',
-                                                    in_graph_converter_function=pipeline_template_as_nx_graph)
+            self.graph_visualizer.draw_nx_dag(last_best_pipeline,
+                                              in_graph_converter_function=pipeline_template_as_nx_graph)
             fig.canvas.draw()
             img = figure_to_array(fig)
             self.best_pipelines_imgs.append(img)

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -15,7 +15,7 @@ import matplotlib as mpl
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from matplotlib import animation, cm, image as mpimg, pyplot as plt, ticker
+from matplotlib import animation, cm, pyplot as plt, ticker
 from matplotlib.colors import Normalize
 from matplotlib.widgets import Button
 
@@ -481,7 +481,7 @@ class PipelineEvolutionVisualiser:
             def generate_graph_images(self):
                 for ind in self.best_individuals:
                     ind.graph.show(self.temp_path)
-                    self.graph_images.append(mpimg.imread(str(self.temp_path)))
+                    self.graph_images.append(plt.imread(str(self.temp_path)))
 
             def update_graph(self):
                 ax_graph.imshow(self.graph_images[self.index])

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -45,7 +45,7 @@ def with_alternate_matplotlib_backend(func):
             mpl.use('TKAgg')
             return func(*args, **kwargs)
         except ImportError as e:
-            default_log('Requirements').warning(f'{e} or ignore this warning')
+            default_log('Requirements').warning(e)
         finally:
             mpl.use(default_mpl_backend)
 

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -843,7 +843,7 @@ def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str],
         formatted_text = formatted_text.replace(' ', '\\;')
         return formatted_text
 
-    def format_wrapped_text(wrapped_text: List[str], part_to_format: str, html_format_tag: str = 'it') -> List[str]:
+    def format_wrapped_text(wrapped_text: List[str], part_to_format: str, latex_format_tag: str = 'it') -> List[str]:
 
         long_text = ''.join(wrapped_text)
         first_tag_pos = long_text.find(part_to_format)
@@ -858,22 +858,23 @@ def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str],
         second_tag_char = second_tag_pos % line_len
 
         if first_tag_line == second_tag_line:
-            wrapped_text[first_tag_line] = \
-                wrapped_text[first_tag_line][:first_tag_char] + \
-                format_text(wrapped_text[first_tag_line][first_tag_char:second_tag_char], html_format_tag) + \
-                wrapped_text[first_tag_line][second_tag_char:]
+            wrapped_text[first_tag_line] = (
+                    wrapped_text[first_tag_line][:first_tag_char] +
+                    format_text(wrapped_text[first_tag_line][first_tag_char:second_tag_char], latex_format_tag) +
+                    wrapped_text[first_tag_line][second_tag_char:]
+            )
         else:
             for line in range(first_tag_line + 1, second_tag_line):
-                wrapped_text[line] = format_text(wrapped_text[line], html_format_tag)
+                wrapped_text[line] = format_text(wrapped_text[line], latex_format_tag)
 
-            wrapped_text[first_tag_line] = \
-                wrapped_text[first_tag_line][:first_tag_char] + \
-                format_text(wrapped_text[first_tag_line][first_tag_char:], html_format_tag)
-
-            wrapped_text[second_tag_line] = \
-                format_text(wrapped_text[second_tag_line][:second_tag_char], html_format_tag) + \
+            wrapped_text[first_tag_line] = (
+                wrapped_text[first_tag_line][:first_tag_char] +
+                format_text(wrapped_text[first_tag_line][first_tag_char:], latex_format_tag)
+            )
+            wrapped_text[second_tag_line] = (
+                    format_text(wrapped_text[second_tag_line][:second_tag_char], latex_format_tag) +
                 wrapped_text[second_tag_line][second_tag_char:]
-
+            )
         return wrapped_text
 
     tag = make_text_fancy(tag)

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -328,7 +328,7 @@ class PipelineEvolutionVisualiser:
         else:
             save_path = Path(save_path)
             if not save_path.is_absolute():
-                save_path = Path(os.getcwd(), save_path)
+                save_path = Path.cwd().joinpath(save_path)
             figure.savefig(save_path, dpi=300)
             self.log.info(f'The figure was saved to "{save_path}".')
             plt.close()
@@ -813,7 +813,7 @@ class PipelineEvolutionVisualiser:
         plt.tight_layout()
 
         if not save_path.is_absolute():
-            save_path = Path(os.getcwd(), save_path)
+            save_path = Path.cwd().joinpath(save_path)
 
         ani = animation.FuncAnimation(
             fig,

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -602,21 +602,20 @@ class PipelineEvolutionVisualiser:
         self.__show_or_save_figure(fig, save_path, dpi)
 
     def visualize_operations_kde(self, history: 'OptHistory', save_path: Optional[Union[os.PathLike, str]] = None,
-                                 dpi: int = 300, tags_model: Optional[List[str]] = None,
-                                 tags_data: Optional[List[str]] = None,
-                                 pct_best: Optional[float] = None):
+                                 dpi: int = 300, pct_best: Optional[float] = None,
+                                 tags_model: Optional[List[str]] = None, tags_data: Optional[List[str]] = None):
         """ Visualizes operations used across generations in the form of KDE.
 
         :param history: OptHistory.
         :param save_path: path to save the visualization. If set, then the image will be saved,
             and if not, it will be displayed.
         :param dpi: DPI of the output figure.
+        :param pct_best: fraction of the best individuals of each generation that included in the visualization.
+            Must be in the interval (0, 1].
         :param tags_model: tags for OperationTypesRepository('model') to map the history operations.
             The later the tag, the higher its priority in case of intersection.
         :param tags_data: tags for OperationTypesRepository('data_operation') to map the history operations.
             The later the tag, the higher its priority in case of intersection.
-        :param pct_best: fraction of the best individuals of each generation that included in the visualization.
-            Must be in the interval (0, 1].
         """
 
         tags_model = tags_model or OperationTypesRepository.DEFAULT_MODEL_TAGS
@@ -660,21 +659,21 @@ class PipelineEvolutionVisualiser:
         self.__show_or_save_figure(fig, save_path, dpi)
 
     def visualize_operations_animated_bar(self, history: 'OptHistory', save_path: Union[os.PathLike, str],
-                                          dpi: int = 300, tags_model: Optional[List[str]] = None,
-                                          tags_data: Optional[List[str]] = None,
-                                          pct_best: Optional[float] = None, show_fitness_color: bool = True):
+                                          dpi: int = 300, pct_best: Optional[float] = None,
+                                          show_fitness_color: bool = True, tags_model: Optional[List[str]] = None,
+                                          tags_data: Optional[List[str]] = None):
         """ Visualizes operations used across generations in the form of animated bar plot.
 
         :param history: OptHistory instance.
         :param save_path: path to save the visualization.
         :param dpi: DPI of the output figure.
+        :param pct_best: fraction of the best individuals of each generation that included in the visualization.
+            Must be in the interval (0, 1].
+        :param show_fitness_color: if False, the bar colors will not correspond to fitness.
         :param tags_model: tags for OperationTypesRepository('model') to map the history operations.
             The later the tag, the higher its priority in case of intersection.
         :param tags_data: tags for OperationTypesRepository('data_operation') to map the history operations.
             The later the tag, the higher its priority in case of intersection.
-        :param pct_best: fraction of the best individuals of each generation that included in the visualization.
-            Must be in the interval (0, 1].
-        :param show_fitness_color: if False, the bar colors will not correspond to fitness.
         """
 
         def interpolate_points(point_1, point_2, smoothness=18, power=4) -> List[np.array]:

--- a/fedot/sensitivity/deletion_methods/multi_times_analysis.py
+++ b/fedot/sensitivity/deletion_methods/multi_times_analysis.py
@@ -113,7 +113,7 @@ class MultiTimesAnalyze:
 
     def _visualize(self, name, path):
         image_path = join(path, f'{name}.png')
-        self.pipeline.show(path=image_path)
+        self.pipeline.show(save_path=image_path)
 
     def get_metric(self):
         self.pipeline.fit(self.train_data, use_fitted=False)

--- a/fedot/utilities/project_import_export.py
+++ b/fedot/utilities/project_import_export.py
@@ -129,7 +129,7 @@ def _prepare_paths(zip_path: Union[str, Path]) -> Tuple[Path, Path, Path, Path]:
 
     absolute_folder_path = DEFAULT_PROJECTS_PATH.joinpath(folder_name)
     if not zip_path.is_absolute():
-        absolute_zip_path = Path(os.getcwd(), zip_path)
+        absolute_zip_path = Path.cwd().joinpath(zip_path)
     else:
         absolute_zip_path = zip_path
         zip_path = Path(zip_path.name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ scikit-optimize >= 0.7.4
 # Plotting
 matplotlib == 3.0.2; python_version == '3.7'
 matplotlib >= 3.3.1; python_version >= '3.8'
+pyvis==0.2.1
 seaborn >= 0.9.*
 
 # Misc

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -22,7 +22,9 @@ def create_individual():
     return individual
 
 
-def generate_history(generations_quantity, pop_size):
+@pytest.fixture(scope='module')
+def generate_history(request):
+    generations_quantity, pop_size = request.param
     history = OptHistory()
     for gen_num in range(generations_quantity):
         new_pop = []
@@ -34,29 +36,32 @@ def generate_history(generations_quantity, pop_size):
     return history
 
 
-def test_history_adding():
+@pytest.mark.parametrize('generate_history', [[2, 10]], indirect=True)
+def test_history_adding(generate_history):
     generations_quantity = 2
     pop_size = 10
-    history = generate_history(generations_quantity, pop_size)
+    history = generate_history
 
     assert len(history.individuals) == generations_quantity
     for gen in range(generations_quantity):
         assert len(history.individuals[gen]) == pop_size
 
 
-def test_individual_graph_type_is_optgraph():
+@pytest.mark.parametrize('generate_history', [[2, 10]], indirect=True)
+def test_individual_graph_type_is_optgraph(generate_history):
     generations_quantity = 2
     pop_size = 10
-    history = generate_history(generations_quantity, pop_size)
+    history = generate_history
     for gen in range(generations_quantity):
         for ind in range(pop_size):
             assert type(history.individuals[gen][ind].graph) == OptGraph
 
 
-def test_prepare_for_visualisation():
+@pytest.mark.parametrize('generate_history', [[2, 10]], indirect=True)
+def test_prepare_for_visualisation(generate_history):
     generations_quantity = 2
     pop_size = 10
-    history = generate_history(generations_quantity, pop_size)
+    history = generate_history
     assert len(history.historical_pipelines) == pop_size * generations_quantity
     assert len(history.all_historical_fitness) == pop_size * generations_quantity
 
@@ -71,10 +76,9 @@ def test_prepare_for_visualisation():
     assert 'Position' in leaderboard
 
 
-def test_all_historical_quality():
-    pop_size = 4
-    generations_quantity = 3
-    history = generate_history(generations_quantity, pop_size)
+@pytest.mark.parametrize('generate_history', [[3, 4]], indirect=True)
+def test_all_historical_quality(generate_history):
+    history = generate_history
     eval_fitness = [[0.9, 0.8], [0.8, 0.6], [0.2, 0.4], [0.9, 0.9]]
     weights = (-1, 1)
     for pop_num, population in enumerate(history.individuals):
@@ -87,14 +91,13 @@ def test_all_historical_quality():
     assert all_quality[0] == -0.9 and all_quality[4] == -1.4 and all_quality[5] == -1.3 and all_quality[10] == -1.2
 
 
+@pytest.mark.parametrize('generate_history', [[3, 4]], indirect=True)
 @pytest.mark.parametrize('plot_type', PlotTypesEnum)
-def test_history_show_saving_plots(tmp_path, plot_type: PlotTypesEnum):
-    generations_quantity = 2
-    pop_size = 5
+def test_history_show_saving_plots(tmp_path, plot_type: PlotTypesEnum, generate_history):
     save_path = Path(tmp_path, plot_type.name)
     save_path = save_path.with_suffix('.gif') if plot_type is PlotTypesEnum.operations_animated_bar \
         else save_path.with_suffix('.png')
-    history = generate_history(generations_quantity, pop_size)
-    history.show(plot_type=plot_type, save_path=str(save_path), pct_best=0.1)
+    history = generate_history
+    history.show(plot_type=plot_type, save_path=str(save_path), pct_best=0.1, dpi=100)
     if plot_type is not PlotTypesEnum.fitness_line_interactive:
         assert save_path.exists()

--- a/test/unit/visualization/test_graph_visualizations.py
+++ b/test/unit/visualization/test_graph_visualizations.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Type, Union
+
+import pytest
+
+from fedot.core.dag.graph import Graph
+from fedot.core.dag.graph_node import GraphNode
+from fedot.core.optimisers.graph import OptGraph, OptNode
+from fedot.core.pipelines.node import Node
+from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.utils import DEFAULT_PARAMS_STUB
+
+
+@pytest.fixture(scope='module', params=[Graph, Pipeline, OptGraph])
+def graph(request):
+    graph_type: Union[Type[Graph], Type[Pipeline], Type[OptGraph]] = request.param
+    nodes_kwargs = [{'content': {'name': f'n{i+1}', 'params': DEFAULT_PARAMS_STUB}} for i in range(4)]
+    nodes_kwargs[-1]['nodes_from'] = range(len(nodes_kwargs) - 1)
+    if graph_type is Graph:
+        node_type = GraphNode
+    elif graph_type is Pipeline:
+        node_type = Node
+    else:
+        node_type = OptNode
+    nodes = []
+    for i, kwargs in enumerate(nodes_kwargs):
+        if 'nodes_from' in kwargs:
+            kwargs['nodes_from'] = [nodes[j] for j in kwargs['nodes_from']]
+        else:
+            kwargs['nodes_from'] = []
+        nodes.append(node_type(**kwargs))
+    return graph_type(nodes[-1])
+
+
+@pytest.mark.parametrize('engine', ('matplotlib', 'pyvis', 'graphviz'))
+def test_graph_show_saving_plots(graph, engine, tmp_path):
+    save_path = Path(tmp_path, engine)
+    save_path = save_path.with_suffix('.html') if engine == 'pyvis' else save_path.with_suffix('.png')
+    try:
+        graph.show(engine=engine, save_path=save_path, dpi=100)
+        assert save_path.exists()
+    except ImportError:
+        assert engine == 'graphviz'

--- a/test/unit/visualization/test_visualisation_utils.py
+++ b/test/unit/visualization/test_visualisation_utils.py
@@ -66,7 +66,6 @@ def make_comparable_lists(pos, real_hierarchy_levels, node_labels, dim, reverse)
 
 def test_hierarchy_pos():
     pipeline = pipeline_first()
-    pipeline.show()
     real_hierarchy_levels_y = {0: ['logit'],
                                1: ['lda', 'rf'],
                                2: ['rf'],

--- a/test/unit/visualization/test_visualisation_utils.py
+++ b/test/unit/visualization/test_visualisation_utils.py
@@ -1,7 +1,7 @@
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.fitness.multi_objective_fitness import MultiObjFitness
 from fedot.core.optimisers.gp_comp.individual import Individual
-from fedot.core.pipelines.convert import pipeline_template_as_nx_graph
+from fedot.core.pipelines.convert import graph_structure_as_nx_graph, pipeline_template_as_nx_graph
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.template import PipelineTemplate
@@ -66,12 +66,21 @@ def make_comparable_lists(pos, real_hierarchy_levels, node_labels, dim, reverse)
 
 def test_hierarchy_pos():
     pipeline = pipeline_first()
-    real_hierarchy_levels_y = {0: ['rf'], 1: ['rf', 'knn'],
-                               2: ['logit', 'lda', 'logit', 'lda']}
-    real_hierarchy_levels_x = {0: ['logit'], 1: ['rf'], 2: ['lda'],
-                               3: ['rf'], 4: ['logit'], 5: ['knn'], 6: ['lda']}
-    pipeline_template = PipelineTemplate(pipeline)
-    graph, node_labels = pipeline_template_as_nx_graph(pipeline=pipeline_template)
+    pipeline.show()
+    real_hierarchy_levels_y = {0: ['logit'],
+                               1: ['lda', 'rf'],
+                               2: ['rf'],
+                               3: ['logit', 'knn'],
+                               4: ['lda']}
+    real_hierarchy_levels_x = {0: ['logit', 'lda', 'logit', 'lda'],
+                               1: ['rf', 'knn'],
+                               2: ['rf']}
+
+    graph, node_labels = graph_structure_as_nx_graph(pipeline)
+    for n, data in graph.nodes(data=True):
+        data['hierarchy_level'] = node_labels[n].distance_to_primary_level
+        node_labels[n] = str(node_labels[n])
+
     pos, _ = get_hierarchy_pos(graph)
     comparable_lists_y = make_comparable_lists(pos, real_hierarchy_levels_y,
                                                node_labels, 1, reverse=True)

--- a/test/unit/visualization/test_visualisation_utils.py
+++ b/test/unit/visualization/test_visualisation_utils.py
@@ -6,7 +6,7 @@ from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.template import PipelineTemplate
 
-from fedot.core.visualisation.graph_viz import hierarchy_pos
+from fedot.core.visualisation.graph_viz import get_hierarchy_pos
 from fedot.core.visualisation.opt_viz import PipelineEvolutionVisualiser
 
 
@@ -72,7 +72,7 @@ def test_hierarchy_pos():
                                3: ['rf'], 4: ['logit'], 5: ['knn'], 6: ['lda']}
     pipeline_template = PipelineTemplate(pipeline)
     graph, node_labels = pipeline_template_as_nx_graph(pipeline=pipeline_template)
-    pos = hierarchy_pos(graph.to_undirected(), root=0)
+    pos, _ = get_hierarchy_pos(graph)
     comparable_lists_y = make_comparable_lists(pos, real_hierarchy_levels_y,
                                                node_labels, 1, reverse=True)
     comparable_lists_x = make_comparable_lists(pos, real_hierarchy_levels_x,


### PR DESCRIPTION
- Refactored default graph representations by matplotlib + networkx.
- Added 'pyvis' visualization engine for interactive graph views via html.
- Added 'graphviz' visualization engine (requires [Graphviz](https://graphviz.org/) and [pygraphviz](https://pygraphviz.github.io/)).
- Matplotlib visualization supports nodes_size and edges_curvature arguments.
- All graph and history visualizations now support `dpi` argument.
