### PR TITLE
Simplify pickle-serialization of DataPreprocessor

### DIFF
--- a/fedot/core/optimisers/gp_comp/operators/crossover.py
+++ b/fedot/core/optimisers/gp_comp/operators/crossover.py
@@ -46,21 +46,19 @@ class Crossover(Operator):
 
     def _crossover(self, ind_first: Individual, ind_second: Individual) -> Tuple[Individual, Individual]:
         crossover_type = choice(self.crossover_types)
-        try:
-            if self._will_crossover_be_applied(ind_first.graph, ind_second.graph, crossover_type):
-                crossover_func = self._obtain_crossover_function(crossover_type)
-                for _ in range(self.max_number_of_attempts):
-                    new_graphs = self._adapt_and_apply_crossover(ind_first, ind_second, crossover_func)
-                    are_correct = all(self.graph_generation_params.verifier(new_graph) for new_graph in new_graphs)
-                    if are_correct:
-                        parent_individuals = (ind_first, ind_second)
-                        new_individuals = self._get_individuals(new_graphs, parent_individuals, crossover_type)
-                        return new_individuals
 
-                self.log.debug('Number of crossover attempts exceeded. '
-                               'Please check composer requirements for correctness.')
-        except Exception as ex:
-            self.log.error(f'Crossover ex: {ex}')
+        if self._will_crossover_be_applied(ind_first.graph, ind_second.graph, crossover_type):
+            crossover_func = self._obtain_crossover_function(crossover_type)
+            for _ in range(self.max_number_of_attempts):
+                new_graphs = self._adapt_and_apply_crossover(ind_first, ind_second, crossover_func)
+                are_correct = all(self.graph_generation_params.verifier(new_graph) for new_graph in new_graphs)
+                if are_correct:
+                    parent_individuals = (ind_first, ind_second)
+                    new_individuals = self._get_individuals(new_graphs, parent_individuals, crossover_type)
+                    return new_individuals
+
+            self.log.debug('Number of crossover attempts exceeded. '
+                           'Please check composer requirements for correctness.')
 
         return ind_first, ind_second
 

--- a/fedot/preprocessing/preprocessing.py
+++ b/fedot/preprocessing/preprocessing.py
@@ -57,7 +57,6 @@ class DataPreprocessor:
         # Categorical preprocessor for binary categorical features
         self.binary_categorical_processors: Dict[str, BinaryCategoricalPreprocessor] = {}
         self.types_correctors: Dict[str, TableTypesCorrector] = {}
-        self.structure_analysis = PipelineStructureExplorer()
         self.main_target_source_name = None
 
         self.log = default_log(self)
@@ -236,15 +235,15 @@ class DataPreprocessor:
 
         if data_has_missing_values(data):
             # Data contains missing values
-            has_imputer = self.structure_analysis.check_structure_by_tag(pipeline, tag_to_check='imputation',
-                                                                         source_name=source_name)
+            has_imputer = PipelineStructureExplorer.\
+                check_structure_by_tag(pipeline, tag_to_check='imputation', source_name=source_name)
             if not has_imputer:
                 data = self._apply_imputation_unidata(data, source_name)
 
         if data_has_categorical_features(data):
             # Data contains categorical features values
-            has_encoder = self.structure_analysis.check_structure_by_tag(pipeline, tag_to_check='encoding',
-                                                                         source_name=source_name)
+            has_encoder = PipelineStructureExplorer.\
+                check_structure_by_tag(pipeline, tag_to_check='encoding', source_name=source_name)
             if not has_encoder:
                 data = self._apply_categorical_encoding(data, source_name)
 
@@ -491,7 +490,6 @@ def merge_preprocessors(api_preprocessor: DataPreprocessor,
     new_data_preprocessor = api_preprocessor
 
     # Update optional preprocessing (take it from obtained pipeline)
-    new_data_preprocessor.structure_analysis = pipeline_preprocessor.structure_analysis
     if not new_data_preprocessor.features_encoders:
         # Store features encoder from obtained pipeline because in API there are no encoding
         new_data_preprocessor.features_encoders = pipeline_preprocessor.features_encoders

--- a/fedot/preprocessing/preprocessing.py
+++ b/fedot/preprocessing/preprocessing.py
@@ -65,7 +65,10 @@ class DataPreprocessor:
         # Implemented for backward compatibility for unpickling
         #  Pipelines with older preprocessor that had DiGraph with Nodes inside.
         #  see https://github.com/nccr-itmo/FEDOT/pull/802
-        del state['structure_analysis']
+        unrelevant_fields = ['structure_analysis']
+        for field in unrelevant_fields:
+            if field in state:
+                del state[field]
         self.__dict__.update(state)
 
     def _init_supplementary_preprocessors(self, data: Union[InputData, MultiModalData]):

--- a/fedot/preprocessing/preprocessing.py
+++ b/fedot/preprocessing/preprocessing.py
@@ -61,6 +61,13 @@ class DataPreprocessor:
 
         self.log = default_log(self)
 
+    def __setstate__(self, state):
+        # Implemented for backward compatibility for unpickling
+        #  Pipelines with older preprocessor that had DiGraph with Nodes inside.
+        #  see https://github.com/nccr-itmo/FEDOT/pull/802
+        del state['structure_analysis']
+        self.__dict__.update(state)
+
     def _init_supplementary_preprocessors(self, data: Union[InputData, MultiModalData]):
         """ Initialize helpers for preprocessor
 

--- a/fedot/preprocessing/structure.py
+++ b/fedot/preprocessing/structure.py
@@ -52,24 +52,16 @@ class PipelineStructureExplorer:
         primary_df = info_df[info_df['node_type'] == 'primary']
         root_df = info_df[info_df['node_type'] == 'root']
         root_id = root_df.iloc[0]['node_id']
-        for primary_id in primary_df['node_id']:
-            if source_name == DEFAULT_SOURCE_NAME:
-                # Check all possible paths in the pipeline
+
+        for i, node_info in primary_df.iterrows():
+            primary_id = node_info['node_id']
+            node_name = node_info['node_label'].operation.operation_type
+            if source_name in (node_name, DEFAULT_SOURCE_NAME):
                 for path in nx.all_simple_paths(graph, source=primary_id, target=root_id):
-                    # For all paths perform checking if path (branch) has wanted operation
-                    # in correct location or not
+                    # Check the path (branch) whether it has wanted operation in correct location or not
                     path_info = self.check_path(graph, path, tag_to_check)
-                    self.paths[self.path_id].update(path_info)
+                    self.paths[self.path_id] = path_info
                     self.path_id += 1
-            else:
-                node_info = primary_df[primary_df['node_id'] == primary_id]
-                node_name = node_info['node_label'].iloc[0].operation.operation_type
-                if source_name == node_name:
-                    # Only this path is going to be checked
-                    for path in nx.all_simple_paths(graph, source=primary_id, target=root_id):
-                        path_info = self.check_path(graph, path, tag_to_check)
-                        self.paths[self.path_id].update(path_info)
-                        self.path_id += 1
 
         correct_branches = (branch['correctness'] for branch in self.paths.values())
         # 'False' means that least one branch in the graph cannot process desired type of data

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -168,7 +168,7 @@ def test_crossover():
     graph_example_second = adapter.adapt(pipeline_second())
     crossover_types = [CrossoverTypesEnum.none]
     requirements = PipelineComposerRequirements(primary=[], secondary=[], max_depth=3, crossover_prob=1)
-    crossover = Crossover(crossover_types, get_pipeline_generation_params(), requirements)
+    crossover = Crossover(crossover_types, requirements, get_pipeline_generation_params())
     new_graphs = crossover([Individual(graph_example_first), Individual(graph_example_second)])
     assert new_graphs[0].graph == graph_example_first
     assert new_graphs[1].graph == graph_example_second


### PR DESCRIPTION
Main change is that PipelineStructureAnalysis isn't stored in DataPreprocessor. This simplifes pickling/unpickling Pipeline with preprocessor because now it doesn't store nx.DiGraph with Nodes deep internally in preprocessor.structure_analysis.

It's required for #750, because in that PR there're problems with pickle due to changes in Graph implementation that tried to unpickle old variants of Nodes stored accidentally deep inside preprocessor.