### PR TITLE
Fix circular imports

### DIFF
--- a/cases/credit_scoring/credit_scoring_problem_multiobj.py
+++ b/cases/credit_scoring/credit_scoring_problem_multiobj.py
@@ -6,9 +6,9 @@ from sklearn.metrics import roc_auc_score as roc_auc
 
 from cases.credit_scoring.credit_scoring_problem import get_scoring_data
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.optimisers.gp_comp.gp_optimizer import GPGraphOptimizerParameters, GeneticSchemeTypesEnum
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.selection import SelectionTypesEnum
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.operation_types_repository import get_operations_for_task

--- a/cases/river_levels_prediction/river_level_case_composer.py
+++ b/cases/river_levels_prediction/river_level_case_composer.py
@@ -6,8 +6,7 @@ import pandas as pd
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import \
-    PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode

--- a/examples/advanced/fedot_based_solutions/graph_model_optimization.py
+++ b/examples/advanced/fedot_based_solutions/graph_model_optimization.py
@@ -5,7 +5,6 @@ import random
 import numpy as np
 import pandas as pd
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.dag.verification_rules import has_no_cycle, has_no_self_cycled_nodes
 from fedot.core.optimisers.adapters import DirectAdapter
 from fedot.core.optimisers.gp_comp.gp_optimizer import (
@@ -13,6 +12,7 @@ from fedot.core.optimisers.gp_comp.gp_optimizer import (
     GeneticSchemeTypesEnum,
     GPGraphOptimizerParameters
 )
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum
 from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum
 from fedot.core.optimisers.graph import OptGraph, OptNode

--- a/examples/advanced/pipeline_sensitivity.py
+++ b/examples/advanced/pipeline_sensitivity.py
@@ -4,10 +4,10 @@ from os.path import exists, join
 from examples.simple.classification.classification_pipelines import classification_three_depth_manual_pipeline
 from examples.simple.regression.regression_pipelines import regression_three_depth_manual_pipeline
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.optimisers.gp_comp.gp_optimizer import GPGraphOptimizerParameters
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.repository.operation_types_repository import get_operations_for_task
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum, MetricsRepository, \

--- a/examples/advanced/sensitivity_analysis/pipelines_access.py
+++ b/examples/advanced/sensitivity_analysis/pipelines_access.py
@@ -1,6 +1,6 @@
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.gp_optimizer import GPGraphOptimizerParameters
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline

--- a/examples/advanced/time_series_forecasting/composing_pipelines.py
+++ b/examples/advanced/time_series_forecasting/composing_pipelines.py
@@ -8,11 +8,11 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error
 
 from examples.simple.time_series_forecasting.ts_pipelines import *
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.composer.gp_composer.specific_operators import parameter_change_mutation
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.optimisers.gp_comp.gp_optimizer import GPGraphOptimizerParameters
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum

--- a/examples/advanced/time_series_forecasting/multi_ts_arctic_forecasting.py
+++ b/examples/advanced/time_series_forecasting/multi_ts_arctic_forecasting.py
@@ -7,9 +7,9 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error
 from cases.multi_ts_level_forecasting import prepare_data
 from examples.simple.time_series_forecasting.ts_pipelines import *
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.composer.gp_composer.specific_operators import parameter_change_mutation
 from fedot.core.optimisers.gp_comp.gp_optimizer import GPGraphOptimizerParameters
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
 from fedot.core.repository.quality_metrics_repository import \
     MetricsRepository, RegressionMetricsEnum

--- a/examples/simple/classification/multiclass_prediction.py
+++ b/examples/simple/classification/multiclass_prediction.py
@@ -16,7 +16,7 @@ from datetime import timedelta
 import numpy as np
 
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.operation_types_repository import OperationTypesRepository

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -9,12 +9,13 @@ from fedot.api.time import ApiTime
 from fedot.core.caching.pipelines_cache import OperationsCache
 from fedot.core.caching.preprocessing_cache import PreprocessingCache
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import GPComposer, PipelineComposerRequirements
+from fedot.core.composer.gp_composer.gp_composer import GPComposer
 from fedot.core.composer.gp_composer.specific_operators import boosting_mutation, parameter_change_mutation
 from fedot.core.constants import DEFAULT_TUNING_ITERATIONS_NUMBER, MINIMAL_SECONDS_FOR_TUNING
 from fedot.core.data.data import InputData
 from fedot.core.log import LoggerAdapter
 from fedot.core.optimisers.gp_comp.gp_optimizer import GeneticSchemeTypesEnum, GPGraphOptimizerParameters
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
 from fedot.core.optimisers.opt_history import OptHistory

--- a/fedot/core/composer/composer.py
+++ b/fedot/core/composer/composer.py
@@ -1,49 +1,12 @@
-import datetime
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import (List, Optional, Union, Sequence)
 
-from fedot.core.composer.advisor import PipelineChangeAdvisor
 from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.log import default_log
 from fedot.core.optimisers.optimizer import GraphOptimizer
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.pipelines.pipeline import Pipeline
-
-
-@dataclass
-class ComposerRequirements:
-    """
-    This dataclass is for defining the requirements of composition process
-
-    :attribute primary: List of operation types (str) for Primary Nodes
-    :attribute secondary: List of operation types (str) for Secondary Nodes
-    :attribute timeout: max time in minutes available for composition process
-    :attribute max_depth: max depth of the result pipeline
-    :attribute max_pipeline_fit_time: time constraint for operation fitting (minutes)
-    :attribute max_arity: maximal number of parent for node
-    :attribute min_arity: minimal number of parent for node
-    :attribute cv_folds: integer or None to use cross validation
-    """
-    primary: Sequence[str] = tuple()
-    secondary: Sequence[str] = tuple()
-    timeout: Optional[datetime.timedelta] = datetime.timedelta(minutes=5)
-    max_pipeline_fit_time: Optional[datetime.timedelta] = None
-    max_depth: int = 3
-    max_arity: int = 2
-    min_arity: int = 2
-    cv_folds: Optional[int] = None
-    advisor: Optional[PipelineChangeAdvisor] = PipelineChangeAdvisor()
-
-    def __post_init__(self):
-        if self.max_depth < 0:
-            raise ValueError(f'invalid max_depth value')
-        if self.max_arity < 0:
-            raise ValueError(f'invalid max_arity value')
-        if self.min_arity < 0:
-            raise ValueError(f'invalid min_arity value')
-        if self.cv_folds is not None and self.cv_folds <= 1:
-            raise ValueError(f'Number of folds for KFold cross validation must be 2 or more.')
 
 
 class Composer(ABC):

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -6,9 +6,10 @@ from typing import Dict, List, Optional, Sequence, Type, Union
 from fedot.core.caching.pipelines_cache import OperationsCache
 from fedot.core.caching.preprocessing_cache import PreprocessingCache
 from fedot.core.composer.composer import Composer
-from fedot.core.composer.gp_composer.gp_composer import GPComposer, PipelineComposerRequirements
+from fedot.core.composer.gp_composer.gp_composer import GPComposer
 from fedot.core.log import LoggerAdapter, default_log
 from fedot.core.optimisers.gp_comp.gp_optimizer import EvoGraphOptimizer, GPGraphOptimizerParameters
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum
 from fedot.core.optimisers.initial_graphs_generator import InitialPopulationGenerator, GenerationFunction
 from fedot.core.optimisers.objective.objective import Objective

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -3,7 +3,7 @@ from typing import Collection, Optional, Sequence, Tuple, Union
 
 from fedot.core.caching.pipelines_cache import OperationsCache
 from fedot.core.caching.preprocessing_cache import PreprocessingCache
-from fedot.core.composer.composer import Composer, ComposerRequirements
+from fedot.core.composer.composer import Composer
 from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationStrengthEnum
@@ -11,6 +11,7 @@ from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective.data_objective_builder import DataObjectiveBuilder
 from fedot.core.optimisers.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphOptimizer
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.pipelines.pipeline import Pipeline
 
 

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Collection, Optional, Sequence, Tuple, Union
 
 from fedot.core.caching.pipelines_cache import OperationsCache
@@ -6,46 +5,12 @@ from fedot.core.caching.preprocessing_cache import PreprocessingCache
 from fedot.core.composer.composer import Composer
 from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
-from fedot.core.optimisers.gp_comp.operators.mutation import MutationStrengthEnum
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective.data_objective_builder import DataObjectiveBuilder
 from fedot.core.optimisers.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphOptimizer
-from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.pipelines.pipeline import Pipeline
-
-
-@dataclass
-class PipelineComposerRequirements(ComposerRequirements):
-    """
-    Dataclass is for defining the requirements for composition process of genetic programming composer
-
-    :attribute pop_size: initial population size; if unspecified, default value is used.
-    :attribute max_pop_size: maximum population size; optional, if unspecified, then population size is unbound.
-    :attribute num_of_generations: maximal number of evolutionary algorithm generations
-    :attribute crossover_prob: crossover probability (the chance that two chromosomes exchange some of their parts)
-    :attribute mutation_prob: mutation probability
-    :attribute mutation_strength: strength of mutation in tree (using in certain mutation types)
-    :attribute max_pipeline_fit_time: time constraint for operation fitting (minutes)
-    :attribute start_depth: start value of tree depth
-    :attribute validation_blocks: number of validation blocks for time series validation
-    :attribute n_jobs: num of n_jobs
-    :attribute collect_intermediate_metric: save metrics for intermediate (non-root) nodes in pipeline
-    :attribute keep_n_best: Number of the best individuals of previous generation to keep in next generation.
-    """
-    pop_size: int = 20
-    max_pop_size: Optional[int] = 55
-    num_of_generations: int = 20
-    offspring_rate: float = 0.5
-    crossover_prob: float = 0.8
-    mutation_prob: float = 0.8
-    mutation_strength: MutationStrengthEnum = MutationStrengthEnum.mean
-    max_pipeline_fit_time: int = None
-    start_depth: int = None
-    validation_blocks: int = None
-    n_jobs: int = 1
-    collect_intermediate_metric: bool = False
-    keep_n_best: int = 1
 
 
 class GPComposer(Composer):

--- a/fedot/core/composer/random_composer.py
+++ b/fedot/core/composer/random_composer.py
@@ -4,11 +4,12 @@ from typing import (Any, Callable, List, Optional, Sequence)
 
 from numpy import random
 
-from fedot.core.composer.composer import ComposerRequirements, Composer
+from fedot.core.composer.composer import Composer
 from fedot.core.data.data import InputData
 from fedot.core.optimisers.fitness import Fitness
 from fedot.core.optimisers.objective import Objective, ObjectiveFunction
 from fedot.core.optimisers.optimizer import GraphOptimizer
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.pipelines.node import SecondaryNode, PrimaryNode
 from fedot.core.pipelines.pipeline import Node, Pipeline
 

--- a/fedot/core/dag/verification_rules.py
+++ b/fedot/core/dag/verification_rules.py
@@ -1,22 +1,18 @@
-from typing import TYPE_CHECKING
-
 import networkx as nx
 from networkx import isolates, simple_cycles
 
 from fedot.core.pipelines.convert import graph_structure_as_nx_graph
-
-if TYPE_CHECKING:
-    from fedot.core.dag.graph import Graph
+from fedot.core.dag.graph import Graph
 
 ERROR_PREFIX = 'Invalid graph configuration:'
 
 
-def has_one_root(graph: 'Graph'):
+def has_one_root(graph: Graph):
     if graph.root_node:
         return True
 
 
-def has_no_cycle(graph: 'Graph'):
+def has_no_cycle(graph: Graph):
     nx_graph, _ = graph_structure_as_nx_graph(graph)
     cycled = list(simple_cycles(nx_graph))
     if len(cycled) > 0:
@@ -33,13 +29,13 @@ def has_no_isolated_nodes(graph: 'Graph'):
     return True
 
 
-def has_no_self_cycled_nodes(graph: 'Graph'):
+def has_no_self_cycled_nodes(graph: Graph):
     if any([node for node in graph.nodes if node.nodes_from and node in node.nodes_from]):
         raise ValueError(f'{ERROR_PREFIX} Graph has self-cycled nodes')
     return True
 
 
-def has_no_isolated_components(graph: 'Graph'):
+def has_no_isolated_components(graph: Graph):
     nx_graph, _ = graph_structure_as_nx_graph(graph)
     ud_nx_graph = nx.Graph()
     ud_nx_graph.add_nodes_from(nx_graph)

--- a/fedot/core/optimisers/composer_requirements.py
+++ b/fedot/core/optimisers/composer_requirements.py
@@ -1,0 +1,40 @@
+import datetime
+from dataclasses import dataclass
+from typing import Sequence, Optional
+
+from fedot.core.composer.advisor import PipelineChangeAdvisor
+
+
+@dataclass
+class ComposerRequirements:
+    """
+    This dataclass is for defining the requirements of composition process
+
+    :attribute primary: List of operation types (str) for Primary Nodes
+    :attribute secondary: List of operation types (str) for Secondary Nodes
+    :attribute timeout: max time in minutes available for composition process
+    :attribute max_depth: max depth of the result pipeline
+    :attribute max_pipeline_fit_time: time constraint for operation fitting (minutes)
+    :attribute max_arity: maximal number of parent for node
+    :attribute min_arity: minimal number of parent for node
+    :attribute cv_folds: integer or None to use cross validation
+    """
+    primary: Sequence[str] = tuple()
+    secondary: Sequence[str] = tuple()
+    timeout: Optional[datetime.timedelta] = datetime.timedelta(minutes=5)
+    max_pipeline_fit_time: Optional[datetime.timedelta] = None
+    max_depth: int = 3
+    max_arity: int = 2
+    min_arity: int = 2
+    cv_folds: Optional[int] = None
+    advisor: Optional[PipelineChangeAdvisor] = PipelineChangeAdvisor()
+
+    def __post_init__(self):
+        if self.max_depth < 0:
+            raise ValueError(f'invalid max_depth value')
+        if self.max_arity < 0:
+            raise ValueError(f'invalid max_arity value')
+        if self.min_arity < 0:
+            raise ValueError(f'invalid min_arity value')
+        if self.cv_folds is not None and self.cv_folds <= 1:
+            raise ValueError(f'Number of folds for KFold cross validation must be 2 or more.')

--- a/fedot/core/optimisers/gp_comp/gp_operators.py
+++ b/fedot/core/optimisers/gp_comp/gp_operators.py
@@ -2,10 +2,10 @@ from copy import deepcopy
 from random import randint
 from typing import Any, List, Optional, Tuple
 
-from fedot.core.composer.composer import ComposerRequirements
 from fedot.core.constants import MAXIMAL_ATTEMPTS_NUMBER
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.optimisers.optimizer import GraphGenerationParams
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
 
 
 def random_graph(graph_generation_params: GraphGenerationParams,

--- a/fedot/core/optimisers/gp_comp/gp_optimizer.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimizer.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from random import choice
 from typing import Any, List, Optional, Sequence, Union, Callable
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.constants import MAXIMAL_ATTEMPTS_NUMBER, EVALUATION_ATTEMPTS_NUMBER
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, Crossover
@@ -15,6 +14,7 @@ from fedot.core.optimisers.gp_comp.operators.selection import SelectionTypesEnum
 from fedot.core.optimisers.gp_comp.parameters.graph_depth import AdaptiveGraphDepth
 from fedot.core.optimisers.gp_comp.parameters.operators_prob import init_adaptive_operators_prob
 from fedot.core.optimisers.gp_comp.parameters.population_size import init_adaptive_pop_size, PopulationSize
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.objective.objective import Objective
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimizerParameters
 from fedot.core.optimisers.populational_optimizer import PopulationalOptimizer

--- a/fedot/core/optimisers/gp_comp/operators/crossover.py
+++ b/fedot/core/optimisers/gp_comp/operators/crossover.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from random import choice, random
 from typing import Callable, List, Union, Iterable, Tuple
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.log import default_log
 from fedot.core.optimisers.gp_comp.gp_operators import equivalent_subtree, replace_subtrees
 from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator

--- a/fedot/core/optimisers/gp_comp/operators/elitism.py
+++ b/fedot/core/optimisers/gp_comp/operators/elitism.py
@@ -1,6 +1,6 @@
 from random import shuffle
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
 

--- a/fedot/core/optimisers/gp_comp/operators/inheritance.py
+++ b/fedot/core/optimisers/gp_comp/operators/inheritance.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import (Callable)
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
 from fedot.core.optimisers.gp_comp.operators.selection import Selection
 from fedot.core.utilities.data_structures import ComparableEnum as Enum

--- a/fedot/core/optimisers/gp_comp/operators/mutation.py
+++ b/fedot/core/optimisers/gp_comp/operators/mutation.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from functools import partial
 from random import choice, randint, random, sample
-from typing import TYPE_CHECKING, Any, Callable, List, Union, Tuple
+from typing import Callable, List, Union, Tuple
 
 import numpy as np
 
@@ -15,9 +15,8 @@ from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operat
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
 from fedot.core.optimisers.optimizer import GraphGenerationParams
-
-if TYPE_CHECKING:
-    from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements, \
+    MutationStrengthEnum
 
 
 class MutationTypesEnum(Enum):
@@ -33,15 +32,9 @@ class MutationTypesEnum(Enum):
     none = 'none'
 
 
-class MutationStrengthEnum(Enum):
-    weak = 0.2
-    mean = 1.0
-    strong = 5.0
-
-
 class Mutation(Operator):
     def __init__(self, mutation_types: List[Union[MutationTypesEnum, Callable]],
-                 requirements: 'PipelineComposerRequirements', graph_generation_params: GraphGenerationParams,
+                 requirements: PipelineComposerRequirements, graph_generation_params: GraphGenerationParams,
                  max_num_of_mutation_attempts: int = 100,
                  static_mutation_probability: float = 0.7):
         self.mutation_types = mutation_types

--- a/fedot/core/optimisers/gp_comp/operators/operator.py
+++ b/fedot/core/optimisers/gp_comp/operators/operator.py
@@ -2,9 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Sequence, Callable, TYPE_CHECKING
 
 from fedot.core.optimisers.gp_comp.individual import Individual
-
-if TYPE_CHECKING:
-    from fedot.core.composer.composer import ComposerRequirements
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
 
 PopulationT = Sequence[Individual]  # TODO: provisional
 EvaluationOperator = Callable[[PopulationT], PopulationT]
@@ -22,5 +20,5 @@ class Operator(ABC):
     """
 
     @abstractmethod
-    def update_requirements(self, new_requirements: 'ComposerRequirements'):
+    def update_requirements(self, new_requirements: ComposerRequirements):
         pass

--- a/fedot/core/optimisers/gp_comp/operators/regularization.py
+++ b/fedot/core/optimisers/gp_comp/operators/regularization.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, EvaluationOperator, Operator
 from fedot.core.optimisers.graph import OptGraph, OptNode

--- a/fedot/core/optimisers/gp_comp/operators/selection.py
+++ b/fedot/core/optimisers/gp_comp/operators/selection.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from random import choice, randint
 from typing import List, Callable
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
 

--- a/fedot/core/optimisers/gp_comp/parameters/operators_prob.py
+++ b/fedot/core/optimisers/gp_comp/parameters/operators_prob.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.gp_comp.parameters.mutation_prob import AdaptiveMutationProb

--- a/fedot/core/optimisers/gp_comp/parameters/population_size.py
+++ b/fedot/core/optimisers/gp_comp/parameters/population_size.py
@@ -4,7 +4,7 @@ from typing import Optional
 from .parameter import AdaptiveParameter
 from fedot.core.utilities.data_structures import BidirectionalIterator
 from fedot.core.utilities.sequence_iterator import fibonacci_sequence, SequenceIterator
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from ..pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.archive.generation_keeper import ImprovementWatcher
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT

--- a/fedot/core/optimisers/gp_comp/pipeline_composer_requirements.py
+++ b/fedot/core/optimisers/gp_comp/pipeline_composer_requirements.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
+from fedot.core.utilities.data_structures import ComparableEnum as Enum
+
+
+class MutationStrengthEnum(Enum):
+    weak = 0.2
+    mean = 1.0
+    strong = 5.0
+
+
+@dataclass
+class PipelineComposerRequirements(ComposerRequirements):
+    """
+    Dataclass is for defining the requirements for composition process of genetic programming composer
+
+    :attribute pop_size: initial population size; if unspecified, default value is used.
+    :attribute max_pop_size: maximum population size; optional, if unspecified, then population size is unbound.
+    :attribute num_of_generations: maximal number of evolutionary algorithm generations
+    :attribute crossover_prob: crossover probability (the chance that two chromosomes exchange some of their parts)
+    :attribute mutation_prob: mutation probability
+    :attribute mutation_strength: strength of mutation in tree (using in certain mutation types)
+    :attribute max_pipeline_fit_time: time constraint for operation fitting (minutes)
+    :attribute start_depth: start value of tree depth
+    :attribute validation_blocks: number of validation blocks for time series validation
+    :attribute n_jobs: num of n_jobs
+    :attribute collect_intermediate_metric: save metrics for intermediate (non-root) nodes in pipeline
+    :attribute keep_n_best: Number of the best individuals of previous generation to keep in next generation.
+    """
+    pop_size: int = 20
+    max_pop_size: Optional[int] = 55
+    num_of_generations: int = 20
+    offspring_rate: float = 0.5
+    crossover_prob: float = 0.8
+    mutation_prob: float = 0.8
+    mutation_strength: MutationStrengthEnum = MutationStrengthEnum.mean
+    max_pipeline_fit_time: int = None
+    start_depth: int = None
+    validation_blocks: int = None
+    n_jobs: int = 1
+    collect_intermediate_metric: bool = False
+    keep_n_best: int = 1
+
+

--- a/fedot/core/optimisers/gp_comp/pipeline_composer_requirements.py
+++ b/fedot/core/optimisers/gp_comp/pipeline_composer_requirements.py
@@ -42,5 +42,3 @@ class PipelineComposerRequirements(ComposerRequirements):
     n_jobs: int = 1
     collect_intermediate_metric: bool = False
     keep_n_best: int = 1
-
-

--- a/fedot/core/optimisers/initial_graphs_generator.py
+++ b/fedot/core/optimisers/initial_graphs_generator.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, Sequence, Union, Iterable
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.constants import MAXIMAL_ATTEMPTS_NUMBER
 from fedot.core.dag.graph import Graph
 from fedot.core.log import default_log

--- a/fedot/core/optimisers/populational_optimizer.py
+++ b/fedot/core/optimisers/populational_optimizer.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Sequence
 
 from tqdm import tqdm
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.archive import GenerationKeeper
 from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -266,7 +266,7 @@ class Pipeline(Graph, Serializable):
         """
         template = PipelineTemplate(self)
         json_object, dict_fitted_operations = template.export_pipeline(path, root_node=self.root_node,
-                                                                            datetime_in_path=datetime_in_path)
+                                                                       datetime_in_path=datetime_in_path)
         return json_object, dict_fitted_operations
 
     def load(self, source: Union[str, dict], dict_fitted_operations: dict = None):

--- a/fedot/core/pipelines/pipeline_node_factory.py
+++ b/fedot/core/pipelines/pipeline_node_factory.py
@@ -1,17 +1,15 @@
 from random import choice
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 from fedot.core.composer.advisor import PipelineChangeAdvisor
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptNode
 from fedot.core.optimisers.opt_node_factory import OptNodeFactory
 from fedot.core.utils import DEFAULT_PARAMS_STUB
 
-if TYPE_CHECKING:
-    from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
-
 
 class PipelineOptNodeFactory(OptNodeFactory):
-    def __init__(self, requirements: 'PipelineComposerRequirements',
+    def __init__(self, requirements: PipelineComposerRequirements,
                  advisor: Optional[PipelineChangeAdvisor] = None):
         super().__init__(requirements)
         self.advisor = advisor or PipelineChangeAdvisor()

--- a/fedot/core/pipelines/template.py
+++ b/fedot/core/pipelines/template.py
@@ -13,7 +13,6 @@ from fedot.core.log import default_log
 from fedot.core.operations.atomized_template import AtomizedModelTemplate
 from fedot.core.operations.operation_template import OperationTemplate, check_existing_path
 from fedot.core.pipelines.node import Node, PrimaryNode, SecondaryNode
-from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
 from fedot.core.utils import default_fedot_data_dir
 
 if TYPE_CHECKING:

--- a/fedot/core/serializers/coders/individual_serialization.py
+++ b/fedot/core/serializers/coders/individual_serialization.py
@@ -1,13 +1,11 @@
-from typing import Any, Dict, Type, TYPE_CHECKING
+from typing import Any, Dict, Type
 
-from . import any_from_json
 from fedot.core.optimisers.fitness import SingleObjFitness
+from fedot.core.optimisers.gp_comp.individual import Individual
+from . import any_from_json
 
-if TYPE_CHECKING:
-    from fedot.core.optimisers.gp_comp.individual import Individual
 
-
-def individual_from_json(cls: Type['Individual'], json_obj: Dict[str, Any]) -> 'Individual':
+def individual_from_json(cls: Type[Individual], json_obj: Dict[str, Any]) -> Individual:
     deserialized = any_from_json(cls, json_obj)
     if isinstance(deserialized.fitness, float):  # legacy histories support
         object.__setattr__(deserialized, 'fitness', SingleObjFitness(deserialized.fitness))

--- a/test/unit/composer/test_builder.py
+++ b/test/unit/composer/test_builder.py
@@ -2,8 +2,8 @@ import datetime
 from operator import eq
 
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.gp_optimizer import GPGraphOptimizerParameters, GeneticSchemeTypesEnum
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.repository.operation_types_repository import OperationTypesRepository
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -10,7 +10,7 @@ from sklearn.metrics import roc_auc_score as roc_auc
 from fedot.api.main import Fedot
 from fedot.core.caching.pipelines_cache import OperationsCache
 from fedot.core.composer.advisor import PipelineChangeAdvisor
-from fedot.core.composer.composer import ComposerRequirements
+from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.composer.composer_builder import ComposerBuilder
 from fedot.core.composer.gp_composer.gp_composer import GPComposer, PipelineComposerRequirements
 from fedot.core.composer.random_composer import RandomGraphFactory, RandomSearchComposer, RandomSearchOptimizer

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -12,12 +12,13 @@ from fedot.core.caching.pipelines_cache import OperationsCache
 from fedot.core.composer.advisor import PipelineChangeAdvisor
 from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import GPComposer, PipelineComposerRequirements
+from fedot.core.composer.gp_composer.gp_composer import GPComposer
 from fedot.core.composer.random_composer import RandomGraphFactory, RandomSearchComposer, RandomSearchOptimizer
 from fedot.core.data.data import InputData
 from fedot.core.optimisers.gp_comp.gp_operators import random_graph
 from fedot.core.optimisers.gp_comp.gp_optimizer import GeneticSchemeTypesEnum, GPGraphOptimizerParameters
-from fedot.core.optimisers.gp_comp.operators.mutation import MutationStrengthEnum
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements, \
+    MutationStrengthEnum
 from fedot.core.optimisers.gp_comp.operators.selection import SelectionTypesEnum
 from fedot.core.optimisers.objective import Objective
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from fedot.api.main import Fedot
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.dag.graph import Graph
 from fedot.core.dag.verification_rules import DEFAULT_DAG_RULES
 from fedot.core.data.data import InputData

--- a/test/unit/optimizer/test_default_node_factory.py
+++ b/test/unit/optimizer/test_default_node_factory.py
@@ -1,5 +1,5 @@
 from fedot.core.composer.advisor import PipelineChangeAdvisor
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptNode
 from fedot.core.optimisers.opt_node_factory import DefaultOptNodeFactory
 from fedot.core.repository.tasks import Task, TaskTypesEnum

--- a/test/unit/optimizer/test_elitism_operator.py
+++ b/test/unit/optimizer/test_elitism_operator.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import pytest
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.evaluation import SimpleDispatcher
 from fedot.core.optimisers.gp_comp.individual import Individual

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 import numpy as np
 
-
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.composer.gp_composer.specific_operators import boosting_mutation
 from fedot.core.dag.verification_rules import DEFAULT_DAG_RULES
 from fedot.core.data.data import InputData

--- a/test/unit/optimizer/test_initial_population_generator.py
+++ b/test/unit/optimizer/test_initial_population_generator.py
@@ -3,7 +3,7 @@ from random import choice
 
 import pytest
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.initial_graphs_generator import InitialPopulationGenerator
 from fedot.core.pipelines.pipeline_graph_generation_params import get_pipeline_generation_params
 from fedot.core.pipelines.verification import rules_by_task

--- a/test/unit/optimizer/test_selection_operators.py
+++ b/test/unit/optimizer/test_selection_operators.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.debug.metrics import RandomMetric
 from fedot.core.optimisers.fitness.fitness import SingleObjFitness
 from fedot.core.optimisers.gp_comp.gp_operators import random_graph

--- a/test/unit/pipelines/test_pipeline_node_factory.py
+++ b/test/unit/pipelines/test_pipeline_node_factory.py
@@ -1,7 +1,7 @@
 import pytest
 
 from fedot.core.composer.advisor import PipelineChangeAdvisor
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptNode
 from fedot.core.pipelines.pipeline_node_factory import PipelineOptNodeFactory
 from fedot.core.repository.tasks import Task, TaskTypesEnum

--- a/test/unit/tasks/test_custom.py
+++ b/test/unit/tasks/test_custom.py
@@ -2,13 +2,13 @@ import random
 
 import numpy as np
 
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
 from fedot.core.dag.graph import Graph
 from fedot.core.dag.graph_node import GraphNode
 from fedot.core.dag.verification_rules import has_no_self_cycled_nodes
 from fedot.core.optimisers.adapters import DirectAdapter
 from fedot.core.optimisers.gp_comp.gp_optimizer import EvoGraphOptimizer, GPGraphOptimizerParameters, \
     GeneticSchemeTypesEnum
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.initial_graphs_generator import InitialPopulationGenerator
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
 from fedot.core.optimisers.gp_comp.operators.regularization import RegularizationTypesEnum

--- a/test/unit/validation/test_table_cv.py
+++ b/test/unit/validation/test_table_cv.py
@@ -9,7 +9,7 @@ from sklearn.model_selection import KFold, StratifiedKFold
 
 from fedot.api.main import Fedot
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.optimisers.objective.data_objective_advisor import DataObjectiveAdvisor

--- a/test/unit/validation/test_time_series_cv.py
+++ b/test/unit/validation/test_time_series_cv.py
@@ -6,8 +6,7 @@ from sklearn.metrics import mean_absolute_error
 from examples.advanced.time_series_forecasting.composing_pipelines import get_available_operations
 from fedot.api.main import Fedot
 from fedot.core.composer.composer_builder import ComposerBuilder
-from fedot.core.composer.gp_composer.gp_composer import \
-    PipelineComposerRequirements
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.log import default_log
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.quality_metrics_repository import \


### PR DESCRIPTION
This PR gets rid of circular imports for ComposerRequirements and PipelineComposerRequirements by moving this classes to a separate modules. 