### PR TITLE
Hotfix wrap extra dependencies import

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_pretrained.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_pretrained.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import numpy as np
@@ -6,9 +7,15 @@ from fedot.core.log import default_log
 from fedot.core.operations.evaluation.operation_implementations. \
     implementation_interfaces import DataOperationImplementation
 from fedot.core.repository.dataset_types import DataTypesEnum
-import os
-import gensim.downloader as api
-from gensim.models import KeyedVectors
+from fedot.utilities.requirements_notificator import warn_requirement
+
+try:
+    import gensim.downloader as api
+    from gensim.models import KeyedVectors
+except ModuleNotFoundError:
+    warn_requirement('gensim')
+    api = None
+    KeyedVectors = None
 
 
 class PretrainedEmbeddingsImplementation(DataOperationImplementation):

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -26,7 +26,7 @@ try:
 
     from PIL import Image
 except ModuleNotFoundError:
-    warn_requirement('PIL')
+    warn_requirement('Pillow')
     PIL = None
 
 from fedot.core.log import default_log


### PR DESCRIPTION
* Wrapped `gensim` import in `warn_requirement`.
* Fixed warning hint for `Pillow`. 