### PR TITLE
Refactor predict method

### DIFF
--- a/fedot/core/operations/atomized_model.py
+++ b/fedot/core/operations/atomized_model.py
@@ -23,7 +23,6 @@ class AtomizedModel(Operation):
         self.atomized_preprocessor = DataPreprocessor()
 
     def fit(self, params: Optional[Union[str, dict]], data: InputData,
-            is_fit_pipeline_stage: bool = True,
             use_cache: bool = True):
 
         copied_input_data = deepcopy(data)
@@ -34,7 +33,7 @@ class AtomizedModel(Operation):
 
         return fitted_atomized_operation, predicted_train
 
-    def predict(self, fitted_operation, data: InputData, is_fit_pipeline_stage: bool = False,
+    def predict(self, fitted_operation, data: InputData,
                 params: Optional[Union[str, dict]] = None, output_mode: str = 'default'):
 
         # Preprocessing applied
@@ -44,6 +43,10 @@ class AtomizedModel(Operation):
         prediction = fitted_operation.predict(input_data=copied_input_data, output_mode=output_mode)
         prediction = self.assign_tabular_column_types(prediction, output_mode)
         return prediction
+
+    def predict_for_fit(self, fitted_operation, data: InputData, params: Union[str, dict, None] = None,
+                        output_mode: str = 'default'):
+        return self.predict(fitted_operation, data, params, output_mode)
 
     def fine_tune(self, loss_function: Callable,
                   input_data: InputData = None, iterations: int = 50,

--- a/fedot/core/operations/evaluation/automl.py
+++ b/fedot/core/operations/evaluation/automl.py
@@ -55,7 +55,7 @@ class H2OAutoMLRegressionStrategy(EvaluationStrategy):
 
         return H2OSerializationWrapper(models)
 
-    def predict(self, trained_operation, predict_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         res = []
         for model in trained_operation.get_estimators():
             frame = H2OFrame(predict_data.features)
@@ -65,6 +65,9 @@ class H2OAutoMLRegressionStrategy(EvaluationStrategy):
         res = np.hstack(res)
         out = self._convert_to_output(res, predict_data)
         return out
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
@@ -121,7 +124,7 @@ class H2OAutoMLClassificationStrategy(EvaluationStrategy):
         model.leader.classes_ = np.unique(train_data.target)
         return H2OSerializationWrapper([model.leader])
 
-    def predict(self, trained_operation, predict_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         frame = self._data_transform(predict_data)
         prediction = trained_operation.get_estimators()[0].predict(frame)
         prediction = prediction.as_data_frame().to_numpy()
@@ -134,6 +137,9 @@ class H2OAutoMLClassificationStrategy(EvaluationStrategy):
             raise ValueError(f'Output model {self.output_mode} is not supported')
         out = self._convert_to_output(prediction, predict_data)
         return out
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
@@ -186,7 +192,7 @@ class TPOTAutoMLRegressionStrategy(EvaluationStrategy):
         model = TPOTRegressionSerializationWrapper(models)
         return model
 
-    def predict(self, trained_operation, predict_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         res = []
         features = predict_data.features.astype(float)
         for model in trained_operation.get_estimators():
@@ -196,6 +202,9 @@ class TPOTAutoMLRegressionStrategy(EvaluationStrategy):
         res = np.hstack(res)
         out = self._convert_to_output(res, predict_data)
         return out
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
@@ -228,7 +237,7 @@ class TPOTAutoMLClassificationStrategy(EvaluationStrategy):
 
         return model.fitted_pipeline_
 
-    def predict(self, trained_operation, predict_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         n_classes = len(trained_operation.classes_)
         if self.output_mode == 'labels':
             prediction = trained_operation.predict(predict_data.features.astype(float))
@@ -242,6 +251,9 @@ class TPOTAutoMLClassificationStrategy(EvaluationStrategy):
             raise ValueError(f'Output model {self.output_mode} is not supported')
         out = self._convert_to_output(prediction, predict_data)
         return out
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():

--- a/fedot/core/operations/evaluation/automl.py
+++ b/fedot/core/operations/evaluation/automl.py
@@ -66,9 +66,6 @@ class H2OAutoMLRegressionStrategy(EvaluationStrategy):
         out = self._convert_to_output(res, predict_data)
         return out
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]
@@ -138,9 +135,6 @@ class H2OAutoMLClassificationStrategy(EvaluationStrategy):
         out = self._convert_to_output(prediction, predict_data)
         return out
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]
@@ -203,9 +197,6 @@ class TPOTAutoMLRegressionStrategy(EvaluationStrategy):
         out = self._convert_to_output(res, predict_data)
         return out
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]
@@ -251,9 +242,6 @@ class TPOTAutoMLClassificationStrategy(EvaluationStrategy):
             raise ValueError(f'Output model {self.output_mode} is not supported')
         out = self._convert_to_output(prediction, predict_data)
         return out
-
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():

--- a/fedot/core/operations/evaluation/classification.py
+++ b/fedot/core/operations/evaluation/classification.py
@@ -72,14 +72,12 @@ class FedotClassificationStrategy(EvaluationStrategy):
         operation_implementation.fit(train_data)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData):
         """
         Predict method for classification task
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return: prediction target
         """
         n_classes = len(trained_operation.classes_)

--- a/fedot/core/operations/evaluation/classification.py
+++ b/fedot/core/operations/evaluation/classification.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Optional
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy, SkLearnEvaluationStrategy
 from fedot.core.operations.evaluation.operation_implementations.data_operations.decompose \
     import DecomposerClassImplementation
@@ -24,14 +24,12 @@ warnings.filterwarnings("ignore", category=UserWarning)
 class SkLearnClassificationStrategy(SkLearnEvaluationStrategy):
     """ Strategy for applying classification algorithms from Sklearn library """
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for classification task
+        Predict method for classification task for predict stage
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return: prediction target
         """
 
@@ -41,6 +39,16 @@ class SkLearnClassificationStrategy(SkLearnEvaluationStrategy):
         # Convert prediction to output (if it is required)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for classification task for fit stage
+
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return: prediction target
+        """
+        return self.predict(trained_operation, predict_data)
 
 
 class FedotClassificationStrategy(EvaluationStrategy):
@@ -72,9 +80,9 @@ class FedotClassificationStrategy(EvaluationStrategy):
         operation_implementation.fit(train_data)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for classification task
+        Predict method for classification task for predict stage
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
@@ -95,6 +103,16 @@ class FedotClassificationStrategy(EvaluationStrategy):
         # Convert prediction to output (if it is required)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for classification task for fit stage
+
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return: prediction target
+        """
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
@@ -136,20 +154,27 @@ class FedotClassificationPreprocessingStrategy(EvaluationStrategy):
         operation_implementation.fit(train_data)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Transform data
+        Transform data for predict stage
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return:
         """
-        prediction = trained_operation.transform(predict_data,
-                                                 is_fit_pipeline_stage)
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
 
-        # Convert prediction to output (if it is required)
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Transform data for fit stage
+
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/classification.py
+++ b/fedot/core/operations/evaluation/classification.py
@@ -35,20 +35,8 @@ class SkLearnClassificationStrategy(SkLearnEvaluationStrategy):
 
         prediction = self._sklearn_compatible_prediction(trained_operation=trained_operation,
                                                          features=predict_data.features)
-
-        # Convert prediction to output (if it is required)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
-
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for classification task for fit stage
-
-        :param trained_operation: model object
-        :param predict_data: data used for prediction
-        :return: prediction target
-        """
-        return self.predict(trained_operation, predict_data)
 
 
 class FedotClassificationStrategy(EvaluationStrategy):

--- a/fedot/core/operations/evaluation/classification.py
+++ b/fedot/core/operations/evaluation/classification.py
@@ -92,16 +92,6 @@ class FedotClassificationStrategy(EvaluationStrategy):
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for classification task for fit stage
-
-        :param trained_operation: model object
-        :param predict_data: data used for prediction
-        :return: prediction target
-        """
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]

--- a/fedot/core/operations/evaluation/classification.py
+++ b/fedot/core/operations/evaluation/classification.py
@@ -148,7 +148,7 @@ class FedotClassificationPreprocessingStrategy(EvaluationStrategy):
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :return:
+        :return: prediction target
         """
         prediction = trained_operation.transform(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
@@ -160,7 +160,7 @@ class FedotClassificationPreprocessingStrategy(EvaluationStrategy):
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :return:
+        :return: prediction target
         """
         prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)

--- a/fedot/core/operations/evaluation/clustering.py
+++ b/fedot/core/operations/evaluation/clustering.py
@@ -47,17 +47,6 @@ class SkLearnClusteringStrategy(SkLearnEvaluationStrategy):
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for clustering task for fit stage
-        :param trained_operation: operation object
-        :param predict_data: data used for prediction
-        :return :
-        """
-        prediction = trained_operation.predict_for_fit(predict_data.features)
-        converted = self._convert_to_output(prediction, predict_data)
-        return converted
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]

--- a/fedot/core/operations/evaluation/clustering.py
+++ b/fedot/core/operations/evaluation/clustering.py
@@ -36,18 +36,25 @@ class SkLearnClusteringStrategy(SkLearnEvaluationStrategy):
         operation_implementation.fit(train_data.features)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for clustering task
+        Predict method for clustering task for predict stage
         :param trained_operation: operation object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return :
         """
         prediction = trained_operation.predict(predict_data.features)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
 
-        # Convert prediction to output (if it is required)
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for clustering task for fit stage
+        :param trained_operation: operation object
+        :param predict_data: data used for prediction
+        :return :
+        """
+        prediction = trained_operation.predict_for_fit(predict_data.features)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/clustering.py
+++ b/fedot/core/operations/evaluation/clustering.py
@@ -24,7 +24,6 @@ class SkLearnClusteringStrategy(SkLearnEvaluationStrategy):
         Fit method for clustering task
 
         :param train_data: data used for model training
-        :return:
         """
 
         warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -38,10 +37,9 @@ class SkLearnClusteringStrategy(SkLearnEvaluationStrategy):
 
     def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for clustering task for predict stage
+        Predict method for clustering task
         :param trained_operation: operation object
         :param predict_data: data used for prediction
-        :return :
         """
         prediction = trained_operation.predict(predict_data.features)
         converted = self._convert_to_output(prediction, predict_data)

--- a/fedot/core/operations/evaluation/common_preprocessing.py
+++ b/fedot/core/operations/evaluation/common_preprocessing.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Optional
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy
 from fedot.core.operations.evaluation.operation_implementations.data_operations.sklearn_transformations import \
     ImputationImplementation, KernelPCAImplementation, NormalizationImplementation, PCAImplementation, \
@@ -45,19 +45,27 @@ class FedotPreprocessingStrategy(EvaluationStrategy):
         operation_implementation.fit(train_data)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Transform method for preprocessing task
+        Transform method for preprocessing task for predict stage
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return:
         """
-        prediction = trained_operation.transform(predict_data,
-                                                 is_fit_pipeline_stage)
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Transform method for preprocessing task for fit stage
+
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/custom.py
+++ b/fedot/core/operations/evaluation/custom.py
@@ -24,10 +24,15 @@ class CustomModelStrategy(EvaluationStrategy):
         self.operation_impl.fit(train_data)
         return self.operation_impl
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
-        prediction = trained_operation.predict(predict_data, is_fit_pipeline_stage)
-        # Convert prediction to output
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
+
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/custom.py
+++ b/fedot/core/operations/evaluation/custom.py
@@ -26,13 +26,13 @@ class CustomModelStrategy(EvaluationStrategy):
 
     def predict(self, trained_operation, predict_data: InputData) -> OutputData:
 
-        prediction = trained_operation.transform(predict_data)
+        prediction = trained_operation.predict(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
     def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
 
-        prediction = trained_operation.transform_for_fit(predict_data)
+        prediction = trained_operation.predict_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/data_source.py
+++ b/fedot/core/operations/evaluation/data_source.py
@@ -19,8 +19,5 @@ class DataSourceStrategy(EvaluationStrategy):
         return OutputData(idx=predict_data.idx, features=predict_data.features, task=predict_data.task,
                           data_type=predict_data.data_type, target=predict_data.target, predict=predict_data.features)
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         return object()

--- a/fedot/core/operations/evaluation/data_source.py
+++ b/fedot/core/operations/evaluation/data_source.py
@@ -15,10 +15,12 @@ class DataSourceStrategy(EvaluationStrategy):
     def fit(self, train_data: InputData):
         return object()
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         return OutputData(idx=predict_data.idx, features=predict_data.features, task=predict_data.task,
                           data_type=predict_data.data_type, target=predict_data.target, predict=predict_data.features)
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         return object()

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -75,7 +75,6 @@ class EvaluationStrategy:
         """
         raise NotImplementedError()
 
-    @abstractmethod
     def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
         """
         Method to predict the target data for fit stage.
@@ -83,7 +82,7 @@ class EvaluationStrategy:
         :param InputData predict_data: data to predict
         :return OutputData: passed data with new predicted target
         """
-        raise NotImplementedError()
+        return self.predict(trained_operation, predict_data)
 
     @abstractmethod
     def _convert_to_operation(self, operation_type: str):
@@ -199,15 +198,6 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
         :return OutputData: passed data with new predicted target
         """
         raise NotImplementedError()
-
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        This method used for prediction of the target data during fit stage.
-        :param trained_operation: operation object
-        :param predict_data: data to predict
-        :return OutputData: passed data with new predicted target
-        """
-        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -66,13 +66,21 @@ class EvaluationStrategy:
         raise NotImplementedError()
 
     @abstractmethod
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Main method to predict the target data.
+        Method to predict the target data for predict stage.
         :param trained_operation: trained operation object
         :param InputData predict_data: data to predict
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+        :return OutputData: passed data with new predicted target
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Method to predict the target data for fit stage.
+        :param trained_operation: trained operation object
+        :param InputData predict_data: data to predict
         :return OutputData: passed data with new predicted target
         """
         raise NotImplementedError()
@@ -183,13 +191,20 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
             operation_implementation.fit(train_data.features, train_data.target)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        This method used for prediction of the target data.
+        This method used for prediction of the target data during predict stage.
         :param trained_operation: operation object
         :param predict_data: data to predict
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+        :return OutputData: passed data with new predicted target
+        """
+        raise NotImplementedError()
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        This method used for prediction of the target data during fit stage.
+        :param trained_operation: operation object
+        :param predict_data: data to predict
         :return OutputData: passed data with new predicted target
         """
         raise NotImplementedError()

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -207,7 +207,7 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
         :param predict_data: data to predict
         :return OutputData: passed data with new predicted target
         """
-        raise NotImplementedError()
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -78,6 +78,9 @@ class EvaluationStrategy:
     def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
         """
         Method to predict the target data for fit stage.
+        Allows to implement predict method different from main predict method
+        if another behaviour for fit graph stage is needed.
+
         :param trained_operation: trained operation object
         :param InputData predict_data: data to predict
         :return OutputData: passed data with new predicted target

--- a/fedot/core/operations/evaluation/gpu/classification.py
+++ b/fedot/core/operations/evaluation/gpu/classification.py
@@ -11,21 +11,32 @@ warnings.filterwarnings("ignore", category=UserWarning)
 class CuMLClassificationStrategy(CuMLEvaluationStrategy):
     """ Strategy for applying classification algorithms from Sklearn library """
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for classification task
-
+        Predict method for regression task for predict stage
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
-        :return: prediction target
+        :return:
         """
+
         features = cudf.DataFrame(predict_data.features.astype('float32'))
 
-        prediction = self._sklearn_compatible_prediction(trained_operation,
-                                                         features)
-
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.predict(features)
         converted = self._convert_to_output(prediction, predict_data)
+
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for regression task for fit stage
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+
+        features = cudf.DataFrame(predict_data.features.astype('float32'))
+
+        prediction = trained_operation.predict_for_fit(features)
+        converted = self._convert_to_output(prediction, predict_data)
+
         return converted

--- a/fedot/core/operations/evaluation/gpu/classification.py
+++ b/fedot/core/operations/evaluation/gpu/classification.py
@@ -21,7 +21,8 @@ class CuMLClassificationStrategy(CuMLEvaluationStrategy):
 
         features = cudf.DataFrame(predict_data.features.astype('float32'))
 
-        prediction = trained_operation.predict(features)
+        prediction = self._sklearn_compatible_prediction(trained_operation,
+                                                         features)
         converted = self._convert_to_output(prediction, predict_data)
 
         return converted

--- a/fedot/core/operations/evaluation/gpu/classification.py
+++ b/fedot/core/operations/evaluation/gpu/classification.py
@@ -2,7 +2,7 @@ import warnings
 
 import cudf
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.gpu.common import CuMLEvaluationStrategy
 
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -22,21 +22,6 @@ class CuMLClassificationStrategy(CuMLEvaluationStrategy):
         features = cudf.DataFrame(predict_data.features.astype('float32'))
 
         prediction = trained_operation.predict(features)
-        converted = self._convert_to_output(prediction, predict_data)
-
-        return converted
-
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for regression task for fit stage
-        :param trained_operation: model object
-        :param predict_data: data used for prediction
-        :return:
-        """
-
-        features = cudf.DataFrame(predict_data.features.astype('float32'))
-
-        prediction = trained_operation.predict_for_fit(features)
         converted = self._convert_to_output(prediction, predict_data)
 
         return converted

--- a/fedot/core/operations/evaluation/gpu/clustering.py
+++ b/fedot/core/operations/evaluation/gpu/clustering.py
@@ -52,21 +52,6 @@ class CumlClusteringStrategy(CuMLEvaluationStrategy):
 
         return converted
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for regression task for fit stage
-        :param trained_operation: model object
-        :param predict_data: data used for prediction
-        :return:
-        """
-
-        features = cudf.DataFrame(predict_data.features.astype('float32'))
-
-        prediction = trained_operation.predict_for_fit(features)
-        converted = self._convert_to_output(prediction, predict_data)
-
-        return converted
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]

--- a/fedot/core/operations/evaluation/gpu/clustering.py
+++ b/fedot/core/operations/evaluation/gpu/clustering.py
@@ -37,20 +37,34 @@ class CumlClusteringStrategy(CuMLEvaluationStrategy):
         operation_implementation.fit(features)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for clustering task
-        :param trained_operation: operation object
+        Predict method for regression task for predict stage
+        :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
-        :return :
+        :return:
         """
-        features = cudf.DataFrame(predict_data.features.astype('float32'))
-        prediction = trained_operation.predict(features)
 
-        # Convert prediction to output (if it is required)
+        features = cudf.DataFrame(predict_data.features.astype('float32'))
+
+        prediction = trained_operation.predict(features)
         converted = self._convert_to_output(prediction, predict_data)
+
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for regression task for fit stage
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+
+        features = cudf.DataFrame(predict_data.features.astype('float32'))
+
+        prediction = trained_operation.predict_for_fit(features)
+        converted = self._convert_to_output(prediction, predict_data)
+
         return converted
 
     def _convert_to_operation(self, operation_type: str):

--- a/fedot/core/operations/evaluation/gpu/common.py
+++ b/fedot/core/operations/evaluation/gpu/common.py
@@ -96,7 +96,7 @@ class CuMLEvaluationStrategy(SkLearnEvaluationStrategy):
         :param predict_data: data to predict
         :return OutputData: passed data with new predicted target
         """
-        raise NotImplementedError()
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():

--- a/fedot/core/operations/evaluation/gpu/common.py
+++ b/fedot/core/operations/evaluation/gpu/common.py
@@ -80,13 +80,20 @@ class CuMLEvaluationStrategy(SkLearnEvaluationStrategy):
             operation_implementation.fit(features, target)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        This method used for prediction of the target data.
+        This method used for prediction of the target data during predict stage.
         :param trained_operation: operation object
         :param predict_data: data to predict
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+        :return OutputData: passed data with new predicted target
+        """
+        raise NotImplementedError()
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        This method used for prediction of the target data during fit stage.
+        :param trained_operation: operation object
+        :param predict_data: data to predict
         :return OutputData: passed data with new predicted target
         """
         raise NotImplementedError()

--- a/fedot/core/operations/evaluation/gpu/common.py
+++ b/fedot/core/operations/evaluation/gpu/common.py
@@ -89,15 +89,6 @@ class CuMLEvaluationStrategy(SkLearnEvaluationStrategy):
         """
         raise NotImplementedError()
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        This method used for prediction of the target data during fit stage.
-        :param trained_operation: operation object
-        :param predict_data: data to predict
-        :return OutputData: passed data with new predicted target
-        """
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]

--- a/fedot/core/operations/evaluation/gpu/regression.py
+++ b/fedot/core/operations/evaluation/gpu/regression.py
@@ -1,24 +1,36 @@
 import cudf
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.gpu.common import CuMLEvaluationStrategy
 
 
 class CuMLRegressionStrategy(CuMLEvaluationStrategy):
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for regression task
+        Predict method for regression task for predict stage
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return:
         """
 
         features = cudf.DataFrame(predict_data.features.astype('float32'))
 
         prediction = trained_operation.predict(features)
-        # Convert prediction to output (if it is required)
+        converted = self._convert_to_output(prediction, predict_data)
+
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for regression task for fit stage
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+
+        features = cudf.DataFrame(predict_data.features.astype('float32'))
+
+        prediction = trained_operation.predict_for_fit(features)
         converted = self._convert_to_output(prediction, predict_data)
 
         return converted

--- a/fedot/core/operations/evaluation/gpu/regression.py
+++ b/fedot/core/operations/evaluation/gpu/regression.py
@@ -19,18 +19,3 @@ class CuMLRegressionStrategy(CuMLEvaluationStrategy):
         converted = self._convert_to_output(prediction, predict_data)
 
         return converted
-
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for regression task for fit stage
-        :param trained_operation: model object
-        :param predict_data: data used for prediction
-        :return:
-        """
-
-        features = cudf.DataFrame(predict_data.features.astype('float32'))
-
-        prediction = trained_operation.predict_for_fit(features)
-        converted = self._convert_to_output(prediction, predict_data)
-
-        return converted

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/categorical_encoders.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/categorical_encoders.py
@@ -72,16 +72,6 @@ class OneHotEncodingImplementation(DataOperationImplementation):
         self._update_column_types(output_data)
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """
-        The method that transforms the categorical features in the original
-        dataset, but does not affect the rest features. Applicable during fit stage
-
-        :param input_data: data with features, target and ids for transformation
-        :return output_data: output data with transformed features table
-        """
-        return self.transform(input_data)
-
     def _update_column_types(self, output_data: OutputData):
         """ Update column types after encoding. Categorical columns becomes integer with extension """
         if self.categorical_ids:
@@ -164,12 +154,6 @@ class LabelEncodingImplementation(DataOperationImplementation):
 
         self._update_column_types(output_data)
         return output_data
-
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Apply LabelEncoder on categorical features and doesn't process float or int ones.
-        Applicable during fit stage
-        """
-        return self.transform(input_data)
 
     def _update_column_types(self, output_data: OutputData):
         """ Update column types after encoding. Categorical becomes integer """

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/categorical_encoders.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/categorical_encoders.py
@@ -48,13 +48,12 @@ class OneHotEncodingImplementation(DataOperationImplementation):
 
         return self.encoder
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def transform(self, input_data: InputData) -> OutputData:
         """
         The method that transforms the categorical features in the original
-        dataset, but does not affect the rest features
+        dataset, but does not affect the rest features. Applicable during predict stage
 
         :param input_data: data with features, target and ids for transformation
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with transformed features table
         """
         copied_data = deepcopy(input_data)
@@ -73,6 +72,16 @@ class OneHotEncodingImplementation(DataOperationImplementation):
         self._update_column_types(output_data)
         return output_data
 
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """
+        The method that transforms the categorical features in the original
+        dataset, but does not affect the rest features. Applicable during fit stage
+
+        :param input_data: data with features, target and ids for transformation
+        :return output_data: output data with transformed features table
+        """
+        return self.transform(input_data)
+
     def _update_column_types(self, output_data: OutputData):
         """ Update column types after encoding. Categorical columns becomes integer with extension """
         if self.categorical_ids:
@@ -86,7 +95,7 @@ class OneHotEncodingImplementation(DataOperationImplementation):
 
             output_data.supplementary_data.column_types['features'] = numerical_columns
 
-    def _apply_one_hot_encoding(self, features: np.array):
+    def _apply_one_hot_encoding(self, features: np.array) -> np.array:
         """
         The method creates a table based on categorical and real features after One Hot Encoding transformation
 
@@ -108,7 +117,7 @@ class OneHotEncodingImplementation(DataOperationImplementation):
 
         return transformed_features
 
-    def get_params(self):
+    def get_params(self) -> dict:
         return self.encoder.get_params()
 
 
@@ -133,8 +142,10 @@ class LabelEncodingImplementation(DataOperationImplementation):
             self._fit_label_encoders(input_data)
         return self.encoders
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
-        """ Apply LabelEncoder on categorical features and doesn't process float or int ones """
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Apply LabelEncoder on categorical features and doesn't process float or int ones
+        Applicable during predict stage
+        """
         copied_data = deepcopy(input_data)
         if self.categorical_ids:
             # If categorical features are exists - transform them inplace in InputData
@@ -148,14 +159,17 @@ class LabelEncodingImplementation(DataOperationImplementation):
                 transformed = self._apply_label_encoder(categorical_column, categorical_id, gap_ids)
                 copied_data.features[:, categorical_id] = transformed
 
-        # Update features
-        output_data = self._convert_to_output(copied_data,
+        output_data = self._convert_to_output(input_data,
                                               copied_data.features)
-        # Store source features values
-        output_data.features = input_data.features
 
         self._update_column_types(output_data)
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Apply LabelEncoder on categorical features and doesn't process float or int ones.
+        Applicable during fit stage
+        """
+        return self.transform(input_data)
 
     def _update_column_types(self, output_data: OutputData):
         """ Update column types after encoding. Categorical becomes integer """
@@ -177,7 +191,7 @@ class LabelEncodingImplementation(DataOperationImplementation):
             self.encoders.update({categorical_id: le})
 
     def _apply_label_encoder(self, categorical_column: np.array, categorical_id: int,
-                             gap_ids: Union[np.array, None]):
+                             gap_ids: Union[np.array, None]) -> np.array:
         """ Apply fitted LabelEncoder for column transformation
 
         :param categorical_column: numpy array with categorical features
@@ -203,6 +217,6 @@ class LabelEncodingImplementation(DataOperationImplementation):
 
         return transformed_column
 
-    def get_params(self):
+    def get_params(self) -> dict:
         """ Due to LabelEncoder has no parameters - return empty set """
         return {}

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/decompose.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/decompose.py
@@ -3,6 +3,7 @@ from typing import Optional
 import numpy as np
 from sklearn.preprocessing import OneHotEncoder
 
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.operation_implementations. \
     implementation_interfaces import DataOperationImplementation
 from fedot.core.repository.tasks import Task, TaskTypesEnum
@@ -18,23 +19,32 @@ class DecomposerImplementation(DataOperationImplementation):
         super().__init__()
         self.params = None
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """
         The decompose operation doesn't support fit method
         """
         pass
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def transform(self, input_data: InputData) -> OutputData:
         """
-        Method for modifying input_data
+        Method for modifying input_data for predict stage
         :param input_data: data with features, target and ids
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+
         :return input_data: data with transformed features attribute
         """
         raise NotImplementedError()
 
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """
+        Method for modifying input_data for fit stage
+        :param input_data: data with features, target and ids
+
+        :return input_data: data with transformed features attribute
+        """
+        return self.transform(input_data)
+
     @staticmethod
-    def divide_inputs(input_data):
+    def divide_inputs(input_data: InputData) -> (np.array, np.array):
         """ Method for dividing InputData into parts:
         first came from Model parent and second came from Data parent
 
@@ -78,7 +88,7 @@ class DecomposerImplementation(DataOperationImplementation):
 
         return prev_prediction, prev_features
 
-    def get_params(self):
+    def get_params(self) -> dict:
         return {}
 
 
@@ -89,37 +99,41 @@ class DecomposerRegImplementation(DecomposerImplementation):
         super().__init__()
         self.params = None
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def transform(self, input_data: InputData) -> OutputData:
         """
-        Method for modifying input_data
+        Method for modifying input_data for predict stage
         :param input_data: data with features, target and ids
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+
         :return input_data: data with transformed features attribute
         """
+        prev_prediction, prev_features = self.divide_inputs(input_data)
+        output_data = self._get_output_data(input_data, prev_features)
+        return output_data
 
-        # Get inputs from Data and Model parent
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """
+        Method for modifying input_data for fit stage
+        :param input_data: data with features, target and ids
+
+        :return input_data: data with transformed features attribute
+        """
         prev_prediction, prev_features = self.divide_inputs(input_data)
 
-        if is_fit_pipeline_stage:
-            # Target must be a column or table, not one-dimensional array
-            target = np.array(input_data.target)
-            if len(target.shape) < 2:
-                target = target.reshape((-1, 1))
+        # Target must be a column or table, not one-dimensional array
+        target = np.array(input_data.target)
+        if len(target.shape) < 2:
+            target = target.reshape((-1, 1))
 
-            # Calculate difference between prediction of model and current target
-            diff = target - prev_prediction
+        diff = target - prev_prediction
+        input_data.target = diff
 
-            # Update target
-            input_data.target = diff
-            # Create OutputData
-            output_data = self._convert_to_output(input_data, prev_features)
-            # We decompose the target, so in the future we need to ignore
-            output_data.supplementary_data.is_main_target = False
-        else:
-            # For predict stage there is no need to worry about target
-            output_data = self._convert_to_output(input_data, prev_features)
-            output_data.supplementary_data.is_main_target = False
+        output_data = self._get_output_data(input_data, prev_features)
+        return output_data
 
+    def _get_output_data(self, input_data: InputData, prev_features: np.array) -> OutputData:
+        output_data = self._convert_to_output(input_data, prev_features)
+        # We decompose the target, so in the future we need to ignore
+        output_data.supplementary_data.is_main_target = False
         return output_data
 
 
@@ -132,50 +146,54 @@ class DecomposerClassImplementation(DecomposerImplementation):
         super().__init__()
         self.params = None
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def transform(self, input_data: InputData) -> OutputData:
         """
-        Method for modifying input_data
+        Method for modifying input_data for predict stage
         :param input_data: data with features, target and ids
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return input_data: data with transformed features attribute
         """
-
-        # Task since that model - regression
-        regression_task = Task(TaskTypesEnum.regression)
-
-        # Get inputs from Data and Model parent
         prev_prediction, prev_features = self.divide_inputs(input_data)
-
-        if is_fit_pipeline_stage:
-            # Target must be a column or table, not one-dimensional array
-            target = np.array(input_data.target)
-            if len(target.shape) < 2:
-                target = target.reshape((-1, 1))
-
-            classes = np.unique(target)
-            if len(classes) > 2:
-                diff = self._multi_difference(target, prev_prediction)
-            else:
-                # Binary classification task
-                diff = self._binary_difference(classes, target, prev_prediction)
-
-            # Update target
-            input_data.target = diff
-            # Create OutputData
-            output_data = self._convert_to_output(input_data, prev_features)
-            # We decompose the target, so in the future we need to ignore
-            output_data.supplementary_data.is_main_target = False
-            output_data.task = regression_task
-        else:
-            # For predict stage there is no need to worry about target
-            output_data = self._convert_to_output(input_data, prev_features)
-            output_data.supplementary_data.is_main_target = False
-            output_data.task = regression_task
-
+        output_data = self._get_output_data(input_data, prev_features)
         return output_data
 
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """
+        Method for modifying input_data for fit stage
+        :param input_data: data with features, target and ids
+        :return input_data: data with transformed features attribute
+        """
+        prev_prediction, prev_features = self.divide_inputs(input_data)
+
+        target = np.array(input_data.target)
+        if len(target.shape) < 2:
+            target = target.reshape((-1, 1))
+
+        input_data.target = self._get_difference(target, prev_prediction)
+        output_data = self._get_output_data(input_data, prev_features)
+        return output_data
+
+    def _get_output_data(self, input_data: InputData, prev_features: np.array) -> OutputData:
+        regression_task = Task(TaskTypesEnum.regression)
+        output_data = self._convert_to_output(input_data, prev_features)
+        output_data.supplementary_data.is_main_target = False
+        output_data.task = regression_task
+        return output_data
+
+    def _get_difference(self, target: np.array, prev_prediction: np.array) -> np.array:
+        """ Calculates difference between predictions (probabilities) and target
+        :param target: class labels
+        :param prev_prediction: predictions from previous classification model
+        :return diff: difference between probabilities of classes
+        """
+        classes = np.unique(target)
+        if len(classes) > 2:
+            diff = self._multi_difference(target, prev_prediction)
+        else:
+            diff = self._binary_difference(classes, target, prev_prediction)
+        return diff
+
     @staticmethod
-    def _binary_difference(classes, target, prev_prediction):
+    def _binary_difference(classes: np.array, target: np.array, prev_prediction: np.array) -> np.array:
         """ Calculates difference between predictions (probabilities) and target
         for binary classification task
         :param classes: which classes are in the target
@@ -199,7 +217,7 @@ class DecomposerClassImplementation(DecomposerImplementation):
         return diff
 
     @staticmethod
-    def _multi_difference(target, prev_prediction):
+    def _multi_difference(target: np.array, prev_prediction: np.array) -> np.array:
         """ Calculates difference between predictions (probabilities) and target
         for multiclass classification task
 

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/decompose.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/decompose.py
@@ -34,15 +34,6 @@ class DecomposerImplementation(DataOperationImplementation):
         """
         raise NotImplementedError()
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """
-        Method for modifying input_data for fit stage
-        :param input_data: data with features, target and ids
-
-        :return input_data: data with transformed features attribute
-        """
-        return self.transform(input_data)
-
     @staticmethod
     def divide_inputs(input_data: InputData) -> (np.array, np.array):
         """ Method for dividing InputData into parts:

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
@@ -39,24 +39,28 @@ class FilterImplementation(DataOperationImplementation):
 
         return self.operation
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
-        """ Method for making prediction
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: filtered input data by rows
         """
+        output_data = self._convert_to_output(input_data,
+                                              input_data.features)
+        return output_data
 
-        if is_fit_pipeline_stage:
-            # For fit stage - filter data
-            mask = self.operation.inlier_mask_
-            if mask is not None:
-                # Update data
-                input_data = update_data(input_data, mask)
-            else:
-                self.log.info("Filtering Algorithm: didn't fit correctly. Return all objects")
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for fit stage
 
-        # Convert it to OutputData
+        :param input_data: data with features, target and ids to process
+        :return output_data: filtered input data by rows
+        """
+        # For fit stage - filter data
+        mask = self.operation.inlier_mask_
+        if mask is not None:
+            input_data = update_data(input_data, mask)
+        else:
+            self.log.info("Filtering Algorithm: didn't fit correctly. Return all objects")
         output_data = self._convert_to_output(input_data,
                                               input_data.features)
         return output_data
@@ -184,21 +188,26 @@ class IsolationForestRegImplementation(DataOperationImplementation):
         mask = predictions == 1
         return mask
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
-        """ Method for making prediction
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: filtered input data by rows
         """
+        output_data = self._convert_to_output(input_data,
+                                              input_data.features)
+        return output_data
 
-        if is_fit_pipeline_stage:
-            # For fit stage - filter data
-            mask = self._get_inlier_mask(input_data)
-            # Update data
-            input_data = update_data(input_data, mask)
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for fit stage
 
-        # Convert it to OutputData
+        :param input_data: data with features, target and ids to process
+        :return output_data: filtered input data by rows
+        """
+        # For fit stage - filter data
+        mask = self._get_inlier_mask(input_data)
+        input_data = update_data(input_data, mask)
+
         output_data = self._convert_to_output(input_data,
                                               input_data.features)
         return output_data
@@ -232,23 +241,18 @@ class IsolationForestClassImplementation(IsolationForestRegImplementation):
                 return False
         return True
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: bool) -> OutputData:
-        """ Method for making prediction
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for fit stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: filtered input data by rows
         """
+        # For fit stage - filter data
+        mask = self._get_inlier_mask(input_data)
+        modified_input_data = update_data(input_data, mask)
+        if self._is_inlier_mask_correct(input_data.target, modified_input_data.target):
+            input_data = modified_input_data
 
-        if is_fit_pipeline_stage:
-            # For fit stage - filter data
-            mask = self._get_inlier_mask(input_data)
-            # Update data
-            modified_input_data = update_data(input_data, mask)
-            if self._is_inlier_mask_correct(input_data.target, modified_input_data.target):
-                input_data = modified_input_data
-
-        # Convert it to OutputData
         output_data = self._convert_to_output(input_data,
                                               input_data.features)
         return output_data

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_imbalanced_class.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_imbalanced_class.py
@@ -175,13 +175,3 @@ class ResampleImplementation(DataOperationImplementation):
 
     def _resample_data(self, data: np.array):
         return resample(data, replace=self.replace, n_samples=self.n_samples)
-
-    def _return_source_data(self, input_data: Optional[InputData]) -> Optional[OutputData]:
-        return OutputData(
-            idx=input_data.idx,
-            features=input_data.features,
-            predict=input_data.features,
-            task=input_data.task,
-            target=input_data.target,
-            data_type=input_data.data_type,
-            supplementary_data=input_data.supplementary_data)

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_selectors.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_selectors.py
@@ -5,7 +5,7 @@ from sklearn.feature_selection import RFE
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
-from fedot.core.data.data import OutputData
+from fedot.core.data.data import OutputData, InputData
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import \
     DataOperationImplementation
 
@@ -25,7 +25,7 @@ class FeatureSelectionImplementation(DataOperationImplementation):
         # Bool mask where True - remain column and False - drop it
         self.remain_features_mask = None
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Method for fit feature selection
 
         :param input_data: data with features, target and ids to process
@@ -53,11 +53,10 @@ class FeatureSelectionImplementation(DataOperationImplementation):
             self.is_not_fitted = True
         return self.operation
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
-        """ Method for making prediction
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for prediction stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: filtered input data by columns
         """
         if self.is_not_fitted:
@@ -72,6 +71,14 @@ class FeatureSelectionImplementation(DataOperationImplementation):
                                               transformed_features)
         self._update_column_types(source_features_shape, output_data)
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for making prediction for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: filtered input data by columns
+        """
+        return self.transform(input_data)
 
     def get_params(self):
         return self.operation.get_params()

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_selectors.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_selectors.py
@@ -72,14 +72,6 @@ class FeatureSelectionImplementation(DataOperationImplementation):
         self._update_column_types(source_features_shape, output_data)
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method for making prediction for fit stage
-
-        :param input_data: data with features, target and ids to process
-        :return output_data: filtered input data by columns
-        """
-        return self.transform(input_data)
-
     def get_params(self):
         return self.operation.get_params()
 

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
@@ -62,15 +62,6 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
         self.update_column_types(output_data)
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """
-        Method for transformation tabular data using PCA for fit stage
-
-        :param input_data: data with features, target and ids for PCA applying
-        :return output_data: data with transformed features attribute
-        """
-        return self.transform(input_data)
-
     def check_and_correct_params(self):
         """ Method check if number of features in data enough for n_components
         parameter in PCA or not. And if not enough - fixes it
@@ -358,14 +349,6 @@ class ImputationImplementation(DataOperationImplementation):
 
         output_data = self._convert_to_output(input_data, transformed_features, data_type=input_data.data_type)
         return output_data
-
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """
-        Method for transformation tabular data using SimpleImputer for fit stage
-
-        :param input_data: data with features
-        """
-        return self.transform(input_data)
 
     def fit_transform(self, input_data: InputData) -> OutputData:
         """

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
@@ -1,5 +1,5 @@
 import random
-from typing import Optional
+from typing import Optional, Union, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -29,7 +29,7 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
 
         self.parameters_changed = False
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """
         The method trains the PCA model
 
@@ -44,13 +44,11 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
 
         return self.pca
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def transform(self, input_data: InputData) -> OutputData:
         """
-        Method for transformation tabular data using PCA
+        Method for transformation tabular data using PCA for predict stage
 
         :param input_data: data with features, target and ids for PCA applying
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
-        :return input_data: data with transformed features attribute
         """
 
         if self.number_of_features > 1:
@@ -63,6 +61,15 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
                                               transformed_features)
         self.update_column_types(output_data)
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """
+        Method for transformation tabular data using PCA for fit stage
+
+        :param input_data: data with features, target and ids for PCA applying
+        :return output_data: data with transformed features attribute
+        """
+        return self.transform(input_data)
 
     def check_and_correct_params(self):
         """ Method check if number of features in data enough for n_components
@@ -91,7 +98,7 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
             return self.pca.get_params()
 
     @staticmethod
-    def update_column_types(output_data: OutputData):
+    def update_column_types(output_data: OutputData) -> OutputData:
         """ Update column types after applying PCA operations """
         n_rows, n_cols = output_data.predict.shape
         output_data.supplementary_data.column_types['features'] = [str(float) * n_cols]
@@ -169,7 +176,7 @@ class PolyFeaturesImplementation(EncodedInvariantImplementation):
         self.params = params
         self.columns_to_take = None
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Method for fit Poly features operation """
         # Check the number of columns in source dataset
         n_rows, n_cols = input_data.features.shape
@@ -181,12 +188,13 @@ class PolyFeaturesImplementation(EncodedInvariantImplementation):
 
         return super().fit(input_data)
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
-        """ Firstly perform filtration of columns """
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Firstly perform filtration of columns
+        """
         clipped_input_data = input_data
         if self.columns_to_take is not None:
             clipped_input_data = input_data.subset_features(self.columns_to_take)
-        output_data = super().transform(clipped_input_data, is_fit_pipeline_stage)
+        output_data = super().transform(clipped_input_data)
 
         if self.columns_to_take is not None:
             # Get generated features from poly function
@@ -196,7 +204,7 @@ class PolyFeaturesImplementation(EncodedInvariantImplementation):
             output_data.predict = all_features
         return output_data
 
-    def get_params(self):
+    def get_params(self) -> dict:
         return self.operation.get_params()
 
     def _update_column_types(self, source_features_shape, output_data: OutputData):
@@ -229,7 +237,7 @@ class ScalingImplementation(EncodedInvariantImplementation):
             self.operation = StandardScaler(**params)
         self.params = params
 
-    def get_params(self):
+    def get_params(self) -> dict:
         return self.operation.get_params()
 
 
@@ -250,7 +258,7 @@ class NormalizationImplementation(EncodedInvariantImplementation):
             self.operation = MinMaxScaler(**params)
         self.params = params
 
-    def get_params(self):
+    def get_params(self) -> dict:
         return self.operation.get_params()
 
 
@@ -306,13 +314,11 @@ class ImputationImplementation(DataOperationImplementation):
             input_data.features = convert_into_column(input_data.features)
             self.imputer_num.fit(input_data.features)
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool] = None):
+    def transform(self, input_data: InputData) -> OutputData:
         """
-        Method for transformation tabular data using SimpleImputer
+        Method for transformation tabular data using SimpleImputer for predict stage
 
         :param input_data: data with features
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
-        :return input_data: data with transformed features attribute
         """
         replace_inf_with_nans(input_data)
 
@@ -353,19 +359,26 @@ class ImputationImplementation(DataOperationImplementation):
         output_data = self._convert_to_output(input_data, transformed_features, data_type=input_data.data_type)
         return output_data
 
-    def fit_transform(self, input_data, is_fit_pipeline_stage: Optional[bool] = None):
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """
+        Method for transformation tabular data using SimpleImputer for fit stage
+
+        :param input_data: data with features
+        """
+        return self.transform(input_data)
+
+    def fit_transform(self, input_data: InputData) -> OutputData:
         """
         Method for training and transformation tabular data using SimpleImputer
 
         :param input_data: data with features
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return input_data: data with transformed features attribute
         """
         self.fit(input_data)
-        output_data = self.transform(input_data)
+        output_data = self.transform_for_fit(input_data)
         return output_data
 
-    def _categorical_numerical_union(self, categorical_features: np.array, numerical_features: np.array):
+    def _categorical_numerical_union(self, categorical_features: np.array, numerical_features: np.array) -> np.array:
         """ Merge numerical and categorical features in right order (as it was in source table) """
         categorical_df = pd.DataFrame(categorical_features, columns=self.categorical_ids)
         numerical_df = pd.DataFrame(numerical_features, columns=self.non_categorical_ids)

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from fedot.core.data.data import InputData, OutputData
 from fedot.utilities.requirements_notificator import warn_requirement
 
 try:
@@ -31,18 +32,17 @@ class TextCleanImplementation(DataOperationImplementation):
         self._download_nltk_resources()
         super().__init__()
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Class doesn't support fit operation
 
         :param input_data: data with features, target and ids to process
         """
         pass
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
-        """ Method for transformation of the text data
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for transformation of the text data for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with transformed features table
         """
 
@@ -62,6 +62,14 @@ class TextCleanImplementation(DataOperationImplementation):
                                               clean_data,
                                               data_type=DataTypesEnum.text)
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for transformation of the text data for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: output data with transformed features table
+        """
+        return self.transform(input_data)
 
     @staticmethod
     def _download_nltk_resources():

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
@@ -63,14 +63,6 @@ class TextCleanImplementation(DataOperationImplementation):
                                               data_type=DataTypesEnum.text)
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method for transformation of the text data for fit stage
-
-        :param input_data: data with features, target and ids to process
-        :return output_data: output data with transformed features table
-        """
-        return self.transform(input_data)
-
     @staticmethod
     def _download_nltk_resources():
         for resource in ['punkt']:

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_pretrained.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_pretrained.py
@@ -52,14 +52,6 @@ class PretrainedEmbeddingsImplementation(DataOperationImplementation):
                                               data_type=DataTypesEnum.table)
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method for transformation of the text data for fit stage
-
-        :param input_data: data with features, target and ids to process
-        :return output_data: output data with transformed features table
-        """
-        return self.transform(input_data)
-
     @staticmethod
     def vectorize_avg(text: str, embeddings):
         """ Method converts text to an average of token vectors

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_pretrained.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_pretrained.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.log import default_log
 from fedot.core.operations.evaluation.operation_implementations. \
     implementation_interfaces import DataOperationImplementation
@@ -31,18 +32,17 @@ class PretrainedEmbeddingsImplementation(DataOperationImplementation):
         self._download_model_resources()
         super().__init__()
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Class doesn't support fit operation
 
         :param input_data: data with features, target and ids to process
         """
         pass
 
-    def transform(self, input_data, is_fit_pipeline_stage: Optional[bool]):
-        """ Method for transformation of the text data
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for transformation of the text data for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with transformed features table
         """
 
@@ -51,6 +51,14 @@ class PretrainedEmbeddingsImplementation(DataOperationImplementation):
                                               embed_data,
                                               data_type=DataTypesEnum.table)
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for transformation of the text data for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: output data with transformed features table
+        """
+        return self.transform(input_data)
 
     @staticmethod
     def vectorize_avg(text: str, embeddings):

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -696,7 +696,7 @@ class CutImplementation(DataOperationImplementation):
 
         if reset_idx:
             input_copy.idx = np.arange(cut_len, input_values.shape[0])
-        return input_data
+        return input_copy
 
     def get_params(self):
         params_dict = {"cut_part": self.cut_part}

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -36,17 +36,18 @@ class LaggedImplementation(DataOperationImplementation):
         """
         pass
 
-    def transform(self, input_data, is_fit_pipeline_stage: bool):
-        """ Method for transformation of time series to lagged form
+    def get_params(self):
+        raise NotImplementedError()
+
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for transformation of time series to lagged form for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with transformed features table
         """
 
         new_input_data = copy(input_data)
         forecast_length = new_input_data.task.task_params.forecast_length
-        old_idx = new_input_data.idx
 
         # Correct window size parameter
         self.window_size, self.parameters_changed = _check_and_correct_window_size(new_input_data.features,
@@ -54,21 +55,41 @@ class LaggedImplementation(DataOperationImplementation):
                                                                                    forecast_length,
                                                                                    self.window_size_minimum,
                                                                                    self.log)
-        if is_fit_pipeline_stage:
-            # Transformation for fit stage of the pipeline
-            target = np.array(new_input_data.target)
-            features = np.array(new_input_data.features)
 
-            new_target, new_idx = self._apply_transformation_for_fit(new_input_data, features,
-                                                                     target, forecast_length, old_idx)
+        self._apply_transformation_for_predict(new_input_data)
 
-            # Update target for Input Data
-            new_input_data.target = new_target
-            new_input_data.idx = new_idx
-        else:
-            # Transformation for predict stage of the pipeline
-            self._apply_transformation_for_predict(new_input_data, forecast_length)
+        output_data = self._convert_to_output(new_input_data,
+                                              self.features_columns,
+                                              data_type=DataTypesEnum.table)
+        self._update_column_types(output_data)
+        return output_data
 
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for transformation of time series to lagged form for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: output data with transformed features table
+        """
+        new_input_data = copy(input_data)
+        forecast_length = new_input_data.task.task_params.forecast_length
+
+        # Correct window size parameter
+        self.window_size, self.parameters_changed = _check_and_correct_window_size(new_input_data.features,
+                                                                                   self.window_size,
+                                                                                   forecast_length,
+                                                                                   self.window_size_minimum,
+                                                                                   self.log)
+
+        target = np.array(new_input_data.target)
+        features = np.array(new_input_data.features)
+        old_idx = new_input_data.idx
+
+        new_target, new_idx = self._apply_transformation_for_fit(new_input_data, features,
+                                                                 target, forecast_length, old_idx)
+
+        # Update target for Input Data
+        new_input_data.target = new_target
+        new_input_data.idx = new_idx
         output_data = self._convert_to_output(new_input_data,
                                               self.features_columns,
                                               data_type=DataTypesEnum.table)
@@ -198,7 +219,7 @@ class LaggedImplementation(DataOperationImplementation):
             # if multivariable case
             return target
 
-    def _apply_transformation_for_predict(self, input_data: InputData, forecast_length: int):
+    def _apply_transformation_for_predict(self, input_data: InputData):
         """ Apply lagged transformation for every column (time series) in the dataset """
         if self.sparse_transform:
             self.log.debug(f'Sparse lagged transformation applied. If new data were used. Call fit method')
@@ -308,18 +329,17 @@ class TsSmoothingImplementation(DataOperationImplementation):
         else:
             self.window_size = round(params.get('window_size'))
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Class doesn't support fit operation
 
         :param input_data: data with features, target and ids to process
         """
         pass
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: bool):
-        """ Method for smoothing time series
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for smoothing time series for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with smoothed time series
         """
 
@@ -342,6 +362,14 @@ class TsSmoothingImplementation(DataOperationImplementation):
 
         return output_data
 
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for smoothing time series for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: output data with smoothed time series
+        """
+        return self.transform(input_data)
+
     def _apply_smoothing_to_series(self, ts):
         smoothed_ts = ts.rolling(window=self.window_size).mean()
         smoothed_ts = np.array(smoothed_ts)
@@ -359,18 +387,37 @@ class ExogDataTransformationImplementation(DataOperationImplementation):
     def __init__(self, **params):
         super().__init__()
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Class doesn't support fit operation
 
         :param input_data: data with features, target and ids to process
         """
         pass
 
-    def transform(self, input_data, is_fit_pipeline_stage: bool):
-        """ Method for representing time series as column
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for representing time series as column for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+        :return output_data: output data with features as columns
+        """
+        copied_data = copy(input_data)
+        parameters = copied_data.task.task_params
+        forecast_length = parameters.forecast_length
+
+        features_columns = np.array(copied_data.features)[-forecast_length:]
+        copied_data.idx = copied_data.idx[-forecast_length:]
+        features_columns = features_columns.reshape(1, -1)
+
+        output_data = self._convert_to_output(copied_data,
+                                              features_columns,
+                                              data_type=DataTypesEnum.table)
+
+        return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for representing time series as column for fit stage
+
+        :param input_data: data with features, target and ids to process
         :return output_data: output data with features as columns
         """
         copied_data = copy(input_data)
@@ -378,28 +425,21 @@ class ExogDataTransformationImplementation(DataOperationImplementation):
         old_idx = copied_data.idx
         forecast_length = parameters.forecast_length
 
-        if is_fit_pipeline_stage is True:
-            # Transform features in "target-like way"
-            _, _, features_columns = prepare_target(all_idx=input_data.idx,
-                                                    idx=old_idx,
-                                                    features_columns=copied_data.features,
-                                                    target=copied_data.features,
-                                                    forecast_length=forecast_length)
+        # Transform features in "target-like way"
+        _, _, features_columns = prepare_target(all_idx=input_data.idx,
+                                                idx=old_idx,
+                                                features_columns=copied_data.features,
+                                                target=copied_data.features,
+                                                forecast_length=forecast_length)
 
-            # Transform target
-            new_idx, _, new_target = prepare_target(all_idx=input_data.idx,
-                                                    idx=old_idx,
-                                                    features_columns=copied_data.features,
-                                                    target=copied_data.target,
-                                                    forecast_length=forecast_length)
-            # Update target for Input Data
-            copied_data.target = new_target
-            copied_data.idx = new_idx
-        else:
-            # Transformation for predict stage of the pipeline
-            features_columns = np.array(copied_data.features)[-forecast_length:]
-            copied_data.idx = copied_data.idx[-forecast_length:]
-            features_columns = features_columns.reshape(1, -1)
+        # Transform target
+        new_idx, _, new_target = prepare_target(all_idx=input_data.idx,
+                                                idx=old_idx,
+                                                features_columns=copied_data.features,
+                                                target=copied_data.target,
+                                                forecast_length=forecast_length)
+        copied_data.target = new_target
+        copied_data.idx = new_idx
 
         output_data = self._convert_to_output(copied_data,
                                               features_columns,
@@ -421,18 +461,17 @@ class GaussianFilterImplementation(DataOperationImplementation):
         else:
             self.sigma = round(params.get('sigma'))
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Class doesn't support fit operation
 
         :param input_data: data with features, target and ids to process
         """
         pass
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: bool):
-        """ Method for smoothing time series
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for smoothing time series for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with smoothed time series
         """
 
@@ -449,6 +488,14 @@ class GaussianFilterImplementation(DataOperationImplementation):
                                               data_type=input_data.data_type)
 
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for smoothing time series for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: output data with smoothed time series
+        """
+        return self.transform(input_data)
 
     def get_params(self):
         return {'sigma': self.sigma}
@@ -472,18 +519,17 @@ class NumericalDerivativeFilterImplementation(DataOperationImplementation):
         self.window_size = int(self.params['window_size'])
         self._correct_params()
 
-    def fit(self, input_data):
+    def fit(self, input_data: InputData):
         """ Class doesn't support fit operation
 
         :param input_data: data with features, target and ids to process
         """
         pass
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: bool):
-        """ Method for finding numerical derivative of time series
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Method for finding numerical derivative of time series for predict stage
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with smoothed time series
         """
 
@@ -505,6 +551,14 @@ class NumericalDerivativeFilterImplementation(DataOperationImplementation):
                                                   data_type=input_data.data_type)
 
         return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method for finding numerical derivative of time series for fit stage
+
+        :param input_data: data with features, target and ids to process
+        :return output_data: output data with smoothed time series
+        """
+        return self.transform(input_data)
 
     def _differential_filter(self, ts):
         """ NumericalDerivative filter """
@@ -601,27 +655,48 @@ class CutImplementation(DataOperationImplementation):
         """
         pass
 
-    def transform(self, input_data: InputData, is_fit_pipeline_stage: Optional[bool]) -> OutputData:
-        """ Cut first cut_part from time series
+    def transform(self, input_data: InputData) -> OutputData:
+        """ Cut first cut_part from time series for predict stage
             new_len = len - int(self.cut_part * (input_values.shape[0]-horizon))
 
             :param input_data: data with features, target and ids to process
-            :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
             :return output_data: output data with cutted time series
         """
+        input_data = self._cut_input_data(input_data)
+
+        output_data = self._convert_to_output(input_data,
+                                              input_data.features,
+                                              data_type=input_data.data_type)
+        return output_data
+
+    def transform_for_fit(self, input_data: InputData) -> OutputData:
+        """ Cut first cut_part from time series for fit stage
+            new_len = len - int(self.cut_part * (input_values.shape[0]-horizon))
+
+            :param input_data: data with features, target and ids to process
+            :return output_data: output data with cutted time series
+        """
+        input_data = self._cut_input_data(input_data, reset_idx=True)
+
+        output_data = self._convert_to_output(input_data,
+                                              input_data.features,
+                                              data_type=input_data.data_type)
+        return output_data
+
+    def _cut_input_data(self, input_data: InputData, reset_idx: bool = False) -> InputData:
         horizon = input_data.task.task_params.forecast_length
         input_copy = copy(input_data)
         input_values = input_copy.features
+
         cut_len = int(self.cut_part * (input_values.shape[0] - horizon))
         output_values = input_values[cut_len::]
-        if is_fit_pipeline_stage:
-            input_copy.idx = np.arange(cut_len, input_values.shape[0])
+
         input_copy.features = output_values
         input_copy.target = output_values
-        output_data = self._convert_to_output(input_copy,
-                                              output_values,
-                                              data_type=input_data.data_type)
-        return output_data
+
+        if reset_idx:
+            input_copy.idx = np.arange(cut_len, input_values.shape[0])
+        return input_data
 
     def get_params(self):
         params_dict = {"cut_part": self.cut_part}

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/ts_transformations.py
@@ -362,14 +362,6 @@ class TsSmoothingImplementation(DataOperationImplementation):
 
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method for smoothing time series for fit stage
-
-        :param input_data: data with features, target and ids to process
-        :return output_data: output data with smoothed time series
-        """
-        return self.transform(input_data)
-
     def _apply_smoothing_to_series(self, ts):
         smoothed_ts = ts.rolling(window=self.window_size).mean()
         smoothed_ts = np.array(smoothed_ts)
@@ -489,14 +481,6 @@ class GaussianFilterImplementation(DataOperationImplementation):
 
         return output_data
 
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method for smoothing time series for fit stage
-
-        :param input_data: data with features, target and ids to process
-        :return output_data: output data with smoothed time series
-        """
-        return self.transform(input_data)
-
     def get_params(self):
         return {'sigma': self.sigma}
 
@@ -551,14 +535,6 @@ class NumericalDerivativeFilterImplementation(DataOperationImplementation):
                                                   data_type=input_data.data_type)
 
         return output_data
-
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method for finding numerical derivative of time series for fit stage
-
-        :param input_data: data with features, target and ids to process
-        :return output_data: output data with smoothed time series
-        """
-        return self.transform(input_data)
 
     def _differential_filter(self, ts):
         """ NumericalDerivative filter """

--- a/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
+++ b/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import numpy as np
 
-from fedot.core.data.data import OutputData
+from fedot.core.data.data import OutputData, InputData
 from fedot.core.log import default_log
 from fedot.core.repository.dataset_types import DataTypesEnum
 
@@ -187,11 +187,18 @@ class ModelImplementation(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def predict(self, input_data: InputData) -> OutputData:
         """ Method make prediction
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
+        """ Method make prediction while pipeline fitting
+
+        :param input_data: data with features, target and ids to process
         """
         raise NotImplementedError()
 

--- a/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
+++ b/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
@@ -34,7 +34,9 @@ class DataOperationImplementation(ABC):
         raise NotImplementedError()
 
     def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method apply transform operation on a dataset for fit stage
+        """ Method apply transform operation on a dataset for fit stage.
+        Allows to implement transform method different from main transform method
+        if another behaviour for fit graph stage is needed.
 
         :param input_data: data with features, target and ids to process
         """
@@ -200,7 +202,9 @@ class ModelImplementation(ABC):
         raise NotImplementedError()
 
     def predict_for_fit(self, input_data: InputData) -> OutputData:
-        """ Method make prediction while pipeline fitting
+        """ Method make prediction while graph fitting.
+        Allows to implement predict method different from main predict method
+        if another behaviour for fit graph stage is needed.
 
         :param input_data: data with features, target and ids to process
         """

--- a/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
+++ b/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
@@ -33,13 +33,12 @@ class DataOperationImplementation(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
     def transform_for_fit(self, input_data: InputData) -> OutputData:
         """ Method apply transform operation on a dataset for fit stage
 
         :param input_data: data with features, target and ids to process
         """
-        raise NotImplementedError()
+        return self.transform(input_data)
 
     @abstractmethod
     def get_params(self):
@@ -112,15 +111,6 @@ class EncodedInvariantImplementation(DataOperationImplementation):
         output_data = self._convert_to_output(input_data, transformed_features)
         self._update_column_types(source_features_shape, output_data)
         return output_data
-
-    def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """
-        The method that transforms the source features using "operation" for fit stage
-
-        :param input_data: tabular data with features, target and ids to process
-        :return output_data: output data with transformed features table
-        """
-        return self.transform(input_data)
 
     def _make_new_table(self, features):
         """
@@ -209,13 +199,12 @@ class ModelImplementation(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
     def predict_for_fit(self, input_data: InputData) -> OutputData:
         """ Method make prediction while pipeline fitting
 
         :param input_data: data with features, target and ids to process
         """
-        raise NotImplementedError()
+        return self.predict(input_data)
 
     @abstractmethod
     def get_params(self) -> dict:

--- a/fedot/core/operations/evaluation/operation_implementations/models/custom_model.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/custom_model.py
@@ -43,26 +43,19 @@ class CustomModelImplementation(ModelImplementation):
         return self.fitted_model
 
     def predict(self, input_data):
-        output_type = input_data.data_type
-        # if there is no need in fitting custom model
-        if not self.model_fit:
-            predict = input_data.features
-            # If custom model has exceptions inviolate train data goes to Output
-        # make prediction if predict call or there is need to fit custom model
-        else:
-            try:
-                predict, output_type = self.model_predict(self.fitted_model,
-                                                          input_data.idx,
-                                                          input_data.features,
-                                                          self.params)
-                if (input_data.data_type == DataTypesEnum.ts and
-                        input_data.target is not None and len(input_data.target.shape) > 1):
-                    # change target after custom model is processed
-                    input_data.target = input_data.target[:, 0]
-                output_type = DataTypesEnum[output_type]
-            except Exception as e:
-                raise TypeError(f'{e}\nInput model has incorrect behaviour. Check type hints for model: \
-                                        Callable[[any, np.array, dict], np.array, str]')
+        try:
+            predict, output_type = self.model_predict(self.fitted_model,
+                                                      input_data.idx,
+                                                      input_data.features,
+                                                      self.params)
+            if (input_data.data_type == DataTypesEnum.ts and
+                    input_data.target is not None and len(input_data.target.shape) > 1):
+                # change target after custom model is processed
+                input_data.target = input_data.target[:, 0]
+            output_type = DataTypesEnum[output_type]
+        except Exception as e:
+            raise TypeError(f'{e}\nInput model has incorrect behaviour. Check type hints for model: \
+                                    Callable[[any, np.array, dict], np.array, str]')
 
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
@@ -70,7 +63,16 @@ class CustomModelImplementation(ModelImplementation):
         return output_data
 
     def predict_for_fit(self, input_data):
-        return input_data.features
+        output_type = input_data.data_type
+        # if there is no need in fitting custom model and it is fit call
+        if not self.model_fit:
+            predict = input_data.features
+            output_data = self._convert_to_output(input_data,
+                                                  predict=predict,
+                                                  data_type=output_type)
+            return output_data
+        else:
+            return self.predict(input_data)
 
     def get_params(self):
         return self.params

--- a/fedot/core/operations/evaluation/operation_implementations/models/custom_model.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/custom_model.py
@@ -42,10 +42,10 @@ class CustomModelImplementation(ModelImplementation):
             self.fitted_model = self.model_fit(input_data.idx, input_data.features, input_data.target, self.params)
         return self.fitted_model
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def predict(self, input_data):
         output_type = input_data.data_type
-        # if there is no need in fitting custom model and it is fit call
-        if is_fit_pipeline_stage and not self.model_fit:
+        # if there is no need in fitting custom model
+        if not self.model_fit:
             predict = input_data.features
             # If custom model has exceptions inviolate train data goes to Output
         # make prediction if predict call or there is need to fit custom model
@@ -68,6 +68,9 @@ class CustomModelImplementation(ModelImplementation):
                                               predict=predict,
                                               data_type=output_type)
         return output_data
+
+    def predict_for_fit(self, input_data):
+        return input_data.features
 
     def get_params(self):
         return self.params

--- a/fedot/core/operations/evaluation/operation_implementations/models/discriminant_analysis.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/discriminant_analysis.py
@@ -33,13 +33,6 @@ class DiscriminantAnalysisImplementation(ModelImplementation):
 
         return prediction
 
-    def predict_for_fit(self, input_data):
-        """ Method make prediction for pipeline fit stage
-
-        :param input_data: data with features to process
-        """
-        return self.predict(input_data)
-
     def predict_proba(self, input_data):
         """ Method make prediction with probabilities of classes
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/discriminant_analysis.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/discriminant_analysis.py
@@ -22,17 +22,23 @@ class DiscriminantAnalysisImplementation(ModelImplementation):
         self.model.fit(train_data.features, train_data.target)
         return self.model
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool] = None):
+    def predict(self, input_data):
         """ Method make prediction with labels of classes
 
         :param input_data: data with features to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         """
         prediction = self.model.predict(input_data.features)
 
         prediction = nan_to_num(prediction)
 
         return prediction
+
+    def predict_for_fit(self, input_data):
+        """ Method make prediction for pipeline fit stage
+
+        :param input_data: data with features to process
+        """
+        return self.predict(input_data)
 
     def predict_proba(self, input_data):
         """ Method make prediction with probabilities of classes

--- a/fedot/core/operations/evaluation/operation_implementations/models/keras.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/keras.py
@@ -198,14 +198,6 @@ class FedotCNNImplementation(ModelImplementation):
         return predict_cnn(trained_model=self.model, predict_data=input_data,
                            output_mode='labels', logger=self.params['log'])
 
-    def predict_for_fit(self, input_data):
-        """ Method make prediction with labels of classes for fit stage
-
-        :param input_data: data with features to process
-        """
-
-        return self.predict(input_data)
-
     def predict_proba(self, input_data):
         """ Method make prediction with probabilities of classes
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/keras.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/keras.py
@@ -189,15 +189,22 @@ class FedotCNNImplementation(ModelImplementation):
                              optimizer_params=self.params['optimizer_parameters'], logger=self.params['log'])
         return self.model
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool] = None):
-        """ Method make prediction with labels of classes
+    def predict(self, input_data):
+        """ Method make prediction with labels of classes for predict stage
 
         :param input_data: data with features to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         """
 
         return predict_cnn(trained_model=self.model, predict_data=input_data,
                            output_mode='labels', logger=self.params['log'])
+
+    def predict_for_fit(self, input_data):
+        """ Method make prediction with labels of classes for fit stage
+
+        :param input_data: data with features to process
+        """
+
+        return self.predict(input_data)
 
     def predict_proba(self, input_data):
         """ Method make prediction with probabilities of classes

--- a/fedot/core/operations/evaluation/operation_implementations/models/knn.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/knn.py
@@ -31,13 +31,6 @@ class KNeighborsImplementation(ModelImplementation):
 
         return prediction
 
-    def predict_for_fit(self, input_data):
-        """ Method make prediction for pipeline fit stage
-
-        :param input_data: data with features to process
-        """
-        return self.predict(input_data)
-
     def check_and_correct_k_value(self, input_data, model_impl: Callable):
         """ Method check if the amount of neighbors is too big - clip it
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/knn.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/knn.py
@@ -22,15 +22,21 @@ class KNeighborsImplementation(ModelImplementation):
 
         raise NotImplementedError()
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool] = None):
+    def predict(self, input_data):
         """ Method for making prediction
 
         :param input_data: data with features to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         """
         prediction = self.model.predict(input_data.features)
 
         return prediction
+
+    def predict_for_fit(self, input_data):
+        """ Method make prediction for pipeline fit stage
+
+        :param input_data: data with features to process
+        """
+        return self.predict(input_data)
 
     def check_and_correct_k_value(self, input_data, model_impl: Callable):
         """ Method check if the amount of neighbors is too big - clip it

--- a/fedot/core/operations/evaluation/operation_implementations/models/svc.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/svc.py
@@ -29,15 +29,21 @@ class FedotSVCImplementation(ModelImplementation):
         self.model.fit(train_data.features, train_data.target)
         return self.model
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool] = None):
+    def predict(self, input_data):
         """ Method make prediction with labels of classes
 
         :param input_data: data with features to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         """
         prediction = self.model.predict(input_data.features)
 
         return prediction
+
+    def predict_for_fit(self, input_data):
+        """ Method make prediction for pipeline fit stage
+
+        :param input_data: data with features to process
+        """
+        return self.predict(input_data)
 
     def predict_proba(self, input_data):
         """ Method make prediction with probabilities of classes

--- a/fedot/core/operations/evaluation/operation_implementations/models/svc.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/svc.py
@@ -38,13 +38,6 @@ class FedotSVCImplementation(ModelImplementation):
 
         return prediction
 
-    def predict_for_fit(self, input_data):
-        """ Method make prediction for pipeline fit stage
-
-        :param input_data: data with features to process
-        """
-        return self.predict(input_data)
-
     def predict_proba(self, input_data):
         """ Method make prediction with probabilities of classes
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/arima.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/arima.py
@@ -7,7 +7,7 @@ from scipy.special import boxcox, inv_boxcox
 from statsmodels.tsa.api import STLForecast
 from statsmodels.tsa.arima.model import ARIMA
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
 from fedot.core.repository.dataset_types import DataTypesEnum
@@ -46,66 +46,62 @@ class ARIMAImplementation(ModelImplementation):
 
         return self.arima
 
-    def predict(self, input_data, is_fit_pipeline_stage: bool):
+    def predict(self, input_data: InputData):
         """ Method for time series prediction on forecast length
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+
         :return output_data: output data with smoothed time series
         """
         input_data = copy(input_data)
-        parameters = input_data.task.task_params
-        forecast_length = parameters.forecast_length
-        idx = input_data.idx
-        target = input_data.target
+        forecast_length = input_data.task.task_params.forecast_length
+        self.handle_new_data(input_data)
 
-        # For training pipeline get fitted data
-        if is_fit_pipeline_stage:
-            fitted_values = self.arima.fittedvalues
+        start_id = self.actual_ts_len
+        end_id = start_id + forecast_length - 1
 
-            fitted_values = self._inverse_boxcox(predicted=fitted_values,
-                                                 lambda_param=self.lambda_value)
-            # Undo shift operation
-            fitted_values = self._inverse_shift(fitted_values)
+        predicted = self.arima.predict(start=start_id,
+                                       end=end_id)
+        predicted = self._inverse_boxcox(predicted=predicted,
+                                         lambda_param=self.lambda_value)
+        predict = self._inverse_shift(predicted)
 
-            diff = int(self.actual_ts_len - len(fitted_values))
-            # If first elements skipped
-            if diff != 0:
-                # Fill nans with first values
-                first_element = fitted_values[0]
-                first_elements = [first_element] * diff
-                first_elements.extend(list(fitted_values))
+        predict = np.array(predict).reshape(1, -1)
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
 
-                fitted_values = np.array(first_elements)
+        return output_data
 
-            _, predict = ts_to_table(idx=idx,
-                                     time_series=fitted_values,
-                                     window_size=forecast_length)
+    def predict_for_fit(self, input_data: InputData):
+        input_data = copy(input_data)
+        forecast_length = input_data.task.task_params.forecast_length
+        fitted_values = self.arima.fittedvalues
 
-            new_idx, target_columns = ts_to_table(idx=idx,
-                                                  time_series=target,
-                                                  window_size=forecast_length)
-
-            # Update idx and target
-            input_data.idx = new_idx
-            input_data.target = target_columns
-
-        # For predict stage we can make prediction
-        else:
-            self.handle_new_data(input_data)
-            start_id = self.actual_ts_len
-            end_id = start_id + forecast_length - 1
-            predicted = self.arima.predict(start=start_id,
-                                           end=end_id)
-
-            predicted = self._inverse_boxcox(predicted=predicted,
+        fitted_values = self._inverse_boxcox(predicted=fitted_values,
                                              lambda_param=self.lambda_value)
+        fitted_values = self._inverse_shift(fitted_values)
 
-            # Undo shift operation
-            predict = self._inverse_shift(predicted)
-            # Convert one-dim array as column
-            predict = np.array(predict).reshape(1, -1)
-        # Update idx and features
+        diff = int(self.actual_ts_len - len(fitted_values))
+        # If first elements skipped
+        if diff != 0:
+            # Fill nans with first values
+            first_element = fitted_values[0]
+            first_elements = [first_element] * diff
+            first_elements.extend(list(fitted_values))
+
+            fitted_values = np.array(first_elements)
+
+        _, predict = ts_to_table(idx=input_data.idx,
+                                 time_series=fitted_values,
+                                 window_size=forecast_length)
+
+        new_idx, target_columns = ts_to_table(idx=input_data.idx,
+                                              time_series=input_data.target,
+                                              window_size=forecast_length)
+        input_data.idx = new_idx
+        input_data.target = target_columns
+
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
                                               data_type=DataTypesEnum.table)
@@ -208,58 +204,62 @@ class STLForecastARIMAImplementation(ModelImplementation):
 
         return self.model
 
-    def predict(self, input_data, is_fit_pipeline_stage: bool):
+    def predict(self, input_data: InputData) -> OutputData:
         """ Method for time series prediction on forecast length
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
+
         :return output_data: output data with smoothed time series
         """
         parameters = input_data.task.task_params
         forecast_length = parameters.forecast_length
+
+        # in case in(out) sample forecasting
+        self.handle_new_data(input_data)
+        start_id = self.actual_ts_len
+        end_id = start_id + forecast_length - 1
+        predicted = self.model.get_prediction(start=start_id, end=end_id).predicted_mean
+
+        # Convert one-dim array as column
+        predict = np.array(predicted).reshape(1, -1)
+        new_idx = np.arange(start_id, end_id + 1)
+
+        # Update idx
+        input_data.idx = new_idx
+
+        # Update idx and features
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
+        parameters = input_data.task.task_params
+        forecast_length = parameters.forecast_length
         idx = input_data.idx
         target = input_data.target
+        fitted_values = self.model.get_prediction(start=idx[0], end=idx[-1]).predicted_mean
+        diff = int(self.actual_ts_len) - len(fitted_values)
+        # If first elements skipped
+        if diff != 0:
+            # Fill nans with first values
+            first_element = fitted_values[0]
+            first_elements = [first_element] * diff
+            first_elements.extend(list(fitted_values))
 
-        # For training pipeline get fitted data
-        if is_fit_pipeline_stage:
-            fitted_values = self.model.get_prediction(start=idx[0], end=idx[-1]).predicted_mean
-            diff = int(self.actual_ts_len) - len(fitted_values)
-            # If first elements skipped
-            if diff != 0:
-                # Fill nans with first values
-                first_element = fitted_values[0]
-                first_elements = [first_element] * diff
-                first_elements.extend(list(fitted_values))
+            fitted_values = np.array(first_elements)
 
-                fitted_values = np.array(first_elements)
+        _, predict = ts_to_table(idx=idx,
+                                 time_series=fitted_values,
+                                 window_size=forecast_length)
 
-            _, predict = ts_to_table(idx=idx,
-                                     time_series=fitted_values,
-                                     window_size=forecast_length)
+        new_idx, target_columns = ts_to_table(idx=idx,
+                                              time_series=target,
+                                              window_size=forecast_length)
 
-            new_idx, target_columns = ts_to_table(idx=idx,
-                                                  time_series=target,
-                                                  window_size=forecast_length)
-
-            # Update idx and target
-            input_data.idx = new_idx
-            input_data.target = target_columns
-
-        # For predict stage we can make prediction
-        else:
-            # in case in(out) sample forecasting
-            self.handle_new_data(input_data)
-            start_id = self.actual_ts_len
-            end_id = start_id + forecast_length - 1
-            predicted = self.model.get_prediction(start=start_id, end=end_id).predicted_mean
-
-            # Convert one-dim array as column
-            predict = np.array(predicted).reshape(1, -1)
-            new_idx = np.arange(start_id, end_id + 1)
-
-            # Update idx
-            input_data.idx = new_idx
-
+        # Update idx and target
+        input_data.idx = new_idx
+        input_data.target = target_columns
         # Update idx and features
         output_data = self._convert_to_output(input_data,
                                               predict=predict,

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/arima.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/arima.py
@@ -220,14 +220,11 @@ class STLForecastARIMAImplementation(ModelImplementation):
         end_id = start_id + forecast_length - 1
         predicted = self.model.get_prediction(start=start_id, end=end_id).predicted_mean
 
-        # Convert one-dim array as column
         predict = np.array(predicted).reshape(1, -1)
         new_idx = np.arange(start_id, end_id + 1)
 
-        # Update idx
         input_data.idx = new_idx
 
-        # Update idx and features
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
                                               data_type=DataTypesEnum.table)
@@ -257,10 +254,8 @@ class STLForecastARIMAImplementation(ModelImplementation):
                                               time_series=target,
                                               window_size=forecast_length)
 
-        # Update idx and target
         input_data.idx = new_idx
         input_data.target = target_columns
-        # Update idx and features
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
                                               data_type=DataTypesEnum.table)

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/clstm.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/clstm.py
@@ -104,39 +104,46 @@ class CLSTMImplementation(ModelImplementation):
                 final_output = output
         return final_output
 
-    def predict(self, input_data: InputData, is_fit_pipeline_stage: Optional[bool]):
+    def predict(self, input_data: InputData):
         """ Method for time series prediction on forecast length
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with smoothed time series
         """
         self.model.eval()
-        input_data_new = copy(input_data)
-        old_idx = input_data_new.idx
+        input_data = copy(input_data)
         forecast_length = input_data.task.task_params.forecast_length
 
-        if is_fit_pipeline_stage:
-            new_idx, lagged_table = ts_to_table(idx=old_idx,
-                                                time_series=input_data_new.features,
-                                                window_size=self.window_size,
-                                                is_lag=True)
+        input_data.features = input_data.features[-self.window_size:].reshape(1, -1)
+        input_data.idx = input_data.idx[-forecast_length:]
 
-            final_idx, features_columns, final_target = prepare_target(all_idx=old_idx,
-                                                                       idx=new_idx,
-                                                                       features_columns=lagged_table,
-                                                                       target=input_data_new.target,
-                                                                       forecast_length=forecast_length)
-            input_data_new.idx = final_idx
-            input_data_new.features = features_columns
-            input_data_new.target = final_target
-        else:
-            input_data_new.features = input_data_new.features[-self.window_size:].reshape(1, -1)
-            input_data_new.idx = input_data_new.idx[-forecast_length:]
+        predict = self._out_of_sample_ts_forecast(input_data)
 
-        predict = self._out_of_sample_ts_forecast(input_data_new)
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
+        return output_data
 
-        output_data = self._convert_to_output(input_data_new,
+    def predict_for_fit(self, input_data: InputData):
+        self.model.eval()
+        input_data = copy(input_data)
+        forecast_length = input_data.task.task_params.forecast_length
+        new_idx, lagged_table = ts_to_table(idx=input_data.idx,
+                                            time_series=input_data.features,
+                                            window_size=self.window_size,
+                                            is_lag=True)
+
+        final_idx, features_columns, final_target = prepare_target(all_idx=input_data.idx,
+                                                                   idx=new_idx,
+                                                                   features_columns=lagged_table,
+                                                                   target=input_data.target,
+                                                                   forecast_length=forecast_length)
+        input_data.idx = final_idx
+        input_data.features = features_columns
+        input_data.target = final_target
+        predict = self._out_of_sample_ts_forecast(input_data)
+
+        output_data = self._convert_to_output(input_data,
                                               predict=predict,
                                               data_type=DataTypesEnum.table)
         return output_data

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/clstm.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/clstm.py
@@ -1,5 +1,4 @@
 from copy import copy
-from typing import Optional
 
 import numpy as np
 from sklearn.preprocessing import StandardScaler

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -39,7 +39,7 @@ class RepeatLastValueImplementation(ModelImplementation):
             self.elements_to_repeat = input_data.task.task_params.forecast_length
         return self
 
-    def predict(self, input_data: InputData):
+    def predict(self, input_data: InputData) -> OutputData:
         input_data = copy(input_data)
         forecast_length = input_data.task.task_params.forecast_length
 
@@ -52,7 +52,7 @@ class RepeatLastValueImplementation(ModelImplementation):
                                               data_type=DataTypesEnum.table)
         return output_data
 
-    def predict_for_fit(self, input_data: InputData):
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
         input_data = copy(input_data)
         forecast_length = input_data.task.task_params.forecast_length
         # Transform the predicted time series into a table
@@ -94,7 +94,7 @@ class NaiveAverageForecastImplementation(ModelImplementation):
         """ Such a simple approach does not support fit method """
         pass
 
-    def predict(self, input_data: InputData):
+    def predict(self, input_data: InputData) -> OutputData:
         """ Get desired part of time series for averaging and calculate mean value """
         forecast_length = input_data.task.task_params.forecast_length
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -2,7 +2,7 @@ from copy import copy
 
 import numpy as np
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table, \
     transform_features_and_target_into_lagged
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
@@ -39,23 +39,29 @@ class RepeatLastValueImplementation(ModelImplementation):
             self.elements_to_repeat = input_data.task.task_params.forecast_length
         return self
 
-    def predict(self, input_data: InputData, is_fit_pipeline_stage: bool):
+    def predict(self, input_data: InputData):
         input_data = copy(input_data)
         forecast_length = input_data.task.task_params.forecast_length
 
-        if is_fit_pipeline_stage:
-            # Transform the predicted time series into a table
-            new_idx, transformed_cols, new_target = transform_features_and_target_into_lagged(input_data,
-                                                                                              forecast_length,
-                                                                                              self.elements_to_repeat)
-            input_data.idx = new_idx
-            input_data.target = new_target
-            forecast = self._generate_repeated_forecast(transformed_cols, forecast_length)
-        else:
-            # Get last known value from history
-            last_observations = input_data.features[-self.elements_to_repeat:].reshape(1, -1)
-            forecast = self._generate_repeated_forecast(last_observations, forecast_length)
+        # Get last known value from history
+        last_observations = input_data.features[-self.elements_to_repeat:].reshape(1, -1)
+        forecast = self._generate_repeated_forecast(last_observations, forecast_length)
 
+        output_data = self._convert_to_output(input_data,
+                                              predict=forecast,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def predict_for_fit(self, input_data: InputData):
+        input_data = copy(input_data)
+        forecast_length = input_data.task.task_params.forecast_length
+        # Transform the predicted time series into a table
+        new_idx, transformed_cols, new_target = transform_features_and_target_into_lagged(input_data,
+                                                                                          forecast_length,
+                                                                                          self.elements_to_repeat)
+        input_data.idx = new_idx
+        input_data.target = new_target
+        forecast = self._generate_repeated_forecast(transformed_cols, forecast_length)
         output_data = self._convert_to_output(input_data,
                                               predict=forecast,
                                               data_type=DataTypesEnum.table)
@@ -88,30 +94,36 @@ class NaiveAverageForecastImplementation(ModelImplementation):
         """ Such a simple approach does not support fit method """
         pass
 
-    def predict(self, input_data: InputData, is_fit_pipeline_stage: bool):
+    def predict(self, input_data: InputData):
         """ Get desired part of time series for averaging and calculate mean value """
         forecast_length = input_data.task.task_params.forecast_length
-        if is_fit_pipeline_stage:
-            parts = split_rolling_slices(input_data)
-            mean_values_for_chunks = self.average_by_axis(parts)
-            forecast = np.repeat(mean_values_for_chunks.reshape((-1, 1)), forecast_length, axis=1)
-            forecast = forecast[:-forecast_length, :]
 
-            # Update target
-            _, transformed_target = ts_to_table(idx=input_data.idx, time_series=input_data.target,
-                                                window_size=forecast_length, is_lag=True)
-            input_data.target = transformed_target[1:, :]
+        elements_to_take = self._how_many_elements_use_for_averaging(input_data.features)
+        # Prepare single forecast
+        mean_value = np.nanmean(input_data.features[-elements_to_take:])
+        forecast = np.array([mean_value] * forecast_length).reshape((1, -1))
 
-            # Update indices - there is no forecast for first element and skip last out of boundaries predictions
-            last_threshold = forecast_length - 1
-            new_idx = input_data.idx[1: -last_threshold]
-            input_data.idx = new_idx
-        else:
-            elements_to_take = self._how_many_elements_use_for_averaging(input_data.features)
-            # Prepare single forecast
-            mean_value = np.nanmean(input_data.features[-elements_to_take:])
-            forecast = np.array([mean_value] * forecast_length).reshape((1, -1))
+        output_data = self._convert_to_output(input_data,
+                                              predict=forecast,
+                                              data_type=DataTypesEnum.table)
+        return output_data
 
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
+        forecast_length = input_data.task.task_params.forecast_length
+        parts = split_rolling_slices(input_data)
+        mean_values_for_chunks = self.average_by_axis(parts)
+        forecast = np.repeat(mean_values_for_chunks.reshape((-1, 1)), forecast_length, axis=1)
+        forecast = forecast[:-forecast_length, :]
+
+        # Update target
+        _, transformed_target = ts_to_table(idx=input_data.idx, time_series=input_data.target,
+                                            window_size=forecast_length, is_lag=True)
+        input_data.target = transformed_target[1:, :]
+
+        # Update indices - there is no forecast for first element and skip last out of boundaries predictions
+        last_threshold = forecast_length - 1
+        new_idx = input_data.idx[1: -last_threshold]
+        input_data.idx = new_idx
         output_data = self._convert_to_output(input_data,
                                               predict=forecast,
                                               data_type=DataTypesEnum.table)

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/poly.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/poly.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
 from fedot.core.repository.dataset_types import DataTypesEnum
@@ -33,7 +34,29 @@ class PolyfitImplementation(ModelImplementation):
 
         return self.coefs
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def predict(self, input_data):
+        f_x = input_data.idx
+        f_y = np.polyval(self.coefs, f_x)
+        input_data = copy(input_data)
+        parameters = input_data.task.task_params
+        forecast_length = parameters.forecast_length
+        old_idx = input_data.idx
+
+        start_id = old_idx[-1] - forecast_length + 1
+        end_id = old_idx[-1]
+        predict = f_y
+        predict = np.array(predict).reshape(1, -1)
+        new_idx = np.arange(start_id, end_id + 1)
+
+        # Update idx
+        input_data.idx = new_idx
+
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
         f_x = input_data.idx
         f_y = np.polyval(self.coefs, f_x)
         input_data = copy(input_data)
@@ -41,28 +64,17 @@ class PolyfitImplementation(ModelImplementation):
         forecast_length = parameters.forecast_length
         old_idx = input_data.idx
         target = input_data.target
-        if is_fit_pipeline_stage:
-            _, predict = ts_to_table(idx=old_idx,
-                                     time_series=f_y,
-                                     window_size=forecast_length)
-            new_idx, target_columns = ts_to_table(idx=old_idx,
-                                                  time_series=target,
-                                                  window_size=forecast_length)
 
-            # Update idx and target
-            input_data.idx = new_idx
-            input_data.target = target_columns
+        _, predict = ts_to_table(idx=old_idx,
+                                 time_series=f_y,
+                                 window_size=forecast_length)
+        new_idx, target_columns = ts_to_table(idx=old_idx,
+                                              time_series=target,
+                                              window_size=forecast_length)
 
-        else:
-            start_id = old_idx[-1] - forecast_length + 1
-            end_id = old_idx[-1]
-            predict = f_y
-            predict = np.array(predict).reshape(1, -1)
-            new_idx = np.arange(start_id, end_id + 1)
-
-            # Update idx
-            input_data.idx = new_idx
-
+        # Update idx and target
+        input_data.idx = new_idx
+        input_data.target = target_columns
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
                                               data_type=DataTypesEnum.table)

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/poly.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/poly.py
@@ -48,7 +48,6 @@ class PolyfitImplementation(ModelImplementation):
         predict = np.array(predict).reshape(1, -1)
         new_idx = np.arange(start_id, end_id + 1)
 
-        # Update idx
         input_data.idx = new_idx
 
         output_data = self._convert_to_output(input_data,

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -82,7 +82,7 @@ class GLMImplementation(ModelImplementation):
         parameters = input_data.task.task_params
         forecast_length = parameters.forecast_length
         old_idx = input_data.idx
-        if forecast_length == 1 :
+        if forecast_length == 1:
             predictions = self.model.predict(np.concatenate([np.array([1]),
                                                              input_data.idx.astype("float64")]).reshape(-1, 2))
         else:

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -1,5 +1,4 @@
 from copy import copy
-from typing import Optional
 
 import numpy as np
 import statsmodels.api as sm
@@ -10,7 +9,6 @@ from statsmodels.tsa.ar_model import AutoReg
 from statsmodels.tsa.exponential_smoothing.ets import ETSModel
 
 from fedot.core.data.data import InputData, OutputData
-from fedot.core.log import LoggerAdapter
 from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
 from fedot.core.repository.dataset_types import DataTypesEnum
@@ -96,7 +94,6 @@ class GLMImplementation(ModelImplementation):
         predict = np.array(predict).reshape(1, -1)
         new_idx = np.arange(start_id, end_id + 1)
 
-        # Update idx
         input_data.idx = new_idx
 
         output_data = self._convert_to_output(input_data,
@@ -118,7 +115,6 @@ class GLMImplementation(ModelImplementation):
                                               time_series=target,
                                               window_size=forecast_length)
 
-        # Update idx and target
         input_data.idx = new_idx
         input_data.target = target_columns
 
@@ -232,7 +228,6 @@ class AutoRegImplementation(ModelImplementation):
                                               time_series=target,
                                               window_size=forecast_length)
 
-        # Update idx and target
         input_data.idx = new_idx
         input_data.target = target_columns
         output_data = self._convert_to_output(input_data,
@@ -323,7 +318,6 @@ class ExpSmoothingImplementation(ModelImplementation):
         predict = np.array(predict).reshape(1, -1)
         new_idx = np.arange(start_id, end_id + 1)
 
-        # Update idx
         input_data.idx = new_idx
 
         output_data = self._convert_to_output(input_data,
@@ -350,7 +344,6 @@ class ExpSmoothingImplementation(ModelImplementation):
                                               time_series=target,
                                               window_size=forecast_length)
 
-        # Update idx and target
         input_data.idx = new_idx
         input_data.target = target_columns
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -9,7 +9,7 @@ from statsmodels.genmod.generalized_linear_model import GLM
 from statsmodels.tsa.ar_model import AutoReg
 from statsmodels.tsa.exponential_smoothing.ets import ETSModel
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.log import LoggerAdapter
 from fedot.core.operations.evaluation.operation_implementations.data_operations.ts_transformations import ts_to_table
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
@@ -79,39 +79,48 @@ class GLMImplementation(ModelImplementation):
         ).fit()
         return self.model
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def predict(self, input_data):
         input_data = copy(input_data)
         parameters = input_data.task.task_params
         forecast_length = parameters.forecast_length
         old_idx = input_data.idx
-        target = input_data.target
-        if forecast_length == 1 and not is_fit_pipeline_stage:
+        if forecast_length == 1 :
             predictions = self.model.predict(np.concatenate([np.array([1]),
                                                              input_data.idx.astype("float64")]).reshape(-1, 2))
         else:
             predictions = self.model.predict(sm.add_constant(input_data.idx.astype("float64")).reshape(-1, 2))
 
-        if is_fit_pipeline_stage:
-            _, predict = ts_to_table(idx=old_idx,
-                                     time_series=predictions,
-                                     window_size=forecast_length)
-            new_idx, target_columns = ts_to_table(idx=old_idx,
-                                                  time_series=target,
-                                                  window_size=forecast_length)
+        start_id = old_idx[-1] - forecast_length + 1
+        end_id = old_idx[-1]
+        predict = predictions
+        predict = np.array(predict).reshape(1, -1)
+        new_idx = np.arange(start_id, end_id + 1)
 
-            # Update idx and target
-            input_data.idx = new_idx
-            input_data.target = target_columns
+        # Update idx
+        input_data.idx = new_idx
 
-        else:
-            start_id = old_idx[-1] - forecast_length + 1
-            end_id = old_idx[-1]
-            predict = predictions
-            predict = np.array(predict).reshape(1, -1)
-            new_idx = np.arange(start_id, end_id + 1)
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
+        return output_data
 
-            # Update idx
-            input_data.idx = new_idx
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
+        input_data = copy(input_data)
+        parameters = input_data.task.task_params
+        forecast_length = parameters.forecast_length
+        old_idx = input_data.idx
+        target = input_data.target
+        predictions = self.model.predict(sm.add_constant(input_data.idx.astype("float64")).reshape(-1, 2))
+        _, predict = ts_to_table(idx=old_idx,
+                                 time_series=predictions,
+                                 window_size=forecast_length)
+        new_idx, target_columns = ts_to_table(idx=old_idx,
+                                              time_series=target,
+                                              window_size=forecast_length)
+
+        # Update idx and target
+        input_data.idx = new_idx
+        input_data.target = target_columns
 
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
@@ -183,44 +192,49 @@ class AutoRegImplementation(ModelImplementation):
 
         return self.autoreg
 
-    def predict(self, input_data, is_fit_pipeline_stage: bool):
+    def predict(self, input_data):
         """ Method for time series prediction on forecast length
 
         :param input_data: data with features, target and ids to process
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return output_data: output data with smoothed time series
         """
         input_data = copy(input_data)
         parameters = input_data.task.task_params
         forecast_length = parameters.forecast_length
+
+        # in case in(out) sample forecasting
+        self.handle_new_data(input_data)
+        start_id = self.actual_ts_len
+        end_id = start_id + forecast_length - 1
+        predicted = self.autoreg.predict(start=start_id, end=end_id)
+        predict = np.array(predicted).reshape(1, -1)
+
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
+        input_data = copy(input_data)
+        parameters = input_data.task.task_params
+        forecast_length = parameters.forecast_length
         idx = input_data.idx
         target = input_data.target
+        predicted = self.autoreg.predict(start=idx[0], end=idx[-1])
+        # adding nan to target as in predicted
+        nan_mask = np.isnan(predicted)
+        target = target.astype(float)
+        target[nan_mask] = np.nan
+        _, predict = ts_to_table(idx=idx,
+                                 time_series=predicted,
+                                 window_size=forecast_length)
+        new_idx, target_columns = ts_to_table(idx=idx,
+                                              time_series=target,
+                                              window_size=forecast_length)
 
-        if is_fit_pipeline_stage:
-            predicted = self.autoreg.predict(start=idx[0], end=idx[-1])
-            # adding nan to target as in predicted
-            nan_mask = np.isnan(predicted)
-            target = target.astype(float)
-            target[nan_mask] = np.nan
-            _, predict = ts_to_table(idx=idx,
-                                     time_series=predicted,
-                                     window_size=forecast_length)
-            new_idx, target_columns = ts_to_table(idx=idx,
-                                                  time_series=target,
-                                                  window_size=forecast_length)
-
-            # Update idx and target
-            input_data.idx = new_idx
-            input_data.target = target_columns
-
-        else:
-            # in case in(out) sample forecasting
-            self.handle_new_data(input_data)
-            start_id = self.actual_ts_len
-            end_id = start_id + forecast_length - 1
-            predicted = self.autoreg.predict(start=start_id, end=end_id)
-            predict = np.array(predicted).reshape(1, -1)
-
+        # Update idx and target
+        input_data.idx = new_idx
+        input_data.target = target_columns
         output_data = self._convert_to_output(input_data,
                                               predict=predict,
                                               data_type=DataTypesEnum.table)
@@ -297,39 +311,48 @@ class ExpSmoothingImplementation(ModelImplementation):
         self.model = self.model.fit(disp=False)
         return self.model
 
-    def predict(self, input_data, is_fit_pipeline_stage: Optional[bool]):
+    def predict(self, input_data):
+        input_data = copy(input_data)
+        idx = input_data.idx
+
+        start_id = idx[0]
+        end_id = idx[-1]
+        predictions = self.model.predict(start=start_id,
+                                         end=end_id)
+        predict = predictions
+        predict = np.array(predict).reshape(1, -1)
+        new_idx = np.arange(start_id, end_id + 1)
+
+        # Update idx
+        input_data.idx = new_idx
+
+        output_data = self._convert_to_output(input_data,
+                                              predict=predict,
+                                              data_type=DataTypesEnum.table)
+        return output_data
+
+    def predict_for_fit(self, input_data: InputData) -> OutputData:
         input_data = copy(input_data)
         parameters = input_data.task.task_params
         forecast_length = parameters.forecast_length
         idx = input_data.idx
         target = input_data.target
 
-        if is_fit_pipeline_stage:
-            # Indexing for statsmodels is different
-            predictions = self.model.predict(start=idx[0],
-                                             end=idx[-1])
-            _, predict = ts_to_table(idx=idx,
-                                     time_series=predictions,
-                                     window_size=forecast_length)
-            new_idx, target_columns = ts_to_table(idx=idx,
-                                                  time_series=target,
-                                                  window_size=forecast_length)
+        # Indexing for statsmodels is different
+        start_id = idx[0]
+        end_id = idx[-1]
+        predictions = self.model.predict(start=start_id,
+                                         end=end_id)
+        _, predict = ts_to_table(idx=idx,
+                                 time_series=predictions,
+                                 window_size=forecast_length)
+        new_idx, target_columns = ts_to_table(idx=idx,
+                                              time_series=target,
+                                              window_size=forecast_length)
 
-            # Update idx and target
-            input_data.idx = new_idx
-            input_data.target = target_columns
-
-        else:
-            start_id = idx[0]
-            end_id = idx[-1]
-            predictions = self.model.predict(start=start_id,
-                                             end=end_id)
-            predict = predictions
-            predict = np.array(predict).reshape(1, -1)
-            new_idx = np.arange(start_id, end_id + 1)
-
-            # Update idx
-            input_data.idx = new_idx
+        # Update idx and target
+        input_data.idx = new_idx
+        input_data.target = target_columns
 
         output_data = self._convert_to_output(input_data,
                                               predict=predict,

--- a/fedot/core/operations/evaluation/regression.py
+++ b/fedot/core/operations/evaluation/regression.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Optional
 
-from fedot.core.data.data import InputData
+from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy, SkLearnEvaluationStrategy
 from fedot.core.operations.evaluation.operation_implementations.data_operations.decompose \
     import DecomposerRegImplementation
@@ -17,18 +17,27 @@ warnings.filterwarnings("ignore", category=UserWarning)
 
 
 class SkLearnRegressionStrategy(SkLearnEvaluationStrategy):
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Predict method for regression task
+        Predict method for regression task for predict stage
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return:
         """
 
         prediction = trained_operation.predict(predict_data.features)
-        # Convert prediction to output (if it is required)
+        converted = self._convert_to_output(prediction, predict_data)
+
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Predict method for regression task for fit stage
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+        prediction = trained_operation.predict_for_fit(predict_data.features)
         converted = self._convert_to_output(prediction, predict_data)
 
         return converted
@@ -68,19 +77,27 @@ class FedotRegressionPreprocessingStrategy(EvaluationStrategy):
         operation_implementation.fit(train_data)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        Transform method for preprocessing
+        Transform method for preprocessing for predict stage
 
         :param trained_operation: model object
         :param predict_data: data used for prediction
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return:
         """
-        prediction = trained_operation.transform(predict_data, is_fit_pipeline_stage)
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
 
-        # Convert prediction to output (if it is required)
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        Transform method for preprocessing for fit stage
+
+        :param trained_operation: model object
+        :param predict_data: data used for prediction
+        :return:
+        """
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
@@ -116,12 +133,15 @@ class FedotRegressionStrategy(EvaluationStrategy):
         operation_implementation.fit(train_data)
         return operation_implementation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool):
-        """ Predict method for regression models """
-        prediction = trained_operation.predict(predict_data, is_fit_pipeline_stage)
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
 
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/regression.py
+++ b/fedot/core/operations/evaluation/regression.py
@@ -30,18 +30,6 @@ class SkLearnRegressionStrategy(SkLearnEvaluationStrategy):
 
         return converted
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        """
-        Predict method for regression task for fit stage
-        :param trained_operation: model object
-        :param predict_data: data used for prediction
-        :return:
-        """
-        prediction = trained_operation.predict_for_fit(predict_data.features)
-        converted = self._convert_to_output(prediction, predict_data)
-
-        return converted
-
 
 class FedotRegressionPreprocessingStrategy(EvaluationStrategy):
     """ Strategy for applying custom algorithms from FEDOT to preprocess data
@@ -135,13 +123,13 @@ class FedotRegressionStrategy(EvaluationStrategy):
 
     def predict(self, trained_operation, predict_data: InputData) -> OutputData:
 
-        prediction = trained_operation.transform(predict_data)
+        prediction = trained_operation.predict(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
     def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
 
-        prediction = trained_operation.transform_for_fit(predict_data)
+        prediction = trained_operation.predict_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/text.py
+++ b/fedot/core/operations/evaluation/text.py
@@ -47,9 +47,6 @@ class SkLearnTextVectorizeStrategy(EvaluationStrategy):
         converted = self._convert_to_output(predicted, predict_data)
         return converted
 
-    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
-        return self.predict(trained_operation, predict_data)
-
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
             return self.__operations_by_types[operation_type]

--- a/fedot/core/operations/evaluation/text.py
+++ b/fedot/core/operations/evaluation/text.py
@@ -38,8 +38,7 @@ class SkLearnTextVectorizeStrategy(EvaluationStrategy):
 
         return self.vectorizer
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
 
         features_list = self._convert_to_one_dim(predict_data.features)
         predicted = trained_operation.transform(features_list).toarray()
@@ -47,6 +46,9 @@ class SkLearnTextVectorizeStrategy(EvaluationStrategy):
         # Convert prediction to output (if it is required)
         converted = self._convert_to_output(predicted, predict_data)
         return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        return self.predict(trained_operation, predict_data)
 
     def _convert_to_operation(self, operation_type: str):
         if operation_type in self.__operations_by_types.keys():
@@ -94,20 +96,28 @@ class FedotTextPreprocessingStrategy(EvaluationStrategy):
         self.text_processor.fit(train_data)
         return self.text_processor
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        This method used for prediction of the target data.
+        This method used for prediction of the target data during predict stage.
 
         :param trained_operation: trained operation object
         :param predict_data: data to predict
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return OutputData: passed data with new predicted target
         """
 
-        prediction = trained_operation.transform(predict_data,
-                                                 is_fit_pipeline_stage)
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        This method used for prediction of the target data during fit stage.
+
+        :param trained_operation: trained operation object
+        :param predict_data: data to predict
+        :return OutputData: passed data with new predicted target
+        """
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
@@ -141,12 +151,15 @@ class GensimTextVectorizeStrategy(EvaluationStrategy):
         self.vectorizer.fit(train_data)
         return self.vectorizer
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
 
-        prediction = trained_operation.transform(predict_data,
-                                                 is_fit_pipeline_stage)
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.transform(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/time_series.py
+++ b/fedot/core/operations/evaluation/time_series.py
@@ -145,7 +145,7 @@ class FedotTsTransformingStrategy(EvaluationStrategy):
         :return OutputData: passed data with new predicted target
         """
 
-        prediction = trained_operation.predict(predict_data)
+        prediction = trained_operation.transform(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
@@ -158,7 +158,7 @@ class FedotTsTransformingStrategy(EvaluationStrategy):
         :return OutputData: passed data with new predicted target
         """
 
-        prediction = trained_operation.predict_for_fit(predict_data)
+        prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/operations/evaluation/time_series.py
+++ b/fedot/core/operations/evaluation/time_series.py
@@ -63,20 +63,29 @@ class FedotTsForecastingStrategy(EvaluationStrategy):
         model.fit(train_data)
         return model
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        This method used for prediction of the target data.
+        This method used for prediction of the target data during predict stage.
 
         :param trained_operation: trained operation object
         :param predict_data: data to predict
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return OutputData: passed data with new predicted target
         """
 
-        prediction = trained_operation.predict(predict_data,
-                                               is_fit_pipeline_stage)
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.predict(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        This method used for prediction of the target data during fit stage.
+
+        :param trained_operation: trained operation object
+        :param predict_data: data to predict
+        :return OutputData: passed data with new predicted target
+        """
+
+        prediction = trained_operation.predict_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 
@@ -127,20 +136,29 @@ class FedotTsTransformingStrategy(EvaluationStrategy):
         transformation_operation.fit(train_data)
         return transformation_operation
 
-    def predict(self, trained_operation, predict_data: InputData,
-                is_fit_pipeline_stage: bool) -> OutputData:
+    def predict(self, trained_operation, predict_data: InputData) -> OutputData:
         """
-        This method used for prediction of the target data.
+        This method used for prediction of the target data during predict stage.
 
         :param trained_operation: trained operation object
         :param predict_data: data to predict
-        :param is_fit_pipeline_stage: is this fit or predict stage for pipeline
         :return OutputData: passed data with new predicted target
         """
 
-        prediction = trained_operation.transform(predict_data,
-                                                 is_fit_pipeline_stage)
-        # Convert prediction to output (if it is required)
+        prediction = trained_operation.predict(predict_data)
+        converted = self._convert_to_output(prediction, predict_data)
+        return converted
+
+    def predict_for_fit(self, trained_operation, predict_data: InputData) -> OutputData:
+        """
+        This method used for prediction of the target data during fit stage.
+
+        :param trained_operation: trained operation object
+        :param predict_data: data to predict
+        :return OutputData: passed data with new predicted target
+        """
+
+        prediction = trained_operation.predict_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)
         return converted
 

--- a/fedot/core/pipelines/node.py
+++ b/fedot/core/pipelines/node.py
@@ -197,14 +197,12 @@ class Node(GraphNode):
         if self.fitted_operation is None:
             with Timer() as t:
                 self.fitted_operation, operation_predict = self.operation.fit(params=self.content['params'],
-                                                                              data=input_data,
-                                                                              is_fit_pipeline_stage=True)
+                                                                              data=input_data)
                 self.fit_time_in_seconds = round(t.seconds_from_start, 3)
         else:
-            operation_predict = self.operation.predict(fitted_operation=self.fitted_operation,
-                                                       data=input_data,
-                                                       is_fit_pipeline_stage=True,
-                                                       params=self.content['params'])
+            operation_predict = self.operation.predict_for_fit(fitted_operation=self.fitted_operation,
+                                                               data=input_data,
+                                                               params=self.content['params'])
 
         # Update parameters after operation fitting (they can be corrected)
         not_atomized_operation = 'atomized' not in self.operation.operation_type
@@ -225,8 +223,7 @@ class Node(GraphNode):
             operation_predict = self.operation.predict(fitted_operation=self.fitted_operation,
                                                        params=self.content['params'],
                                                        data=input_data,
-                                                       output_mode=output_mode,
-                                                       is_fit_pipeline_stage=False)
+                                                       output_mode=output_mode)
             self.inference_time_in_seconds = round(t.seconds_from_start, 3)
         return operation_predict
 

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -106,7 +106,7 @@ class Pipeline(Graph, Serializable):
     def _fit(self, input_data: Optional[InputData] = None,
              process_state_dict: dict = None, fitted_operations: list = None) -> Optional[OutputData]:
         """
-        Runs training process in all of the pipeline nodes starting with root
+        Runs training process in all the pipeline nodes starting with root
 
         :param input_data: data used for operation training
         :param process_state_dict: dictionary used for saving required pipeline parameters

--- a/fedot/preprocessing/preprocessing.py
+++ b/fedot/preprocessing/preprocessing.py
@@ -325,7 +325,7 @@ class DataPreprocessor:
                 # Store encoder to make prediction in the future
                 self.features_encoders.update({source_name: encoder})
                 self.use_label_encoder = True
-            encoder_output = encoder.transform(data, True)
+            encoder_output = encoder.transform_for_fit(data)
             data.features = encoder_output.predict
             data.supplementary_data = encoder_output.supplementary_data
 
@@ -366,8 +366,7 @@ class DataPreprocessor:
             encoder = LabelEncodingImplementation() if self.use_label_encoder else OneHotEncodingImplementation()
             encoder.fit(data)
             self.features_encoders[source_name] = encoder
-        output_data = encoder.transform(data, True)
-
+        output_data = encoder.transform_for_fit(data)
         output_data.predict = output_data.predict.astype(float)
         data.features = output_data.predict
         data.supplementary_data = output_data.supplementary_data

--- a/test/test_gpu_strategy.py
+++ b/test/test_gpu_strategy.py
@@ -31,7 +31,6 @@ def test_gpu_evaluation_strategy_predict():
                                           params=dict(kernel='rbf', C=10, gamma=1, cache_size=2000, probability=True))
 
     operation = strategy.fit(train_data)
-    prediction = strategy.predict(operation, test_data,
-                                  is_fit_pipeline_stage=False)
+    prediction = strategy.predict(operation, test_data)
 
     assert isinstance(prediction, OutputData)

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -9,7 +9,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 
 from cases.metocean_forecasting_problem import prepare_input_data
-from examples.advanced.multi_modal_pipeline import prepare_multi_modal_data
 from fedot.api.api_utils.api_composer import _divide_parameters
 from fedot.api.api_utils.api_data import ApiDataProcessor
 from fedot.api.main import Fedot

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -604,7 +604,7 @@ def test_correctness_resample_operation_with_expand_minority(n_samples, target_d
 
     data = get_unbalanced_dataset(target_dim=target_dim)
 
-    assert resample.transform(data, is_fit_pipeline_stage=True).predict.shape == expected
+    assert resample.transform_for_fit(data).predict.shape == expected
 
 @pytest.mark.parametrize(
     'n_samples, target_dim, expected',
@@ -618,4 +618,4 @@ def test_correctness_resample_operation_with_reduce_majority(n_samples, target_d
 
     data = get_unbalanced_dataset(target_dim=target_dim)
 
-    assert resample.transform(data, is_fit_pipeline_stage=True).predict.shape == expected
+    assert resample.transform_for_fit(data).predict.shape == expected

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -333,7 +333,7 @@ def test_ts_forecasting_cut_data_operation():
     horizon = train_input.task.task_params.forecast_length
     operation_cut = CutImplementation(cut_part=0.5)
 
-    transformed_input = operation_cut.transform(train_input, is_fit_pipeline_stage=True)
+    transformed_input = operation_cut.transform_for_fit(train_input)
     assert train_input.idx.shape[0] == 2 * transformed_input.idx.shape[0] - horizon
 
 
@@ -520,8 +520,8 @@ def test_lagged_with_multivariate_time_series():
     input_data = get_multivariate_time_series()
     lagged = LaggedTransformationImplementation(**{'window_size': 2})
 
-    transformed_for_fit = lagged.transform(input_data, is_fit_pipeline_stage=True)
-    transformed_for_predict = lagged.transform(input_data, is_fit_pipeline_stage=False)
+    transformed_for_fit = lagged.transform_for_fit(input_data)
+    transformed_for_predict = lagged.transform(input_data)
 
     # Check correctness on fit stage
     lagged_features = transformed_for_fit.predict
@@ -555,8 +555,8 @@ def test_lagged_with_multi_ts_type():
     correct_predict_output = np.array([[8, 9]])
     input_data = get_multivariate_time_series(mutli_ts=True)
     lagged = LaggedTransformationImplementation(**{'window_size': 2})
-    transformed_for_fit = lagged.transform(input_data, is_fit_pipeline_stage=True)
-    transformed_for_predict = lagged.transform(input_data, is_fit_pipeline_stage=False)
+    transformed_for_fit = lagged.transform_for_fit(input_data)
+    transformed_for_predict = lagged.transform(input_data)
 
     # Check correctness on fit stage
     lagged_features = transformed_for_fit.predict

--- a/test/unit/models/test_custom_model_introduction.py
+++ b/test/unit/models/test_custom_model_introduction.py
@@ -163,17 +163,19 @@ def get_simple_pipeline(multi_data):
 
 
 def test_pipeline_with_custom_node():
-    train_input, predict_input = get_input_data()
-    pipeline = get_centered_pipeline()
-    pipeline.fit_from_scratch(train_input)
-    predicted_centered = pipeline.predict(predict_input)
+    # train_input, predict_input = get_input_data()
+    # pipeline = get_centered_pipeline()
+    # #pipeline.show()
+    # pipeline.fit_from_scratch(train_input)
+    # predicted_centered = pipeline.predict(predict_input)
 
     train_input, predict_input = get_input_data()
     pipeline = get_starting_pipeline()
+    pipeline.show()
     pipeline.fit_from_scratch(train_input)
     predicted_starting = pipeline.predict(predict_input)
 
-    assert predicted_centered and predicted_starting is not None
+    assert  predicted_starting is not None
 
 
 def test_pipeline_with_custom_fitted_node():
@@ -208,6 +210,7 @@ def test_advanced_pipeline_with_custom_model():
     train_data, test_data = prepare_data()
 
     pipeline = get_simple_pipeline(train_data)
+    #pipeline.show()
 
     pipeline.fit_from_scratch(train_data)
     predicted_test = pipeline.predict(test_data)

--- a/test/unit/models/test_custom_model_introduction.py
+++ b/test/unit/models/test_custom_model_introduction.py
@@ -163,19 +163,17 @@ def get_simple_pipeline(multi_data):
 
 
 def test_pipeline_with_custom_node():
-    # train_input, predict_input = get_input_data()
-    # pipeline = get_centered_pipeline()
-    # #pipeline.show()
-    # pipeline.fit_from_scratch(train_input)
-    # predicted_centered = pipeline.predict(predict_input)
+    train_input, predict_input = get_input_data()
+    pipeline = get_centered_pipeline()
+    pipeline.fit_from_scratch(train_input)
+    predicted_centered = pipeline.predict(predict_input)
 
     train_input, predict_input = get_input_data()
     pipeline = get_starting_pipeline()
-    pipeline.show()
     pipeline.fit_from_scratch(train_input)
     predicted_starting = pipeline.predict(predict_input)
 
-    assert  predicted_starting is not None
+    assert predicted_centered and predicted_starting is not None
 
 
 def test_pipeline_with_custom_fitted_node():
@@ -210,7 +208,6 @@ def test_advanced_pipeline_with_custom_model():
     train_data, test_data = prepare_data()
 
     pipeline = get_simple_pipeline(train_data)
-    #pipeline.show()
 
     pipeline.fit_from_scratch(train_data)
     predicted_test = pipeline.predict(test_data)

--- a/test/unit/models/test_model.py
+++ b/test/unit/models/test_model.py
@@ -33,7 +33,7 @@ from test.unit.tasks.test_regression import get_synthetic_regression_data
 def check_predict_correct(model, fitted_operation, test_data):
     return is_predict_ignores_target(
         predict_func=model.predict,
-        predict_args={'fitted_operation': fitted_operation, 'is_fit_pipeline_stage': False},
+        predict_args={'fitted_operation': fitted_operation},
         data_arg_name='data',
         input_data=test_data,
     )
@@ -147,7 +147,7 @@ def test_classification_models_fit_predict_correct(data_fixture, request):
         logger.info(f"Test classification model: {model_name}.")
         model = Model(operation_type=model_name)
         fitted_operation, train_predicted = model.fit(params=None, data=train_data)
-        test_pred = model.predict(fitted_operation=fitted_operation, data=test_data, is_fit_pipeline_stage=False)
+        test_pred = model.predict(fitted_operation=fitted_operation, data=test_data)
         roc_on_test = get_roc_auc(valid_data=test_data,
                                   predicted_data=test_pred)
         if model_name not in ['bernb', 'multinb']:
@@ -172,7 +172,7 @@ def test_regression_models_fit_predict_correct():
         model = Model(operation_type=model_name)
 
         fitted_operation, train_predicted = model.fit(params=None, data=train_data)
-        test_pred = model.predict(fitted_operation=fitted_operation, data=test_data, is_fit_pipeline_stage=False)
+        test_pred = model.predict(fitted_operation=fitted_operation, data=test_data)
         rmse_value_test = mean_squared_error(y_true=test_data.target, y_pred=test_pred.predict)
 
         rmse_threshold = np.std(test_data.target) ** 2
@@ -197,7 +197,7 @@ def test_ts_models_fit_predict_correct():
             default_params = None
 
         fitted_operation, train_predicted = model.fit(params=default_params, data=deepcopy(train_data))
-        test_pred = model.predict(fitted_operation=fitted_operation, data=test_data, is_fit_pipeline_stage=False)
+        test_pred = model.predict(fitted_operation=fitted_operation, data=test_data)
         mae_value_test = mean_absolute_error(y_true=test_data.target, y_pred=test_pred.predict[0])
 
         mae_threshold = np.var(test_data.target) * 2
@@ -331,8 +331,8 @@ def test_ts_naive_average_forecast_correctly():
     train_input, predict_input, _ = synthetic_univariate_ts()
 
     model = NaiveAverageForecastImplementation(part_for_averaging=1.0)
-    fit_forecast = model.predict(train_input, is_fit_pipeline_stage=True)
-    predict_forecast = model.predict(predict_input, is_fit_pipeline_stage=False)
+    fit_forecast = model.predict_for_fit(train_input)
+    predict_forecast = model.predict(predict_input)
 
     # Check correctness during pipeline fit stage
     assert (10, 4) == fit_forecast.target.shape
@@ -349,8 +349,8 @@ def test_locf_forecast_correctly():
     model = RepeatLastValueImplementation(part_for_repeat=0.2)
 
     model.fit(train_input)
-    fit_forecast = model.predict(train_input, is_fit_pipeline_stage=True)
-    predict_forecast = model.predict(predict_input, is_fit_pipeline_stage=False)
+    fit_forecast = model.predict_for_fit(train_input)
+    predict_forecast = model.predict(predict_input)
 
     assert (8, 4) == fit_forecast.target.shape
     assert np.array_equal(fit_forecast.idx, np.array([3, 4, 5, 6, 7, 8, 9, 10]))

--- a/test/unit/models/test_model.py
+++ b/test/unit/models/test_model.py
@@ -292,7 +292,7 @@ def test_glm_indexes_correct():
     input_data = generate_simple_series()
     glm_impl = GLMImplementation(family="gaussian", link="identity")
     glm_impl.fit(input_data)
-    predicted = glm_impl.predict(input_data, is_fit_pipeline_stage=True)
+    predicted = glm_impl.predict_for_fit(input_data)
     pred_values = predicted.predict
     for i in range(9):
         assert pred_values[i, 0] - i < 0.5

--- a/test/unit/models/test_strategy.py
+++ b/test/unit/models/test_strategy.py
@@ -24,8 +24,7 @@ def test_vectorize_tfidf_strategy():
     vectorizer_fitted = vectorizer.fit(train_data)
 
     predicted = vectorizer.predict(trained_operation=vectorizer_fitted,
-                                   predict_data=test_data,
-                                   is_fit_pipeline_stage=False)
+                                   predict_data=test_data)
     predicted_labels = predicted.predict
 
     assert isinstance(vectorizer_fitted, TfidfVectorizer)

--- a/test/unit/test_logger.py
+++ b/test/unit/test_logger.py
@@ -66,7 +66,7 @@ def test_logger_write_logs_correctly():
 
     try:
         knn = Model(operation_type='knnreg')
-        model, _ = knn.fit(params=DEFAULT_PARAMS_STUB, data=train_data, is_fit_pipeline_stage=True)
+        model, _ = knn.fit(params=DEFAULT_PARAMS_STUB, data=train_data)
     except Exception:
         print('Captured error')
 


### PR DESCRIPTION
Predict and transform metods for fit and predict stage were separated. Changes have affected implementations of such classes as: 

- ```DataOperationImplementation```
- ```ModelImplementation```
- ```EvaluationStrategy```

Flag ```is_fit_pipeline_stage``` was removed.

#822