### PR TITLE
Fix & improve visualizations

### DIFF
--- a/examples/simple/pipeline_and_history_visualization.py
+++ b/examples/simple/pipeline_and_history_visualization.py
@@ -12,7 +12,7 @@ def run_pipeline_and_history_visualization(with_pipeline_visualization=True):
     pipeline = PipelineAdapter().restore(history.individuals[-1][-1].graph)
 
     history.show('fitness_line')
-    history.show('fitness_box', pct_best=0.5)
+    history.show('fitness_box', best_fraction=0.5)
     history.show('operations_kde')
     history.show('operations_animated_bar', save_path='example_animation.gif', show_fitness=True)
     if with_pipeline_visualization:

--- a/examples/simple/pipeline_visualization.py
+++ b/examples/simple/pipeline_visualization.py
@@ -1,0 +1,84 @@
+from fedot.core.log import default_log
+from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
+from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.pipelines.pipeline_builder import PipelineBuilder
+
+
+def generate_pipeline() -> Pipeline:
+    node_scaling = PrimaryNode('scaling')
+    node_first = SecondaryNode('kmeans', nodes_from=[node_scaling])
+    node_second = SecondaryNode('rf', nodes_from=[node_scaling])
+    node_third = SecondaryNode('linear', nodes_from=[node_scaling])
+    node_root = SecondaryNode('logit', nodes_from=[node_first, node_second, node_third, node_scaling])
+
+    return Pipeline(node_root)
+
+
+def show_default(pipeline: Pipeline):
+    """ Show with default properties via networkx. """
+    pipeline.show()
+
+
+def show_customized(pipeline: Pipeline):
+    """ Show with adjusted sizes and green nodes. """
+    pipeline.show(node_color='green', edge_curvature_scale=1.2, node_size_scale=2.0, font_size_scale=1.4)
+
+
+def show_custom_colors(pipeline: Pipeline):
+    """ Show with colors defined by label-color dictionary. """
+    pipeline.show(node_color={'scaling': 'tab:olive', 'rf': '#FF7F50', 'linear': (0, 1, 1), None: 'black'},
+                  edge_curvature_scale=1.2, node_size_scale=2.0, font_size_scale=1.4)
+
+
+def show_complex_colors(pipeline: Pipeline):
+    """ Show with colors defined by function. """
+    def nodes_color(labels):
+        if 'xgboost' in labels:
+            return {'xgboost': 'tab:orange', None: 'black'}
+        else:
+            return {'rf': 'tab:green', None: 'black'}
+
+    pipeline.show(node_color=nodes_color)
+
+
+def show_pyvis(pipeline: Pipeline):
+    """ Show with pyvis. """
+    pipeline.show(engine='pyvis')
+
+
+def show_pyvis_custom_colors(pipeline: Pipeline):
+    """ Show with pyvis with custom colors. """
+    pipeline.show(engine='pyvis',
+                  node_color={'scaling': 'tab:olive', 'rf': '#FF7F50', 'linear': (0, 1, 1), None: 'black'})
+
+
+def show_graphviz(pipeline: Pipeline):
+    """ Show with graphviz (requires Graphviz and pygraphviz). """
+    pipeline.show(engine='graphviz')
+
+
+def show_graphviz_custom_colors(pipeline: Pipeline):
+    """ Show with graphviz with custom colors (requires Graphviz and pygraphviz). """
+    pipeline.show(engine='graphviz',
+                  node_color={'scaling': 'tab:olive', 'rf': '#FF7F50', 'linear': (0, 1, 1), None: 'black'})
+
+
+def main():
+    pipeline = generate_pipeline()
+    show_default(pipeline)
+    show_customized(pipeline)
+    show_custom_colors(pipeline)
+    show_complex_colors(pipeline)
+    show_complex_colors(PipelineBuilder(*pipeline.nodes).add_node('xgboost').to_pipeline())
+    show_pyvis(pipeline)
+    show_pyvis_custom_colors(pipeline)
+    try:
+        import graphviz
+        show_graphviz(pipeline)
+        show_graphviz_custom_colors(pipeline)
+    except ImportError:
+        default_log().info('Either Graphviz or pygraphviz is not installed. Skipping visualizations.')
+
+
+if __name__ == '__main__':
+    main()

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -91,19 +91,19 @@ class Graph:
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
              node_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
-             node_size_factor: float = 1.0, font_size_factor: float = 1.0, edge_curvature_factor: float = 1.0):
+             node_size_scale: float = 1.0, font_size_scale: float = 1.0, edge_curvature_scale: float = 1.0):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.
         :param engine: engine to visualize the graph.
         :param node_color: color of nodes to use.
-        :param node_size_factor: use to make node size bigger or lesser.
-        :param font_size_factor: use to make font size bigger or lesser.
-        :param edge_curvature_factor: use to make edges more or less curved.
+        :param node_size_scale: use to make node size bigger or lesser.
+        :param font_size_scale: use to make font size bigger or lesser.
+        :param edge_curvature_scale: use to make edges more or less curved.
         :param dpi: DPI of the output image. Not used if engine='pyvis'.
         """
-        GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_factor, font_size_factor,
-                                    edge_curvature_factor)
+        GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_scale, font_size_scale,
+                                    edge_curvature_scale)
 
     def __eq__(self, other_graph: 'Graph') -> bool:
         """Compares this graph with the ``other_graph``

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -95,12 +95,12 @@ class Graph:
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.
-        :param engine: engine to visualize the graph.
+        :param engine: engine to visualize the graph. Possible values: 'matplotlib', 'pyvis', 'graphviz'.
         :param node_color: color of nodes to use.
-        :param node_size_scale: use to make node size bigger or lesser.
-        :param font_size_scale: use to make font size bigger or lesser.
-        :param edge_curvature_scale: use to make edges more or less curved.
-        :param dpi: DPI of the output image. Not used if engine='pyvis'.
+        :param node_size_scale: use to make node size bigger or lesser. Supported only for the engine 'matplotlib'.
+        :param font_size_scale: use to make font size bigger or lesser. Supported only for the engine 'matplotlib'.
+        :param edge_curvature_scale: use to make edges more or less curved. Supported only for the engine 'matplotlib'.
+        :param dpi: DPI of the output image. Not supported for the engine 'pyvis'.
         """
         GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_scale, font_size_scale,
                                     edge_curvature_scale)

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -5,7 +5,7 @@ from fedot.core.dag.graph_node import GraphNode
 from fedot.core.dag.graph_operator import GraphOperator
 from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
 from fedot.core.utils import copy_doc
-from fedot.core.visualisation.graph_viz import GraphVisualiser
+from fedot.core.visualisation.graph_viz import GraphVisualiser, NodeColorType
 
 if TYPE_CHECKING:
     from fedot.core.dag.graph_node import GraphNode
@@ -90,7 +90,7 @@ class Graph:
         return self._operator.get_edges()
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             node_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
+             node_color: Optional[NodeColorType] = None, dpi: int = 300,
              node_size_scale: float = 1.0, font_size_scale: float = 1.0, edge_curvature_scale: float = 1.0):
         """Visualizes graph or saves its picture to the specified ``path``
 

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -90,17 +90,20 @@ class Graph:
         return self._operator.get_edges()
 
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
-             edges_curvature: float = 0.3):
+             node_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
+             node_size_factor: float = 1.0, font_size_factor: float = 1.0, edge_curvature_factor: float = 1.0):
         """Visualizes graph or saves its picture to the specified ``path``
 
         :param save_path: optional, save location of the graph visualization image.
         :param engine: engine to visualize the graph.
-        :param nodes_color: color of nodes to use.
-        :param edges_curvature: used make edges more or less curved.
+        :param node_color: color of nodes to use.
+        :param node_size_factor: use to make node size bigger or lesser.
+        :param font_size_factor: use to make font size bigger or lesser.
+        :param edge_curvature_factor: use to make edges more or less curved.
         :param dpi: DPI of the output image. Not used if engine='pyvis'.
         """
-        GraphVisualiser().visualise(self, save_path, engine, nodes_color, dpi, edges_curvature)
+        GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_factor, font_size_factor,
+                                    edge_curvature_factor)
 
     def __eq__(self, other_graph: 'Graph') -> bool:
         """Compares this graph with the ``other_graph``

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -236,9 +236,9 @@ class OptGraph:
     @copy_doc(Graph.show)
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
              node_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
-             node_size_factor: float = 1.0, font_size_factor: float = 1.0, edge_curvature_factor: float = 1.0):
-        GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_factor,
-                                    font_size_factor, edge_curvature_factor)
+             node_size_scale: float = 1.0, font_size_scale: float = 1.0, edge_curvature_scale: float = 1.0):
+        GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_scale,
+                                    font_size_scale, edge_curvature_scale)
 
     @copy_doc(Graph.__eq__)
     def __eq__(self, other_graph: 'OptGraph') -> bool:

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -11,7 +11,7 @@ from fedot.core.dag.node_operator import NodeOperator
 from fedot.core.log import default_log
 from fedot.core.utilities.data_structures import UniqueList, ensure_wrapped_in_sequence
 from fedot.core.utils import DEFAULT_PARAMS_STUB, copy_doc
-from fedot.core.visualisation.graph_viz import GraphVisualiser
+from fedot.core.visualisation.graph_viz import GraphVisualiser, NodeColorType
 
 
 def node_ops_adaptation(func: Callable) -> Callable:
@@ -235,7 +235,7 @@ class OptGraph:
 
     @copy_doc(Graph.show)
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             node_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
+             node_color: Optional[NodeColorType] = None, dpi: int = 300,
              node_size_scale: float = 1.0, font_size_scale: float = 1.0, edge_curvature_scale: float = 1.0):
         GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_scale,
                                     font_size_scale, edge_curvature_scale)

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -235,9 +235,10 @@ class OptGraph:
 
     @copy_doc(Graph.show)
     def show(self, save_path: Optional[Union[os.PathLike, str]] = None, engine: str = 'matplotlib',
-             nodes_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
-             edges_curvature: float = 0.3):
-        GraphVisualiser().visualise(self, save_path, engine, nodes_color, dpi, edges_curvature)
+             node_color: Optional[Union[str, Tuple[float, float, float]]] = None, dpi: int = 300,
+             node_size_factor: float = 1.0, font_size_factor: float = 1.0, edge_curvature_factor: float = 1.0):
+        GraphVisualiser().visualise(self, save_path, engine, node_color, dpi, node_size_factor,
+                                    font_size_factor, edge_curvature_factor)
 
     @copy_doc(Graph.__eq__)
     def __eq__(self, other_graph: 'OptGraph') -> bool:

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -126,7 +126,7 @@ class OptHistory:
     def show(self, plot_type: Union[PlotTypesEnum, str] = PlotTypesEnum.fitness_box,
              save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
              best_fraction: Optional[float] = None, show_fitness: bool = True, per_time: bool = True,
-             use_repos_tags: bool = True):
+             use_tags: bool = True):
         """ Visualizes fitness values or operations used across generations.
 
         :param plot_type: visualization to show. Expected values are listed in
@@ -139,7 +139,7 @@ class OptHistory:
         :param show_fitness: if False, visualizations that support this parameter will not display fitness.
         :param per_time: Shows time axis instead of generations axis. Currently, supported for plot types:
             'show_fitness_line', 'show_fitness_line_interactive'.
-        :param use_repos_tags: if True (default), all operations in the history are colored and grouped based on FEDOT
+        :param use_tags: if True (default), all operations in the history are colored and grouped based on FEDOT
             repo tags. If False, operations are not grouped, colors are picked by fixed colormap for every history
             independently.
         """
@@ -179,13 +179,13 @@ class OptHistory:
         if plot_type is PlotTypesEnum.fitness_line:
             viz.visualize_fitness_line(self, per_time, save_path, dpi)
         elif plot_type is PlotTypesEnum.fitness_line_interactive:
-            viz.visualize_fitness_line_interactive(self, per_time, save_path, dpi, color_as_pipelines=use_repos_tags)
+            viz.visualize_fitness_line_interactive(self, per_time, save_path, dpi, use_tags)
         elif plot_type is PlotTypesEnum.fitness_box:
             viz.visualise_fitness_box(self, save_path, dpi, best_fraction)
         elif plot_type is PlotTypesEnum.operations_kde:
-            viz.visualize_operations_kde(self, save_path, dpi, best_fraction, use_repos_tags)
+            viz.visualize_operations_kde(self, save_path, dpi, best_fraction, use_tags)
         elif plot_type is PlotTypesEnum.operations_animated_bar:
-            viz.visualize_operations_animated_bar(self, save_path, dpi, best_fraction, show_fitness, use_repos_tags)
+            viz.visualize_operations_animated_bar(self, save_path, dpi, best_fraction, show_fitness, use_tags)
         else:
             raise NotImplementedError(f'Oops, plot type {plot_type.name} has no function to show!')
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -125,7 +125,8 @@ class OptHistory:
 
     def show(self, plot_type: Union[PlotTypesEnum, str] = PlotTypesEnum.fitness_box,
              save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
-             pct_best: Optional[float] = None, show_fitness: bool = True, per_time: bool = True):
+             pct_best: Optional[float] = None, show_fitness: bool = True, per_time: bool = True,
+             use_repos_tags: bool = True):
         """ Visualizes fitness values or operations used across generations.
 
         :param plot_type: visualization to show. Expected values are listed in
@@ -138,6 +139,9 @@ class OptHistory:
         :param show_fitness: if False, visualizations that support this parameter will not display fitness.
         :param per_time: Shows time axis instead of generations axis. Currently, supported for plot types:
             'show_fitness_line', 'show_fitness_line_interactive'.
+        :param use_repos_tags: if True (default), all operations in the history are colored and grouped based on FEDOT
+            repo tags. If False, operations are not grouped, colors are picked by fixed colormap for every history
+            independently.
         """
 
         def check_args_constraints():
@@ -175,13 +179,13 @@ class OptHistory:
         if plot_type is PlotTypesEnum.fitness_line:
             viz.visualize_fitness_line(self, per_time, save_path, dpi)
         elif plot_type is PlotTypesEnum.fitness_line_interactive:
-            viz.visualize_fitness_line_interactive(self, per_time, save_path, dpi)
+            viz.visualize_fitness_line_interactive(self, per_time, save_path, dpi, color_as_pipelines=use_repos_tags)
         elif plot_type is PlotTypesEnum.fitness_box:
             viz.visualise_fitness_box(self, save_path, dpi, pct_best)
         elif plot_type is PlotTypesEnum.operations_kde:
-            viz.visualize_operations_kde(self, save_path, dpi, pct_best)
+            viz.visualize_operations_kde(self, save_path, dpi, pct_best, use_repos_tags)
         elif plot_type is PlotTypesEnum.operations_animated_bar:
-            viz.visualize_operations_animated_bar(self, save_path, dpi, pct_best, show_fitness)
+            viz.visualize_operations_animated_bar(self, save_path, dpi, pct_best, show_fitness, use_repos_tags)
         else:
             raise NotImplementedError(f'Oops, plot type {plot_type.name} has no function to show!')
 

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -125,7 +125,7 @@ class OptHistory:
 
     def show(self, plot_type: Union[PlotTypesEnum, str] = PlotTypesEnum.fitness_box,
              save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
-             pct_best: Optional[float] = None, show_fitness: bool = True, per_time: bool = True,
+             best_fraction: Optional[float] = None, show_fitness: bool = True, per_time: bool = True,
              use_repos_tags: bool = True):
         """ Visualizes fitness values or operations used across generations.
 
@@ -134,7 +134,7 @@ class OptHistory:
         :param save_path: path to save the visualization. If set, then the image will be saved,
             and if not, it will be displayed. Essential for animations.
         :param dpi: DPI of the output figure.
-        :param pct_best: fraction of individuals with the best fitness per generation. The value should be in the
+        :param best_fraction: fraction of individuals with the best fitness per generation. The value should be in the
             interval (0, 1]. The other individuals are filtered out. The fraction will also be mentioned on the plot.
         :param show_fitness: if False, visualizations that support this parameter will not display fitness.
         :param per_time: Shows time axis instead of generations axis. Currently, supported for plot types:
@@ -146,10 +146,10 @@ class OptHistory:
 
         def check_args_constraints():
             nonlocal per_time
-            # Check supported cases for `pct_best`.
-            if pct_best is not None and \
-                    (pct_best <= 0 or pct_best > 1):
-                raise ValueError('`pct_best` parameter should be in the interval (0, 1].')
+            # Check supported cases for `best_fraction`.
+            if best_fraction is not None and \
+                    (best_fraction <= 0 or best_fraction > 1):
+                raise ValueError('`best_fraction` parameter should be in the interval (0, 1].')
             # Check supported cases for show_fitness == False.
             if not show_fitness and plot_type is not PlotTypesEnum.operations_animated_bar:
                 self._log.warning(f'Argument `show_fitness` is not supported for "{plot_type.name}". It is ignored.')
@@ -181,11 +181,11 @@ class OptHistory:
         elif plot_type is PlotTypesEnum.fitness_line_interactive:
             viz.visualize_fitness_line_interactive(self, per_time, save_path, dpi, color_as_pipelines=use_repos_tags)
         elif plot_type is PlotTypesEnum.fitness_box:
-            viz.visualise_fitness_box(self, save_path, dpi, pct_best)
+            viz.visualise_fitness_box(self, save_path, dpi, best_fraction)
         elif plot_type is PlotTypesEnum.operations_kde:
-            viz.visualize_operations_kde(self, save_path, dpi, pct_best, use_repos_tags)
+            viz.visualize_operations_kde(self, save_path, dpi, best_fraction, use_repos_tags)
         elif plot_type is PlotTypesEnum.operations_animated_bar:
-            viz.visualize_operations_animated_bar(self, save_path, dpi, pct_best, show_fitness, use_repos_tags)
+            viz.visualize_operations_animated_bar(self, save_path, dpi, best_fraction, show_fitness, use_repos_tags)
         else:
             raise NotImplementedError(f'Oops, plot type {plot_type.name} has no function to show!')
 

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -210,27 +210,27 @@ class GraphVisualiser:
                        font_size_scale)
         # The ongoing section defines curvature for all edges.
         #   This is 'connection style' for an edge that does not intersect any nodes.
-        CONNECTION_STYLE = 'arc3'
+        connection_style = 'arc3'
         #   This is 'connection style' template for an edge that is too close to any node and must bend around it.
         #   The curvature value is defined individually for each edge.
-        CONNECTION_STYLE_CURVED_TEMPLATE = CONNECTION_STYLE + ',rad={}'
-        DEFAULT_EDGE_CURVATURE = 0.3
+        connection_style_curved_template = connection_style + ',rad={}'
+        default_edge_curvature = 0.3
         #   The minimum distance from a node to an edge on which the edge must bend around the node.
-        NODE_DISTANCE_GAP = 0.15
+        node_distance_gap = 0.15
         for u, v, e in nx_graph.edges(data=True):
-            e['connectionstyle'] = CONNECTION_STYLE
+            e['connectionstyle'] = connection_style
             p_1, p_2 = np.array(pos[u]), np.array(pos[v])
             p_1_2 = p_2 - p_1
             p_1_2_length = np.linalg.norm(p_1_2)
             # Finding the closest node to the edge.
-            min_distance_found = NODE_DISTANCE_GAP * 2  # It just must be bigger than the gap.
+            min_distance_found = node_distance_gap * 2  # It just must be bigger than the gap.
             closest_node_id = None
             for node_id in nx_graph.nodes:
                 if node_id in (u, v):
                     continue  # The node is adjacent to the edge.
                 p_3 = np.array(pos[node_id])
                 distance_to_node = abs(np.cross(p_1_2, p_3 - p_1)) / p_1_2_length
-                if (distance_to_node > min(NODE_DISTANCE_GAP, min_distance_found)  # The node is too far.
+                if (distance_to_node > min(node_distance_gap, min_distance_found)  # The node is too far.
                         or ((p_3 - p_1) @ p_1_2) < 0  # There's no perpendicular from the node to the edge.
                         or ((p_3 - p_2) @ -p_1_2) < 0):
                     continue
@@ -242,7 +242,7 @@ class GraphVisualiser:
             # Finally, define the edge's curvature based on the closest node position.
             p_3 = np.array(pos[closest_node_id])
             p_1_3 = p_3 - p_1
-            curvature_strength = DEFAULT_EDGE_CURVATURE * edge_curvature_scale
+            curvature_strength = default_edge_curvature * edge_curvature_scale
             # 'alpha' denotes the angle between the abscissa and the edge.
             cos_alpha = p_1_2[0] / p_1_2_length
             sin_alpha = np.sqrt(1 - cos_alpha ** 2) * (-1) ** (p_1_2[1] < 0)
@@ -252,7 +252,7 @@ class GraphVisualiser:
             p_1_3_rotated = rotation_matrix @ p_1_3
             curvature_direction = (-1) ** (p_1_3_rotated[1] < 0)  # +1 is a "boat" \/, -1 is a "cat" /\.
             edge_curvature = curvature_direction * curvature_strength
-            e['connectionstyle'] = CONNECTION_STYLE_CURVED_TEMPLATE.format(edge_curvature)
+            e['connectionstyle'] = connection_style_curved_template.format(edge_curvature)
         # Draw the graph's edges.
         arrow_style = ArrowStyle('Simple', head_length=1.5, head_width=0.8)
         for u, v, e in nx_graph.edges(data=True):

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -297,7 +297,7 @@ def get_hierarchy_pos(graph: nx.DiGraph, max_line_length: int = 6) -> Tuple[Dict
     return pos, longest_sequence
 
 
-def remove_old_files_from_dir(dir: Path, time_interval=datetime.timedelta(minutes=10)):
-    for path in dir.iterdir():
+def remove_old_files_from_dir(dir_: Path, time_interval=datetime.timedelta(minutes=10)):
+    for path in dir_.iterdir():
         if datetime.datetime.now() - datetime.datetime.fromtimestamp(path.stat().st_ctime) > time_interval:
             path.unlink()

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -211,7 +211,7 @@ class GraphVisualiser:
         # The ongoing section defines curvature for all edges.
         #   This is 'connection style' for an edge that does not intersect any nodes.
         CONNECTION_STYLE = 'arc3'
-        #   This is 'connection style' template for an edge that is too close to any node and nust bend around it.
+        #   This is 'connection style' template for an edge that is too close to any node and must bend around it.
         #   The curvature value is defined individually for each edge.
         CONNECTION_STYLE_CURVED_TEMPLATE = CONNECTION_STYLE + ',rad={}'
         DEFAULT_EDGE_CURVATURE = 0.3

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -26,8 +26,8 @@ class GraphVisualiser:
 
     def visualise(self, graph: Union['Graph', 'OptGraph'], save_path: Optional[Union[os.PathLike, str]] = None,
                   engine: str = 'matplotlib', node_color: Optional[Union[str, Tuple[float, float, float]]] = None,
-                  dpi: int = 300, node_size_factor: float = 1.0, font_size_factor: float = 1.0,
-                  edge_curvature_factor: float = 1.0):
+                  dpi: int = 300, node_size_scale: float = 1.0, font_size_scale: float = 1.0,
+                  edge_curvature_scale: float = 1.0):
         if not graph.nodes:
             raise ValueError('Empty graph can not be visualized.')
         # Define colors
@@ -37,8 +37,8 @@ class GraphVisualiser:
             else:
                 node_color = self.__get_colors_by_labels
         if engine == 'matplotlib':
-            self.draw_with_networkx(graph, save_path, node_color, dpi, node_size_factor, font_size_factor,
-                                    edge_curvature_factor)
+            self.draw_with_networkx(graph, save_path, node_color, dpi, node_size_scale, font_size_scale,
+                                    edge_curvature_scale)
         elif engine == 'pyvis':
             self.draw_with_pyvis(graph, save_path, node_color)
         elif engine == 'graphviz':
@@ -134,12 +134,12 @@ class GraphVisualiser:
                            node_color: Optional[Union[str, Tuple[float, float, float],
                                                       Callable[
                                                            [List[str]], Dict[str, Tuple[float, float, float]]]]] = None,
-                           dpi: int = 300, node_size_factor: float = 1.0, font_size_factor: float = 1.0,
-                           edge_curvature_factor: float = 1.0,
+                           dpi: int = 300, node_size_scale: float = 1.0, font_size_scale: float = 1.0,
+                           edge_curvature_scale: float = 1.0,
                            in_graph_converter_function: Callable = graph_structure_as_nx_graph):
         fig, ax = plt.subplots(figsize=(7, 7))
         fig.set_dpi(dpi)
-        self.draw_nx_dag(graph, ax, node_color, node_size_factor, font_size_factor, edge_curvature_factor,
+        self.draw_nx_dag(graph, ax, node_color, node_size_scale, font_size_scale, edge_curvature_scale,
                          in_graph_converter_function)
         if not save_path:
             plt.show()
@@ -150,7 +150,7 @@ class GraphVisualiser:
     def draw_nx_dag(self, graph: Union['Graph', 'OptGraph'], ax: Optional[plt.Axes] = None,
                     node_color: Optional[Union[str, Tuple[float, float, float],
                                                Callable[[List[str]], Dict[str, Tuple[float, float, float]]]]] = None,
-                    node_size_factor: float = 1, font_size_factor: float = 1, edge_curvature_factor: float = 1,
+                    node_size_scale: float = 1, font_size_scale: float = 1, edge_curvature_scale: float = 1,
                     in_graph_converter_function: Callable = graph_structure_as_nx_graph):
 
         def get_scaled_node_size(nodes_amount):
@@ -174,13 +174,13 @@ class GraphVisualiser:
             node_data['hierarchy_level'] = nodes[node_id].distance_to_primary_level
         # Get nodes positions
         pos, longest_sequence = get_hierarchy_pos(nx_graph)
-        node_size = get_scaled_node_size(longest_sequence) * node_size_factor
+        node_size = get_scaled_node_size(longest_sequence) * node_size_scale
         # Draw the graph's nodes.
         nx.draw_networkx_nodes(nx_graph, pos, node_size=node_size, ax=ax, node_color='w', linewidths=3,
                                edgecolors=edge_colors)
         # Draw the graph's node labels.
         self._draw_nx_labels(pos, {node_id: str(node) for node_id, node in nodes.items()}, ax, longest_sequence,
-                             font_size_factor)
+                             font_size_scale)
         # The ongoing section defines curvature for all edges.
         #   This is 'connection style' for an edge that does not intersect any nodes.
         CONNECTION_STYLE = 'arc3'
@@ -215,7 +215,7 @@ class GraphVisualiser:
             # Finally, define the edge's curvature based on the closest node position.
             p_3 = np.array(pos[closest_node_id])
             p_1_3 = p_3 - p_1
-            curvature_strength = DEFAULT_EDGE_CURVATURE * edge_curvature_factor
+            curvature_strength = DEFAULT_EDGE_CURVATURE * edge_curvature_scale
             # 'alpha' denotes the angle between the abscissa and the edge.
             cos_alpha = p_1_2[0] / p_1_2_length
             sin_alpha = np.sqrt(1 - cos_alpha ** 2) * (-1) ** (p_1_2[1] < 0)
@@ -243,7 +243,7 @@ class GraphVisualiser:
         plt.tight_layout()
 
     @staticmethod
-    def _draw_nx_labels(pos, node_labels, ax, max_sequence_length, font_size_factor=1.0):
+    def _draw_nx_labels(pos, node_labels, ax, max_sequence_length, font_size_scale=1.0):
         def get_scaled_font_size(nodes_amount):
             min_size = 2
             max_size = 20
@@ -256,7 +256,7 @@ class GraphVisualiser:
         for node, (x, y) in pos.items():
             text = '\n'.join(wrap(node_labels[node].replace('_', ' ').replace('-', ' '), 10))
             ax.text(x, y, text, ha='center', va='center',
-                    fontsize=get_scaled_font_size(max_sequence_length) * font_size_factor,
+                    fontsize=get_scaled_font_size(max_sequence_length) * font_size_scale,
                     bbox=dict(alpha=0.9, color='w', boxstyle='round'))
 
 

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -30,9 +30,9 @@ class GraphVisualiser:
                   edge_curvature_scale: float = 1.0):
         if not graph.nodes:
             raise ValueError('Empty graph can not be visualized.')
-        # Define colors
+        # Define colors.
         if not node_color:
-            if type(graph).__name__ == 'Pipeline':
+            if type(graph).__name__ == 'Pipeline':  # This type check avoids circular imports.
                 node_color = self.__get_colors_by_tags
             else:
                 node_color = self.__get_colors_by_labels

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -31,7 +31,7 @@ class GraphVisualiser:
             raise ValueError('Empty graph can not be visualized.')
         # Define colors
         if not nodes_color:
-            if type(graph).__name__ in ('Pipeline', 'OptGraph'):
+            if type(graph).__name__ == 'Pipeline':
                 nodes_color = self.__get_colors_by_tags
             else:
                 nodes_color = self.__get_colors_by_labels

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -166,9 +166,8 @@ class GraphVisualiser:
         else:
             edge_colors = nodes_color
         # Define hierarchy_level
-        for u, v, e in nx_graph.edges(data=True):
-            for node_id in (u, v):
-                nx_graph.nodes[node_id]['hierarchy_level'] = nodes[node_id].distance_to_primary_level
+        for node_id, node_data in nx_graph.nodes(data=True):
+            node_data['hierarchy_level'] = nodes[node_id].distance_to_primary_level
         # Get nodes positions
         pos, longest_sequence = get_hierarchy_pos(nx_graph)
         node_size = get_scaled_node_size(longest_sequence)

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import os
 from copy import deepcopy
@@ -8,7 +10,7 @@ from os import remove
 from pathlib import Path
 from textwrap import wrap
 from time import time
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import matplotlib as mpl
 import numpy as np
@@ -18,12 +20,10 @@ from matplotlib import animation, cm, pyplot as plt, ticker
 from matplotlib.colors import Normalize
 from matplotlib.widgets import Button
 
-from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.utilities.requirements_notificator import warn_requirement
 
 try:
     import PIL
-
     from PIL import Image
 except ModuleNotFoundError:
     warn_requirement('Pillow')
@@ -31,11 +31,15 @@ except ModuleNotFoundError:
 
 from fedot.core.log import default_log
 from fedot.core.optimisers.fitness import null_fitness
+from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.pipelines.convert import pipeline_template_as_nx_graph
 from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_opt_node_tag
 from fedot.core.utils import default_fedot_data_dir
 from fedot.core.visualisation.graph_viz import GraphVisualiser
+
+if TYPE_CHECKING:
+    from fedot.core.optimisers.opt_history import OptHistory
 
 
 def with_alternate_matplotlib_backend(func):
@@ -433,7 +437,7 @@ class PipelineEvolutionVisualiser:
         axis.set_title(title)
         axis.grid(axis='y')
 
-    def visualize_fitness_line(self, history: 'OptHistory', per_time: bool = True,
+    def visualize_fitness_line(self, history: OptHistory, per_time: bool = True,
                                save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300):
         ax = plt.gca()
         if per_time:
@@ -446,7 +450,7 @@ class PipelineEvolutionVisualiser:
         self.__show_or_save_figure(plt.gcf(), save_path, dpi)
 
     @with_alternate_matplotlib_backend
-    def visualize_fitness_line_interactive(self, history: 'OptHistory', per_time: bool = True,
+    def visualize_fitness_line_interactive(self, history: OptHistory, per_time: bool = True,
                                            save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
                                            use_tags: bool = True):
         fig, axes = plt.subplots(1, 2, figsize=(15, 10))
@@ -521,7 +525,7 @@ class PipelineEvolutionVisualiser:
         self.__show_or_save_figure(fig, save_path, dpi)
 
     @staticmethod
-    def __get_history_dataframe(history: 'OptHistory', tags_model: Optional[List[str]] = None,
+    def __get_history_dataframe(history: OptHistory, tags_model: Optional[List[str]] = None,
                                 tags_data: Optional[List[str]] = None, best_fraction: Optional[float] = None,
                                 get_tags: bool = True):
         history_data = {
@@ -569,7 +573,7 @@ class PipelineEvolutionVisualiser:
 
         return df_history
 
-    def visualise_fitness_box(self, history: 'OptHistory', save_path: Optional[Union[os.PathLike, str]] = None,
+    def visualise_fitness_box(self, history: OptHistory, save_path: Optional[Union[os.PathLike, str]] = None,
                               dpi: int = 300, best_fraction: Optional[float] = None):
         """ Visualizes fitness values across generations in the form of boxplot.
 
@@ -607,7 +611,7 @@ class PipelineEvolutionVisualiser:
 
         self.__show_or_save_figure(fig, save_path, dpi)
 
-    def visualize_operations_kde(self, history: 'OptHistory', save_path: Optional[Union[os.PathLike, str]] = None,
+    def visualize_operations_kde(self, history: OptHistory, save_path: Optional[Union[os.PathLike, str]] = None,
                                  dpi: int = 300, best_fraction: Optional[float] = None, use_tags: bool = True,
                                  tags_model: Optional[List[str]] = None, tags_data: Optional[List[str]] = None):
         """ Visualizes operations used across generations in the form of KDE.
@@ -672,7 +676,7 @@ class PipelineEvolutionVisualiser:
 
         self.__show_or_save_figure(fig, save_path, dpi)
 
-    def visualize_operations_animated_bar(self, history: 'OptHistory', save_path: Union[os.PathLike, str],
+    def visualize_operations_animated_bar(self, history: OptHistory, save_path: Union[os.PathLike, str],
                                           dpi: int = 300, best_fraction: Optional[float] = None,
                                           show_fitness_color: bool = True, use_tags: bool = True,
                                           tags_model: Optional[List[str]] = None,

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -485,6 +485,7 @@ class PipelineEvolutionVisualiser:
                         graph = PipelineAdapter().restore(ind.graph)
                     graph.show(self.temp_path)
                     self.graph_images.append(plt.imread(str(self.temp_path)))
+                self.temp_path.unlink()
 
             def update_graph(self):
                 ax_graph.imshow(self.graph_images[self.index])

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -448,7 +448,7 @@ class PipelineEvolutionVisualiser:
     @with_alternate_matplotlib_backend
     def visualize_fitness_line_interactive(self, history: 'OptHistory', per_time: bool = True,
                                            save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
-                                           color_as_pipelines: bool = True):
+                                           use_tags: bool = True):
         fig, axes = plt.subplots(1, 2, figsize=(15, 10))
         ax_fitness, ax_graph = axes
 
@@ -481,7 +481,7 @@ class PipelineEvolutionVisualiser:
             def generate_graph_images(self):
                 for ind in self.best_individuals:
                     graph = ind.graph
-                    if color_as_pipelines:
+                    if use_tags:
                         graph = PipelineAdapter().restore(ind.graph)
                     graph.show(self.temp_path)
                     self.graph_images.append(plt.imread(str(self.temp_path)))

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from textwrap import wrap
 from time import time
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
-from warnings import warn
 
 import matplotlib as mpl
 import numpy as np
@@ -404,19 +403,20 @@ class PipelineEvolutionVisualiser:
         axis.step(best_eval_times, best_fitnesses, where='post', label=label)
 
         if with_generation_limits:
-            prev_time = gen_start_times[0]
+            axis_gen = axis.twiny()
+            axis_gen.set_xlim(axis.get_xlim())
+            axis_gen.set_xticks(gen_start_times, list(range(len(gen_start_times) - 1)) + [''])
+            axis_gen.locator_params(nbins=10)
+            axis_gen.set_xlabel('Generation')
+
+            gen_ticks = axis_gen.get_xticks()
+            prev_time = gen_ticks[0]
             axis.axvline(prev_time, color='k', linestyle='--', alpha=0.3)
-            for i, next_time in enumerate(gen_start_times[1:]):
+            for i, next_time in enumerate(gen_ticks[1:]):
                 axis.axvline(next_time, color='k', linestyle='--', alpha=0.3)
                 if i % 2 == 0:
                     axis.axvspan(prev_time, next_time, color='k', alpha=0.05)
                 prev_time = next_time
-
-            axis_gen = axis.twiny()
-            axis_gen.set_xlim(axis.get_xlim())
-            axis_gen.set_xticks(gen_start_times)
-            axis_gen.set_xticklabels(list(range(len(gen_start_times) - 1)) + [''])
-            axis_gen.set_xlabel('Generation')
 
         return best_individuals
 

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -98,6 +98,6 @@ def test_history_show_saving_plots(tmp_path, plot_type: PlotTypesEnum, generate_
     save_path = save_path.with_suffix('.gif') if plot_type is PlotTypesEnum.operations_animated_bar \
         else save_path.with_suffix('.png')
     history = generate_history
-    history.show(plot_type=plot_type, save_path=str(save_path), pct_best=0.1, dpi=100)
+    history.show(plot_type=plot_type, save_path=str(save_path), best_fraction=0.1, dpi=100)
     if plot_type is not PlotTypesEnum.fitness_line_interactive:
         assert save_path.exists()


### PR DESCRIPTION
There was a critical bug that did not allow showing graphs with a single node.
Besides, a few features were added:
- Improved graphs visual scalability and choice of edge curvature direction;
- Parametrized node size and font size;
- `OptGraph` now uses labels-based color map without use of repository tags;
- All `OptHistory` tags-based animations now can be shown without use of tags, thus they can now visualize non-ML evolution histories.