### PR TITLE
Restrict bugged networkx versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lightgbm >= 3.0.0
 xgboost >= 1.6.0 # to prevent warnings
 statsmodels >= 0.12.0
 ete3 >= 3.1.*
-networkx >= 2.4, < 2.8.1
+networkx >= 2.4, !=2.7.*, !=2.8.1, !=2.8.2, !=2.8.3
 scikit_learn
 scikit_learn >= 1.0.0; python_version == '3.7'
 scikit_learn >= 1.1.0; python_version >= '3.8'


### PR DESCRIPTION
As it is said [here](https://github.com/networkx/networkx/pull/5515#issue-1199131215) the [commit](https://github.com/networkx/networkx/commit/11db137b93f8f0b605cb8cefbeab21720348b9f7) related to networkx 2.7 breaks the order of layers in `multipartite_layout`, currently used for graphs visualization.

The [PR](https://github.com/networkx/networkx/pull/5705) fixes the issue. It relates to networkx 2.8.4, thus the versions 2.7, 2.8.1, 2.8.2 and 2.8.3 should not be used by FEDOT.