### PR TITLE
790 fix - Resample replace fix and operation refactoring

### DIFF
--- a/examples/simple/classification/resample_example.py
+++ b/examples/simple/classification/resample_example.py
@@ -3,9 +3,9 @@ import pandas as pd
 from sklearn.metrics import roc_auc_score as roc_auc
 from sklearn.model_selection import train_test_split
 
-from examples.simple.classification.classification_with_tuning import get_classification_dataset
-from examples.simple.classification.classification_pipelines import classification_pipeline_without_balancing,\
+from examples.simple.classification.classification_pipelines import classification_pipeline_without_balancing, \
     classification_pipeline_with_balancing
+from examples.simple.classification.classification_with_tuning import get_classification_dataset
 from fedot.core.composer.metrics import ROCAUC
 from fedot.core.data.data import InputData
 from fedot.core.repository.dataset_types import DataTypesEnum
@@ -54,7 +54,7 @@ def run_resample_example(path_to_data=None, tune=False):
                               task=task,
                               data_type=DataTypesEnum.table)
 
-    print(f'Begin fit Pipeline without balancing')
+    print('Begin fit Pipeline without balancing')
     # Pipeline without balancing
     pipeline = classification_pipeline_without_balancing()
     pipeline.fit_from_scratch(train_input)
@@ -68,7 +68,7 @@ def run_resample_example(path_to_data=None, tune=False):
     # Pipeline with balancing
     pipeline = classification_pipeline_with_balancing()
 
-    print(f'Begin fit Pipeline with balancing')
+    print('Begin fit Pipeline with balancing')
     # pipeline.fit(train_input)
     pipeline.fit_from_scratch(train_input)
 
@@ -79,7 +79,7 @@ def run_resample_example(path_to_data=None, tune=False):
     print(f'ROC-AUC of pipeline with balancing {roc_auc(y_test, preds):.4f}\n')
 
     if tune:
-        print(f'Start tuning process ...')
+        print('Start tuning process ...')
         tuned_pipeline = pipeline.fine_tune_all_nodes(iterations=50,
                                                       timeout=1,
                                                       input_data=train_input,
@@ -89,7 +89,7 @@ def run_resample_example(path_to_data=None, tune=False):
         predicted_values_tuned = tuned_pipeline.predict(predict_input)
         preds_tuned = predicted_values_tuned.predict
 
-        print(f'Obtained metrics after tuning:')
+        print('Obtained metrics after tuning:')
         print(f'ROC-AUC of tuned pipeline with balancing - {roc_auc(y_test, preds_tuned):.4f}\n')
 
 

--- a/examples/simple/classification/resample_example.py
+++ b/examples/simple/classification/resample_example.py
@@ -6,6 +6,7 @@ from sklearn.model_selection import train_test_split
 from examples.simple.classification.classification_with_tuning import get_classification_dataset
 from examples.simple.classification.classification_pipelines import classification_pipeline_without_balancing,\
     classification_pipeline_with_balancing
+from fedot.core.composer.metrics import ROCAUC
 from fedot.core.data.data import InputData
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import TaskTypesEnum, Task
@@ -82,7 +83,7 @@ def run_resample_example(path_to_data=None, tune=False):
         tuned_pipeline = pipeline.fine_tune_all_nodes(iterations=50,
                                                       timeout=1,
                                                       input_data=train_input,
-                                                      loss_function=roc_auc)
+                                                      loss_function=ROCAUC.metric)
 
         # Predict
         predicted_values_tuned = tuned_pipeline.predict(predict_input)

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_imbalanced_class.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_imbalanced_class.py
@@ -22,14 +22,14 @@ class ResampleImplementation(DataOperationImplementation):
 
     Args:
         balance: Data transformation strategy. Balance strategy can be 'expand_minority' or 'reduce_majority'.
-        In case of expand_minority elements of minor class are expanding to n_samples.
-        In otherwise with reduce_majority elements of major class are reducing to n_samples.
+            In case of expand_minority elements of minor class are expanding to n_samples.
+            In otherwise with reduce_majority elements of major class are reducing to n_samples.
         replace: Implements resampling with replacement. If False, this will implement (sliced) random permutations.
         balance_ratio: Transformation ratio can take values in the range [0, 1].
-        With balance_ratio = 0 nothing happens and data will remain the same.
-        In case of balance_ratio = 1 means that both classes will be balanced and the shape of both will become equal.
-        If balance_ratio < 1.0 means that the data of one class is getting closer to the shape of opposite class.
-        If None numbers of samples will be equal to the shape of opposite selected transformed class.
+            With balance_ratio = 0 nothing happens and data will remain the same.
+            In case of balance_ratio = 1 means that both classes will be balanced and the shape of both will become
+            equal. If balance_ratio < 1.0 means that the data of one class is getting closer to the shape of opposite
+            class. If None numbers of samples will be equal to the shape of opposite selected transformed class.
     """
 
     def __init__(self, **params: Optional[dict]):

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_imbalanced_class.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_imbalanced_class.py
@@ -17,19 +17,19 @@ GLOBAL_PREFIX = 'sklearn_imbalanced_class:'
 
 
 class ResampleImplementation(DataOperationImplementation):
-    """ Implementation of imbalanced bin class transformation for
+    """Implementation of imbalanced bin class transformation for
     classification task by using method from sklearn.utils.resample
 
-    :param balance: Data transformation strategy. Balance strategy can be 'expand_minority' or 'reduce_majority'.
-    In case of expand_minority elements of minor class are expanding to n_samples.
-    In otherwise with reduce_majority elements of major class are reducing to n_samples.
-    :param replace: Implements resampling with replacement. If False, this will implement (sliced) random permutations.
-    :param n_samples: Value of samples for transformation. The n_samples can take values in the range [0, 2].
-    With n_samples = 0 nothing happens and data will remain the same.
-    In case of n_samples = 1 means that both classes will be balanced and the shape of both will become equal.
-    If n_samples < 1.0 means that the data of one class is getting closer to the shape of opposite class.
-    In rest case, when n_samples > 1.0 the data of one class is surpass in shape of opposite class.
-    If None numbers of samples will be equal to the shape of opposite selected transformed class.
+    Args:
+        balance: Data transformation strategy. Balance strategy can be 'expand_minority' or 'reduce_majority'.
+        In case of expand_minority elements of minor class are expanding to n_samples.
+        In otherwise with reduce_majority elements of major class are reducing to n_samples.
+        replace: Implements resampling with replacement. If False, this will implement (sliced) random permutations.
+        balance_ratio: Transformation ratio can take values in the range [0, 1].
+        With balance_ratio = 0 nothing happens and data will remain the same.
+        In case of balance_ratio = 1 means that both classes will be balanced and the shape of both will become equal.
+        If balance_ratio < 1.0 means that the data of one class is getting closer to the shape of opposite class.
+        If None numbers of samples will be equal to the shape of opposite selected transformed class.
     """
 
     def __init__(self, **params: Optional[dict]):
@@ -37,24 +37,27 @@ class ResampleImplementation(DataOperationImplementation):
 
         self.balance = params.get('balance') if params.get('balance') is not None else 'expand_minority'
         self.replace = params.get('replace') if params.get('replace') is not None else False
-        self.n_samples = params.get('n_samples') if params.get('n_samples') is not None else 1.0
+        self.balance_ratio = params.get('balance_ratio') if params.get('balance_ratio') is not None else 1.0
+        self.n_samples = None
         self.parameters_changed = False
 
         self.log = default_log(self)
 
     def fit(self, input_data: Optional[InputData]):
-        """ Class doesn't support fit operation
+        """Class doesn't support fit operation
 
-        :param input_data: data with features, target and ids to process
+        Args:
+            input_data: data with features, target and ids to process
         """
         pass
 
     def get_params(self):
-        """ Method return parameters """
+        """Method return parameters
+        """
         params_dict = {
             'balance': self.balance,
             'replace': self.replace,
-            'n_samples': self.n_samples,
+            'balance_ratio': self.balance_ratio,
         }
         if self.parameters_changed is True:
             return tuple([params_dict, ['replace']])
@@ -62,20 +65,26 @@ class ResampleImplementation(DataOperationImplementation):
             return params_dict
 
     def transform(self, input_data: InputData) -> OutputData:
-        """ Transformed input data via selected balance strategy for predict stage
+        """Transformed input data via selected balance strategy for predict stage
 
-        :param input_data: data with features, target and ids to process
-        :return: output_data: transformed input_data via strategy
+        Args:
+            input_data: data with features, target and ids to process
+
+        Returns:
+            output_data: transformed input_data via strategy
         """
         output_data = self._convert_to_output(input_data, input_data.features,
                                               data_type=input_data.data_type)
         return output_data
 
     def transform_for_fit(self, input_data: InputData) -> OutputData:
-        """ Transformed input data via selected balance strategy for fit stage
+        """Transformed input data via selected balance strategy for fit stage
 
-        :param input_data: data with features, target and ids to process
-        :return: output_data: transformed input_data via strategy
+        Args:
+            input_data: data with features, target and ids to process
+
+        Returns:
+            output_data: transformed input_data via strategy
         """
         copied_data = copy(input_data)
 
@@ -92,21 +101,23 @@ class ResampleImplementation(DataOperationImplementation):
         min_data, maj_data = self._get_data_by_target(copied_data.features, copied_data.target,
                                                       unique_class, number_of_elements)
 
+        self.parameters_changed = self._check_and_correct_balance_ratio_param()
         self.n_samples = self._convert_to_absolute(min_data, maj_data)
-
         self.parameters_changed = self._check_and_correct_replace_param(min_data, maj_data)
 
         if self.balance == 'expand_minority':
             prev_shape = min_data.shape
             min_data = self._resample_data(min_data)
-            self.log.debug(f'{GLOBAL_PREFIX} According to {self.balance} data was changed from {prev_shape} to {min_data.shape}')
+            self.log.debug(
+                f'{GLOBAL_PREFIX} According to {self.balance} data was changed from {prev_shape} to {min_data.shape}'
+            )
 
         elif self.balance == 'reduce_majority':
             prev_shape = maj_data.shape
             maj_data = self._resample_data(maj_data)
-            self.log.debug(f'{GLOBAL_PREFIX} According to {self.balance} data was changed from {prev_shape} to {maj_data.shape}')
-
-        self.n_samples = self._convert_to_relative(min_data, maj_data)
+            self.log.debug(
+                f'{GLOBAL_PREFIX} According to {self.balance} data was changed from {prev_shape} to {maj_data.shape}'
+            )
 
         transformed_data = np.concatenate((min_data, maj_data), axis=0).transpose()
 
@@ -123,7 +134,8 @@ class ResampleImplementation(DataOperationImplementation):
     @staticmethod
     def _get_data_by_target(features: np.array, target: np.array, unique: np.array,
                             number_of_elements: np.array) -> np.array:
-        """ Unify features and target in one array and split into classes """
+        """Unify features and target in one array and split into classes
+        """
         if number_of_elements[0] < number_of_elements[1]:
             min_idx = np.where(target == unique[0])[0]
             maj_idx = np.where(target == unique[1])[0]
@@ -137,17 +149,17 @@ class ResampleImplementation(DataOperationImplementation):
         return minority_data, majority_data
 
     def _check_and_correct_replace_param(self, min_data: np.array, maj_data: np.array) -> bool:
-        """ Method checks if selected replace parameter is correct
+        """Method checks if selected replace parameter is correct
 
-        :param min_data: minority data from input data
-        :param maj_data: majority data from input data
+        Args:
+            min_data: minority data from input data
+            maj_data: majority data from input data
         """
         was_changed = False
 
         if self.replace is False:
             if self.balance == 'expand_minority' and self.n_samples >= min_data.shape[0]:
                 self.replace, was_changed = True, True
-
             elif self.balance == 'reduce_majority' and self.n_samples >= maj_data.shape[0]:
                 self.replace, was_changed = True, True
 
@@ -155,24 +167,26 @@ class ResampleImplementation(DataOperationImplementation):
 
         return was_changed
 
+    def _check_and_correct_balance_ratio_param(self) -> bool:
+        """Method checks if selected balance_ratio parameter is correct
+        """
+        was_changed = False
+
+        if self.balance_ratio < 0 or self.balance_ratio > 1:
+            self.balance_ratio = 1
+            self.log.debug(f'{GLOBAL_PREFIX} balance ratio set to full balance')
+
+        return was_changed
+
     def _convert_to_absolute(self, min_data: np.array, maj_data: np.array) -> float:
-        self.log.debug(f'{GLOBAL_PREFIX} n_samples was converted to absolute values')
+        self.log.debug(f'{GLOBAL_PREFIX} set n_samples in absolute values due to balance_ratio')
         difference = maj_data.shape[0] - min_data.shape[0]
 
         if self.balance == 'expand_minority':
-            return round(difference * self.n_samples + min_data.shape[0])
+            return round(difference * self.balance_ratio + min_data.shape[0])
 
         elif self.balance == 'reduce_majority':
-            return round(maj_data.shape[0] - difference * self.n_samples)
-
-    def _convert_to_relative(self, min_data: np.array, maj_data: np.array) -> float:
-        self.log.debug(f'{GLOBAL_PREFIX} n_samples was converted to relative values')
-
-        if self.balance == 'expand_minority':
-            return round(self.n_samples / maj_data.shape[0], 2)
-
-        elif self.balance == 'reduce_majority':
-            return round(self.n_samples / min_data.shape[0], 2)
+            return round(maj_data.shape[0] - difference * self.balance_ratio)
 
     def _resample_data(self, data: np.array):
         return resample(data, replace=self.replace, n_samples=self.n_samples)

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -284,7 +284,7 @@ class SearchSpace:
             'resample': {
                 'balance': (hp.choice, [['expand_minority', 'reduce_majority']]),
                 'replace': (hp.choice, [[True, False]]),
-                'n_samples': (hp.uniform, [0.3, 1])
+                'balance_ratio': (hp.uniform, [0.3, 1])
             },
             'lda': {
                 'solver': (hp.choice, [['svd', 'lsqr', 'eigen']]),

--- a/fedot/core/repository/data/default_operation_params.json
+++ b/fedot/core/repository/data/default_operation_params.json
@@ -121,8 +121,8 @@
   },
   "resample": {
     "balance": "expand_minority",
-    "replace": true,
-    "n_samples": 1
+    "replace": false,
+    "balance_ratio": 1
   },
   "pca": {
     "svd_solver": "full",

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -583,36 +583,39 @@ def test_poly_features_on_big_datasets():
     n_rows, n_cols = transformed_features.predict.shape
     assert n_cols == 85
 
+
 @pytest.mark.parametrize(
-    'n_samples, target_dim, expected',
+    'balance_ratio, target_dim, expected',
     [(None, 1, (12, 2)), (None, 2, (12, 2)),
      (0.5, 1, (11, 2)), (0.5, 2, (11, 2)),
-     (1.5, 1, (13, 2)), (1.5, 2, (13, 2))]
+     (1.5, 1, (12, 2)), (1.5, 2, (12, 2))]
 )
-def test_correctness_resample_operation_with_expand_minority(n_samples, target_dim, expected):
-    params = {'balance': 'expand_minority', 'replace': False, 'n_samples': n_samples}
+def test_correctness_resample_operation_with_expand_minority(balance_ratio, target_dim, expected):
+    params = {'balance': 'expand_minority', 'replace': False, 'balance_ratio': balance_ratio}
     resample = ResampleImplementation(**params)
 
     data = get_unbalanced_dataset(target_dim=target_dim)
 
     assert resample.transform_for_fit(data).predict.shape == expected
 
+
 @pytest.mark.parametrize(
-    'n_samples, target_dim, expected',
+    'balance_ratio, target_dim, expected',
     [(None, 1, (8, 2)), (None, 2, (8, 2)),
      (0.5, 1, (9, 2)), (0.5, 2, (9, 2)),
-     (1.5, 1, (7, 2)), (1.5, 2, (7, 2))]
+     (1.5, 1, (8, 2)), (1.5, 2, (8, 2))]
 )
-def test_correctness_resample_operation_with_reduce_majority(n_samples, target_dim, expected):
-    params = {'balance': 'reduce_majority', 'replace': False, 'n_samples': n_samples}
+def test_correctness_resample_operation_with_reduce_majority(balance_ratio, target_dim, expected):
+    params = {'balance': 'reduce_majority', 'replace': False, 'balance_ratio': balance_ratio}
     resample = ResampleImplementation(**params)
 
     data = get_unbalanced_dataset(target_dim=target_dim)
 
     assert resample.transform_for_fit(data).predict.shape == expected
 
+
 @pytest.mark.parametrize(
-    'strategy, n_samples, disbalance, expected',
+    'strategy, balance_ratio, disbalance, expected',
     [('expand_minority', 0.5, 0.4, True), ('expand_minority', 0.5, 0.2, True),
      ('expand_minority', 1, 0.4, True), ('expand_minority', 1, 0.2, True),
      ('expand_minority', 1.5, 0.4, True), ('expand_minority', 1.5, 0.2, True),
@@ -620,13 +623,13 @@ def test_correctness_resample_operation_with_reduce_majority(n_samples, target_d
      ('reduce_majority', 1, 0.4, False), ('reduce_majority', 1, 0.2, False),
      ('reduce_majority', 1.5, 0.4, False), ('reduce_majority', 1.5, 0.2, False)]
 )
-def test_correctness_resample_operation_with_dynamic_replace_param(strategy, n_samples, disbalance, expected):
+def test_correctness_resample_operation_with_dynamic_replace_param(strategy, balance_ratio, disbalance, expected):
     """
     Default params for replace is False.
     In case of expanding strategy it causes difficulties and needed to change replace param to True.
     It is required to avoid error in sklearn method, which cannot reuse data if replace is False.
     """
-    params = {'balance': strategy, 'replace': False, 'n_samples': n_samples}
+    params = {'balance': strategy, 'replace': False, 'balance_ratio': balance_ratio}
 
     resample = ResampleImplementation(**params)
 


### PR DESCRIPTION
Solving another problem with resample operation from Issue https://github.com/nccr-itmo/FEDOT/issues/790. 
Bug was in replace parameter. In case of expanding strategy it causes difficulties and needed to change replace param to True. It is required to avoid error in sklearn method, which cannot create data if replace is False. Solution is to check this parameter and dynamically change it in process when it is required.