### PR TITLE
Fix preprocessing tests on python 3.7

### DIFF
--- a/test/unit/preprocessing/test_pipeline_preprocessing.py
+++ b/test/unit/preprocessing/test_pipeline_preprocessing.py
@@ -32,7 +32,7 @@ def data_with_mixed_types_in_each_column(multi_output: bool = False):
                          [np.nan, 8, 'a', 1, 1],
                          [np.nan, np.nan, np.nan, np.nan, np.nan],
                          [np.nan, '4', 'b', 0, 0],
-                         [np.nan, '5', 'c', -1, -1]], dtype=object)
+                         [np.nan, '5', 1, -1, -1]], dtype=object)
     if multi_output:
         # Multi-label classification problem solved
         target = np.array([['label_1', 2],
@@ -46,7 +46,7 @@ def data_with_mixed_types_in_each_column(multi_output: bool = False):
                            [0, '9']], dtype=object)
     else:
         target = np.array(['label_1', 'label_1', 'label_0', 'label_0', 'label_0', 1, 0, 1, 0], dtype=object)
-    input_data = InputData(idx=[0, 1, 2, 3, 4, 5, 6, 7, 8], features=features,
+    input_data = InputData(idx=np.arange(9), features=features,
                            target=target, task=task, data_type=DataTypesEnum.table,
                            supplementary_data=SupplementaryData(was_preprocessed=False))
     return input_data

--- a/test/unit/preprocessing/test_preprocessors.py
+++ b/test/unit/preprocessing/test_preprocessors.py
@@ -133,7 +133,7 @@ def test_column_types_converting_correctly():
     features_types = data.supplementary_data.column_types['features']
     target_types = data.supplementary_data.column_types['target']
 
-    assert len(features_types) == 3
+    assert len(features_types) == 4
     assert len(target_types) == 2
     assert features_types[0] == "<class 'str'>"
     assert features_types[1] == "<class 'str'>"


### PR DESCRIPTION
Minor fix due to the fact that ohe in python 3.7 can not transform arrays with np.nan, it is possible since python version >= 3.8. 
**Explanation:**
In the failed test (_test_data_with_mixed_types_per_column_processed_correctly_), the data was split so that the type of the training part was defined as numerical with some str values + unique values count was < 13, so the final type of this column is a string. So firstly column was transformes to numerical (to avoid treating '1.0' and '1' numbers as different in general case) and then to categorical. Since there was only one truly string value in the test part, when preparing for the predict and going through a similar transformation path as for fit, when converting to a numeric value, we got np.nan, which could not be further encoded. 
