### PR TITLE
Hotfix OptHistory serialization

### DIFF
--- a/fedot/core/serializers/coders/opt_history_serialization.py
+++ b/fedot/core/serializers/coders/opt_history_serialization.py
@@ -18,12 +18,12 @@ def _flatten_generations_list(generations_list: List[List[Individual]]) -> List[
                 parents_map[parent.uid] = parent
                 extract_intermediate_parents(parent)
 
-    uid_to_individual_map = {ind.uid: ind for ind in reversed(list(chain(*generations_list)))}
+    generations_map = {ind.uid: ind for ind in chain(*generations_list)}
     parents_map = {}
-    for individual in uid_to_individual_map.values():
+    for individual in generations_map.values():
         extract_intermediate_parents(individual)
-    uid_to_individual_map.update(parents_map)
-    individuals_pool = list(uid_to_individual_map.values())
+    parents_map.update(generations_map)
+    individuals_pool = list(parents_map.values())
     return individuals_pool
 
 

--- a/fedot/core/serializers/serializer.py
+++ b/fedot/core/serializers/serializer.py
@@ -59,7 +59,8 @@ class Serializer(JSONEncoder, JSONDecoder):
             Serializer.CODERS_BY_TYPE = {
                 Objective: basic_serialization,
                 Fitness: basic_serialization,
-                Individual: {_to_json: any_to_json, _from_json: any_from_json},
+                Individual: basic_serialization,
+                NodeMetadata: basic_serialization,
                 GraphNode: {_to_json: graph_node_to_json, _from_json: any_from_json},
                 Graph: {_to_json: any_to_json, _from_json: graph_from_json},
                 Operation: {_to_json: operation_to_json, _from_json: any_from_json},
@@ -67,7 +68,6 @@ class Serializer(JSONEncoder, JSONDecoder):
                 ParentOperator: {_to_json: parent_operator_to_json, _from_json: parent_operator_from_json},
                 UUID: {_to_json: uuid_to_json, _from_json: uuid_from_json},
                 ComparableEnum: {_to_json: enum_to_json, _from_json: enum_from_json},
-                NodeMetadata: {_to_json: any_to_json, _from_json: any_from_json}
             }
             Serializer.CODERS_BY_TYPE.update({
                 OptNode: Serializer.CODERS_BY_TYPE[GraphNode],

--- a/test/integration/multiprocessing/test_history.py
+++ b/test/integration/multiprocessing/test_history.py
@@ -1,0 +1,5 @@
+from test.unit.composer.test_history import test_newly_generated_history
+
+
+def test_newly_generated_history_with_multiprocessing():
+    test_newly_generated_history(n_jobs=2)

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -126,8 +126,7 @@ def test_ancestor_for_crossover():
         assert crossover_result.parents[1].uid == parent_ind_second.uid
 
 
-@pytest.mark.parametrize('n_jobs', [1, 2])
-def test_newly_generated_history(n_jobs):
+def test_newly_generated_history(n_jobs=1):
     project_root_path = str(fedot_project_root())
     file_path_train = os.path.join(project_root_path, 'test/data/simple_classification.csv')
 
@@ -148,10 +147,8 @@ def test_newly_generated_history(n_jobs):
     dumped_history_json = history.save()
     loaded_history = OptHistory.load(dumped_history_json)
     assert dumped_history_json is not None
-    # TODO: remove the following condition when the issue is fixed: https://github.com/nccr-itmo/FEDOT/issues/896
-    if n_jobs == 1:
-        assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
-        _test_individuals_in_history(history)
+    assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
+    _test_individuals_in_history(history)
     _test_individuals_in_history(loaded_history)
 
 

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -48,6 +48,29 @@ def lagged_ridge_rfr_pipeline():
     return Pipeline(node_third)
 
 
+def _test_individuals_in_history(history: OptHistory):
+    uids = set()
+    ids = set()
+    for ind in chain(*history.individuals):
+        # All individuals in `history.individuals` must have a native generation.
+        assert ind.has_native_generation
+        assert ind.fitness
+        if ind.native_generation == 0:
+            continue
+        # All individuals must have parents, except for the initial assumptions.
+        assert ind.parents
+        # The first of `operators_from_prev_generation` must point to `parents_from_prev_generation`.
+        assert ind.parents_from_prev_generation == list(ind.operators_from_prev_generation[0].parent_individuals)
+
+        uids.add(ind.uid)
+        ids.add(id(ind))
+        for parent_operator in ind.operators_from_prev_generation:
+            uids.update({i.uid for i in parent_operator.parent_individuals})
+            ids.update({id(i) for i in parent_operator.parent_individuals})
+
+    assert len(uids) == len(ids)
+
+
 def test_parent_operator():
     pipeline = Pipeline(PrimaryNode('linear'))
     adapter = PipelineAdapter()
@@ -103,7 +126,8 @@ def test_ancestor_for_crossover():
         assert crossover_result.parents[1].uid == parent_ind_second.uid
 
 
-def test_newly_generated_history():
+@pytest.mark.parametrize('n_jobs', [1, 2])
+def test_newly_generated_history(n_jobs):
     project_root_path = str(fedot_project_root())
     file_path_train = os.path.join(project_root_path, 'test/data/simple_classification.csv')
 
@@ -111,7 +135,8 @@ def test_newly_generated_history():
     auto_model = Fedot(problem='classification', seed=42,
                        timeout=None,
                        num_of_generations=num_of_gens, pop_size=3,
-                       preset='fast_train')
+                       preset='fast_train',
+                       n_jobs=n_jobs)
     auto_model.fit(features=file_path_train, target='Y')
 
     history = auto_model.history
@@ -119,23 +144,15 @@ def test_newly_generated_history():
     assert auto_model.history is not None
     assert len(history.individuals) == num_of_gens + 1  # num_of_gens + initial assumption
     assert len(history.archive_history) == num_of_gens + 1  # num_of_gens + initial assumption
-    # Test individuals with the same uid are not copied
-    individuals = history.individuals
-    assert len({id(i): i for i in chain(*individuals)}) == len({i.uid: i for i in chain(*individuals)})
     # Test history dumps
-    dumped_history = history.save()
-    loaded_history = OptHistory.load(dumped_history).save()
-    assert dumped_history is not None
-    assert dumped_history == loaded_history, 'The history is not equal to itself after reloading!'
-    for ind in chain(*history.individuals):
-        # All individuals in `history.individuals` must have a native generation.
-        assert ind.has_native_generation
-        if ind.native_generation == 0:
-            continue
-        # All individuals must have parents, except for the initial assumptions.
-        assert ind.parents
-        # The first of `operators_from_prev_generation` must point to `parents_from_prev_generation`.
-        assert ind.parents_from_prev_generation == list(ind.operators_from_prev_generation[0].parent_individuals)
+    dumped_history_json = history.save()
+    loaded_history = OptHistory.load(dumped_history_json)
+    assert dumped_history_json is not None
+    # TODO: remove the following condition when the issue is fixed: https://github.com/nccr-itmo/FEDOT/issues/896
+    if n_jobs == 1:
+        assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
+        _test_individuals_in_history(history)
+    _test_individuals_in_history(loaded_history)
 
 
 def assert_intermediate_metrics(pipeline: Graph):
@@ -214,14 +231,16 @@ def test_history_backward_compatibility():
                for parent_op in ind.operators_from_prev_generation
                for parent_ind in parent_op.parent_individuals)
     assert isinstance(history._objective, Objective)
+    _test_individuals_in_history(history)
 
 
 def test_history_correct_serialization():
     test_history_path = Path(fedot_project_root(), 'test', 'data', 'fast_train_classification_history.json')
 
     history = OptHistory.load(test_history_path)
-    dumped_history = history.save()
-    reloaded_history = OptHistory.load(dumped_history)
+    dumped_history_json = history.save()
+    reloaded_history = OptHistory.load(dumped_history_json)
 
     assert history.individuals == reloaded_history.individuals
-    assert dumped_history == reloaded_history.save(), 'The history is not equal to itself after reloading!'
+    assert dumped_history_json == reloaded_history.save(), 'The history is not equal to itself after reloading!'
+    _test_individuals_in_history(reloaded_history)


### PR DESCRIPTION
Hotfix for #896. Partly returns `OptHistory` consistency. 

**The main problem with history:** Sometimes initial assumptions (gen 0) are evaluated after increasing the population (gen 1) by mutations. In this case, individuals in gen 1 get parents without `native_generation` and `fitness`, because their parents are just copies of individuals from gen 0. Before these changes, not evaluated copies from "parents" were replacing the originals, and the final JSON got a bunch of individuals with empty `fitness` and `native_generation`. This bug was catched while evaluating cases in FEDOT.Web.

**Changes:** This PR makes `OptHistory` primarily choose individuals from generations when serializing. 