### PR TITLE
Hotfix matplotlib

### DIFF
--- a/fedot/core/visualisation/opt_history/operations_animated_bar.py
+++ b/fedot/core/visualisation/opt_history/operations_animated_bar.py
@@ -156,7 +156,7 @@ class OperationsAnimatedBar(HistoryVisualization):
             bar_color = smoothen_frames_data(bar_color, animation_frames_per_step, animation_interpolation_power)
             sm = cm.ScalarMappable(norm=Normalize(min_fitness, max_fitness), cmap=fitness_colormap)
             sm.set_array([])
-            fig.colorbar(sm, label=fitness_column_name)
+            fig.colorbar(sm, label=fitness_column_name, ax=ax)
 
         count = bar_data[0]
         color = bar_color[0] if show_fitness else [no_fitness_palette[tag] for tag in operations_found]


### PR DESCRIPTION
Pass an `ax` to `colorbar` according to [these changes](https://github.com/matplotlib/matplotlib/commit/5509ebbed92ba0dd90c03fa34713b5754c7007d0#diff-01b0c7a8c4445ae46a3c055ace167e99f59dcd54dbf04c84bca2132914d2f8dfR1247-R1263). 