### PR TITLE
Selection minor refactoring

### DIFF
--- a/examples/simple/time_series_forecasting/ts_pipelines.py
+++ b/examples/simple/time_series_forecasting/ts_pipelines.py
@@ -109,7 +109,7 @@ def ts_complex_ridge_pipeline():
 
     """
     pip_builder = PipelineBuilder() \
-        .add_sequence('lagged', 'rigde', branch_idx=0) \
+        .add_sequence('lagged', 'ridge', branch_idx=0) \
         .add_sequence('lagged', 'ridge', branch_idx=1).join_branches('ridge')
 
     pipeline = pip_builder.to_pipeline()

--- a/fedot/core/optimisers/gp_comp/operators/operator.py
+++ b/fedot/core/optimisers/gp_comp/operators/operator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional, TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING,  Callable, List, Optional
 
 from fedot.core.log import default_log
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
@@ -8,7 +8,7 @@ from fedot.core.optimisers.opt_history_objects.individual import Individual
 if TYPE_CHECKING:
     from fedot.core.optimisers.optimizer import GraphOptimizerParameters
 
-PopulationT = Sequence[Individual]  # TODO: provisional EvaluationOperator = Callable[[PopulationT], PopulationT]
+PopulationT = List[Individual]  # TODO: provisional EvaluationOperator = Callable[[PopulationT], PopulationT]
 EvaluationOperator = Callable[[PopulationT], PopulationT]
 
 

--- a/fedot/core/optimisers/gp_comp/operators/selection.py
+++ b/fedot/core/optimisers/gp_comp/operators/selection.py
@@ -1,7 +1,7 @@
 import math
 from copy import copy, deepcopy
 from random import choice, randint, sample
-from typing import List, Callable
+from typing import List, Callable, Optional
 
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
@@ -58,6 +58,7 @@ class Selection(Operator):
 
 
 def tournament_selection(individuals: PopulationT, pop_size: int, fraction: float = 0.1) -> PopulationT:
+    individuals = list({ind.uid: ind for ind in individuals}.values())
     group_size = math.ceil(len(individuals) * fraction)
     min_group_size = 2 if len(individuals) > 1 else 1
     group_size = max(group_size, min_group_size)
@@ -66,21 +67,21 @@ def tournament_selection(individuals: PopulationT, pop_size: int, fraction: floa
     for _ in range(iterations_limit):
         if len(chosen) >= pop_size:
             break
-        group = random_selection(individuals, group_size)
+        group = sample(individuals, group_size)
         best = max(group, key=lambda ind: ind.fitness)
-        if best.uid not in (c.uid for c in chosen):
-            chosen.append(best)
+        individuals.remove(best)
+        chosen.append(best)
     return chosen
 
 
 def random_selection(individuals: PopulationT, pop_size: int) -> PopulationT:
+    individuals = list({ind.uid: ind for ind in individuals}.values())
     if not individuals:
         return []
     if len(individuals) == 1:
-        return [individuals[0]] * pop_size
-    unique = list({ind.uid: ind for ind in individuals}.values())
-    sample_size = min(pop_size, len(unique))
-    return sample(unique, sample_size)
+        return individuals * pop_size
+    sample_size = min(pop_size, len(individuals))
+    return sample(individuals, sample_size)
 
 
 # Code of spea2 selection is modified part of DEAP library (Library URL: https://github.com/DEAP/deap).

--- a/fedot/core/optimisers/gp_comp/operators/selection.py
+++ b/fedot/core/optimisers/gp_comp/operators/selection.py
@@ -1,6 +1,6 @@
 import math
 from copy import copy, deepcopy
-from random import choice, randint
+from random import choice, randint, sample
 from typing import List, Callable
 
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
@@ -76,17 +76,11 @@ def tournament_selection(individuals: PopulationT, pop_size: int, fraction: floa
 def random_selection(individuals: PopulationT, pop_size: int) -> PopulationT:
     if not individuals:
         return []
-    if len(individuals) <= 1:
+    if len(individuals) == 1:
         return [individuals[0]] * pop_size
-    chosen = []
-    iterations_limit = pop_size * 10
-    for _ in range(iterations_limit):
-        if len(chosen) >= pop_size:
-            break
-        individual = choice(individuals)
-        if individual.uid not in (c.uid for c in chosen):
-            chosen.append(individual)
-    return chosen
+    unique = list({ind.uid: ind for ind in individuals}.values())
+    sample_size = min(pop_size, len(unique))
+    return sample(unique, sample_size)
 
 
 # Code of spea2 selection is modified part of DEAP library (Library URL: https://github.com/DEAP/deap).

--- a/fedot/core/optimisers/gp_comp/operators/selection.py
+++ b/fedot/core/optimisers/gp_comp/operators/selection.py
@@ -1,7 +1,7 @@
 import math
 from copy import copy, deepcopy
 from random import choice, randint, sample
-from typing import List, Callable, Optional
+from typing import List, Callable
 
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
 from fedot.core.utilities.data_structures import ComparableEnum as Enum

--- a/fedot/core/optimisers/gp_comp/operators/selection.py
+++ b/fedot/core/optimisers/gp_comp/operators/selection.py
@@ -1,6 +1,6 @@
 import functools
 import math
-from copy import copy, deepcopy
+from copy import copy
 from random import choice, randint, sample
 from typing import Callable, List, Optional
 
@@ -34,28 +34,7 @@ class Selection(Operator):
             raise ValueError(f'Required selection not found: {selection_type}')
 
     def individuals_selection(self, individuals: PopulationT) -> PopulationT:
-        pop_size = self.parameters.pop_size
-        if pop_size == len(individuals):
-            chosen = individuals
-        else:
-            chosen = []
-            remaining_individuals = copy(individuals)
-            remove_remaining_individuals = pop_size <= len(individuals)
-            # TODO: refactor this unnecessary param copying --
-            #  call selection without without self.__call__ and pass pop_size explicitly
-            old_requirements = deepcopy(self.parameters)
-            self.parameters.pop_size = 1
-            iterations_limit = pop_size * 10
-            for _ in range(iterations_limit):
-                if len(chosen) >= pop_size or not remaining_individuals:
-                    break
-                individual = self.__call__(remaining_individuals)[0]
-                if individual.uid not in (chosen_individual.uid for chosen_individual in chosen):
-                    chosen.append(individual)
-                    if remove_remaining_individuals:
-                        remaining_individuals.remove(individual)
-            self.parameters = old_requirements
-        return chosen
+        return self.__call__(individuals)
 
 
 def default_selection_behaviour(selection_func: Optional[Callable] = None, *, ensure_unique: bool = True,
@@ -78,8 +57,8 @@ def default_selection_behaviour(selection_func: Optional[Callable] = None, *, en
         return wrapper
 
     if selection_func:
-        return func_wrapper(selection_func)
-    return func_wrapper
+        return func_wrapper(selection_func)  # Allows to decorate without args.
+    return func_wrapper  # Allows to decorate with args but no selection_func specified.
 
 
 @default_selection_behaviour

--- a/test/unit/optimizer/test_selection_operators.py
+++ b/test/unit/optimizer/test_selection_operators.py
@@ -35,8 +35,8 @@ def obj_function() -> float:
 
 
 def test_tournament_selection():
-    num_of_inds = 2
-    population = rand_population_gener_and_eval(pop_size=4)
+    num_of_inds = 40
+    population = rand_population_gener_and_eval(pop_size=50)
     requirements = GPGraphOptimizerParameters(selection_types=[SelectionTypesEnum.tournament], pop_size=num_of_inds)
     selection = Selection(requirements)
     selected_individuals = selection(population)


### PR DESCRIPTION
- Made all selection types significantly faster.
- Made all selection types maintain default behavior: remove duplicate individuals and return a multiple instances of a single individual if only one individual was passed as a population.
- Made inheritance use one of competitive selection algorithms at a time, instead of their mixture.