### PR TITLE
Refactor opt history & fix serialization

### DIFF
--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -6,9 +6,9 @@ from fedot.api.main import Fedot
 from fedot.core.composer.gp_composer.specific_operators import boosting_mutation, parameter_change_mutation
 from fedot.core.dag.graph import Graph
 from fedot.core.optimisers.gp_comp.evaluation import SimpleDispatcher
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, Mutation
 from fedot.core.optimisers.objective import Objective, ObjectiveFunction
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimizer, GraphOptimizerParameters
 from fedot.core.optimisers.timer import OptimisationTimer
 from fedot.core.utils import fedot_project_root

--- a/examples/advanced/parallelization_comparison.py
+++ b/examples/advanced/parallelization_comparison.py
@@ -8,7 +8,7 @@ import pandas as pd
 from matplotlib import cm, colors, pyplot as plt
 
 from fedot.api.main import Fedot
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.utils import fedot_project_root
 
 

--- a/examples/simple/pipeline_and_history_visualization.py
+++ b/examples/simple/pipeline_and_history_visualization.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from fedot.core.optimisers.adapters import PipelineAdapter
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.utils import fedot_project_root
 
 

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -22,14 +22,13 @@ from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.operators.inheritance import GeneticSchemeTypesEnum
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_node_factory import PipelineOptNodeFactory
 from fedot.core.pipelines.tuning.tuner_builder import TunerBuilder
 from fedot.core.pipelines.tuning.unified import PipelineTuner
 from fedot.core.pipelines.verification import rules_by_task
-from fedot.core.repository.operation_types_repository import get_operations_for_task
 from fedot.core.repository.pipeline_operation_repository import PipelineOperationRepository
 from fedot.core.repository.quality_metrics_repository import MetricsRepository, MetricType, MetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -15,7 +15,7 @@ from fedot.core.constants import DEFAULT_API_TIMEOUT_MINUTES
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.data.visualisation import plot_biplot, plot_forecast, plot_roc_auc
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.ts_wrappers import out_of_sample_ts_forecast, convert_forecast_to_output
 from fedot.core.repository.quality_metrics_repository import MetricsRepository

--- a/fedot/core/adapter/adapter.py
+++ b/fedot/core/adapter/adapter.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from copy import deepcopy
-from typing import TypeVar, Generic, Type, Optional, Dict, Any, Callable, Tuple, Sequence, Union
+from typing import TYPE_CHECKING, TypeVar, Generic, Type, Optional, Dict, Any, Callable, Tuple, Sequence, Union
 
 from fedot.core.log import default_log
-from fedot.core.optimisers.gp_comp.individual import Individual
-from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.graph import OptGraph, OptNode
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.adapter.adapt_registry import AdaptRegistry
+
+if TYPE_CHECKING:
+    from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 
 DomainStructureType = TypeVar('DomainStructureType')
 

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -14,7 +14,7 @@ from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.initial_graphs_generator import InitialPopulationGenerator, GenerationFunction
 from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.opt_history import OptHistory, log_to_history
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory, log_to_history
 from fedot.core.optimisers.optimizer import GraphOptimizer, GraphOptimizerParameters, GraphGenerationParams
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_graph_generation_params import get_pipeline_generation_params

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -9,7 +9,7 @@ from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import Pipelin
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import PipelineObjectiveEvaluate
 from fedot.core.optimisers.objective.data_source_splitter import DataSourceSplitter
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphOptimizer
 from fedot.core.pipelines.pipeline import Pipeline
 

--- a/fedot/core/optimisers/archive/generation_keeper.py
+++ b/fedot/core/optimisers/archive/generation_keeper.py
@@ -4,9 +4,9 @@ from typing import Dict, Iterable, Sequence, Type
 import numpy as np
 
 from fedot.core.optimisers.fitness import is_metric_worse
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.objective.objective import Objective
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.repository.quality_metrics_repository import ComplexityMetricsEnum, MetricsEnum, QualityMetricsEnum
 from .individuals_containers import HallOfFame, ParetoFront
 

--- a/fedot/core/optimisers/archive/individuals_containers.py
+++ b/fedot/core/optimisers/archive/individuals_containers.py
@@ -3,8 +3,8 @@ from bisect import bisect_right
 from operator import eq
 from typing import Callable, Optional
 
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 
 
 class HallOfFame:

--- a/fedot/core/optimisers/gp_comp/evaluation.py
+++ b/fedot/core/optimisers/gp_comp/evaluation.py
@@ -12,9 +12,9 @@ from fedot.core.adapter import BaseOptimizationAdapter
 from fedot.core.dag.graph import Graph
 from fedot.core.log import default_log, Log
 from fedot.core.optimisers.fitness import Fitness
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import EvaluationOperator, PopulationT
 from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.optimisers.timer import Timer, get_forever_timer
 from fedot.core.pipelines.verification import verifier_for_task
 from fedot.remote.remote_evaluator import RemoteEvaluator

--- a/fedot/core/optimisers/gp_comp/gp_optimizer.py
+++ b/fedot/core/optimisers/gp_comp/gp_optimizer.py
@@ -5,7 +5,6 @@ from typing import Sequence, Callable
 from fedot.core.constants import MAXIMAL_ATTEMPTS_NUMBER, EVALUATION_ATTEMPTS_NUMBER
 from fedot.core.dag.graph import Graph
 from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.crossover import Crossover
 from fedot.core.optimisers.gp_comp.operators.elitism import Elitism
 from fedot.core.optimisers.gp_comp.operators.inheritance import Inheritance
@@ -19,6 +18,7 @@ from fedot.core.optimisers.gp_comp.parameters.population_size import init_adapti
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective.objective import Objective
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.optimisers.populational_optimizer import PopulationalOptimizer, EvaluationAttemptsError
 

--- a/fedot/core/optimisers/gp_comp/operators/crossover.py
+++ b/fedot/core/optimisers/gp_comp/operators/crossover.py
@@ -3,11 +3,12 @@ from random import choice, random
 from typing import Callable, Union, Iterable, Tuple, TYPE_CHECKING
 
 from fedot.core.adapter import register_native
-from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.gp_comp.gp_operators import equivalent_subtree, replace_subtrees
-from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptGraph
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
 

--- a/fedot/core/optimisers/gp_comp/operators/mutation.py
+++ b/fedot/core/optimisers/gp_comp/operators/mutation.py
@@ -9,10 +9,11 @@ from fedot.core.adapter import register_native
 from fedot.core.composer.advisor import RemoveType
 from fedot.core.dag.graph_node import GraphNode
 from fedot.core.optimisers.gp_comp.gp_operators import random_graph
-from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, Operator
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptGraph, OptNode
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.utilities.data_structures import ComparableEnum as Enum
 

--- a/fedot/core/optimisers/gp_comp/operators/operator.py
+++ b/fedot/core/optimisers/gp_comp/operators/operator.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 from typing import Sequence, Optional, TYPE_CHECKING, Callable
 
 from fedot.core.log import default_log
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 
 if TYPE_CHECKING:
     from fedot.core.optimisers.optimizer import GraphOptimizerParameters

--- a/fedot/core/optimisers/gp_comp/operators/regularization.py
+++ b/fedot/core/optimisers/gp_comp/operators/regularization.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
 
-from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT, EvaluationOperator, Operator
 from fedot.core.optimisers.graph import OptGraph
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.pipelines.node import Node
 from fedot.core.utilities.data_structures import ComparableEnum as Enum

--- a/fedot/core/optimisers/opt_history.py
+++ b/fedot/core/optimisers/opt_history.py
@@ -10,9 +10,7 @@ from typing import List, Optional, Sequence, Union
 from fedot.core.log import default_log
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.archive import GenerationKeeper
-# ParentOperator is needed for backward compatibility with older optimization histories.
-# This is a temporary solution until the issue #699 (https://github.com/nccr-itmo/FEDOT/issues/699) is closed.
-from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator  # noqa
+from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.objective import Objective
 from fedot.core.optimisers.utils.population_utils import get_metric_position

--- a/fedot/core/optimisers/opt_history_objects/individual.py
+++ b/fedot/core/optimisers/opt_history_objects/individual.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4
 
 from fedot.core.log import default_log
 from fedot.core.optimisers.fitness.fitness import Fitness, null_fitness
 from fedot.core.optimisers.graph import OptGraph
+
+if TYPE_CHECKING:
+    from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 
 INDIVIDUAL_COPY_RESTRICTION_MESSAGE = ('`Individual` instance was copied.\n'
                                        'Normally, you don\'t want to do that to keep uid-individual uniqueness.\n'
@@ -87,7 +90,7 @@ class Individual:
         return (f'<Individual {self.uid} | fitness: {self.fitness} | native_generation: {self.native_generation} '
                 f'| graph: {self.graph}>')
 
-    def __eq__(self, other: 'Individual'):
+    def __eq__(self, other: Individual):
         return self.uid == other.uid
 
     def __copy__(self):
@@ -105,21 +108,3 @@ class Individual:
         for k, v in self.__dict__.items():
             object.__setattr__(result, k, deepcopy(v, memo))
         return result
-
-
-@dataclass(frozen=True)
-class ParentOperator:
-    type_: str
-    operators: Union[Tuple[str, ...], str]
-    parent_individuals: Union[Tuple[Individual, ...], Individual] = field()
-    uid: str = field(default_factory=lambda: str(uuid4()), init=False)
-
-    def __post_init__(self):
-        if isinstance(self.operators, str):
-            object.__setattr__(self, 'operators', (self.operators,))
-        if isinstance(self.parent_individuals, Individual):
-            object.__setattr__(self, 'parent_individuals', (self.parent_individuals,))
-
-    def __repr__(self):
-        return (f'<ParentOperator {self.uid} | type: {self.type_} | operators: {self.operators} '
-                f'| parent_individuals({len(self.parent_individuals)}): {self.parent_individuals}>')

--- a/fedot/core/optimisers/opt_history_objects/opt_history.py
+++ b/fedot/core/optimisers/opt_history_objects/opt_history.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import io
 import itertools
@@ -5,13 +7,10 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Sequence, Union, TYPE_CHECKING
 
 from fedot.core.log import default_log
 from fedot.core.optimisers.adapters import PipelineAdapter
-from fedot.core.optimisers.archive import GenerationKeeper
-from fedot.core.optimisers.gp_comp.individual import Individual
-from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.objective import Objective
 from fedot.core.optimisers.utils.population_utils import get_metric_position
 from fedot.core.pipelines.template import PipelineTemplate
@@ -19,6 +18,11 @@ from fedot.core.repository.quality_metrics_repository import QualityMetricsEnum
 from fedot.core.serializers import Serializer
 from fedot.core.utils import default_fedot_data_dir
 from fedot.core.visualisation.opt_viz import OptHistoryVisualizer
+
+if TYPE_CHECKING:
+    from fedot.core.optimisers.archive import GenerationKeeper
+    from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
+    from fedot.core.optimisers.opt_history_objects.individual import Individual
 
 
 class OptHistory:

--- a/fedot/core/optimisers/opt_history_objects/parent_operator.py
+++ b/fedot/core/optimisers/opt_history_objects/parent_operator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Tuple, Union
+from uuid import uuid4
+
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
+
+
+@dataclass(frozen=True)
+class ParentOperator:
+    type_: str
+    operators: Union[Tuple[str, ...], str]
+    parent_individuals: Union[Iterable[Individual], Individual] = field()
+    uid: str = field(default_factory=lambda: str(uuid4()), init=False)
+
+    def __post_init__(self):
+        if isinstance(self.operators, str):
+            object.__setattr__(self, 'operators', (self.operators,))
+        parent_individuals = ensure_wrapped_in_sequence(self.parent_individuals)
+        object.__setattr__(self, 'parent_individuals', tuple(parent_individuals))
+
+    def __repr__(self):
+        return (f'<ParentOperator {self.uid} | type: {self.type_} | operators: {self.operators} '
+                f'| parent_individuals({len(self.parent_individuals)}): {self.parent_individuals}>')

--- a/fedot/core/serializers/coders/opt_history_serialization.py
+++ b/fedot/core/serializers/coders/opt_history_serialization.py
@@ -1,9 +1,9 @@
 from itertools import chain
 from typing import Any, Dict, List, Sequence, Type, Union
 
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.graph import OptGraph
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from . import any_from_json, any_to_json
 
 MISSING_INDIVIDUAL_ARGS = {
@@ -62,6 +62,7 @@ def _deserialize_generations_list(generations_list: List[List[Union[str, Individ
 def _deserialize_parent_individuals(individuals: List[Individual],
                                     uid_to_individual_map: Dict[str, Individual]):
     """The operation is executed in-place"""
+
     def deserialize_intermediate_parents(ind):
         parent_op = ind.parent_operator
         if not parent_op:

--- a/fedot/core/serializers/coders/parent_operator_serialization.py
+++ b/fedot/core/serializers/coders/parent_operator_serialization.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Type
 
-from fedot.core.optimisers.gp_comp.individual import ParentOperator
+from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 from . import any_from_json, any_to_json
 
 
@@ -15,5 +15,5 @@ def parent_operator_to_json(obj: ParentOperator) -> Dict[str, Any]:
 
 def parent_operator_from_json(cls: Type[ParentOperator], json_obj: Dict[str, Any]) -> ParentOperator:
     deserialized = any_from_json(cls, json_obj)
-    object.__setattr__(deserialized, 'parent_individuals', tuple(deserialized.parent_individuals))
+    object.__setattr__(deserialized, 'parent_individuals', deserialized.parent_individuals)
     return deserialized

--- a/fedot/core/serializers/serializer.py
+++ b/fedot/core/serializers/serializer.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 from inspect import isclass, isfunction, ismethod, signature
 from json import JSONDecoder, JSONEncoder
-from typing import Any, Callable, Dict, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
 
 from fedot.core.optimisers.fitness.fitness import Fitness
 from fedot.core.pipelines.node import NodeMetadata
@@ -12,11 +12,11 @@ INSTANCE_OR_CALLABLE = TypeVar('INSTANCE_OR_CALLABLE', object, Callable)
 CLASS_PATH_KEY = '_class_path'
 LEGACY_CLASS_PATHS = {
     'fedot.core.optimisers.gp_comp.individual/Individual':
-        f'fedot.core.optimisers.opt_history_objects.individual{MODULE_X_NAME_DELIMITER}Individual',
+        f'fedot.core.optimisers.opt_history_objects.individual/Individual',
     'fedot.core.optimisers.gp_comp.individual/ParentOperator':
-        f'fedot.core.optimisers.opt_history_objects.parent_operator{MODULE_X_NAME_DELIMITER}ParentOperator',
+        f'fedot.core.optimisers.opt_history_objects.parent_operator/ParentOperator',
     'fedot.core.optimisers.opt_history/OptHistory':
-        f'fedot.core.optimisers.opt_history_objects.opt_history{MODULE_X_NAME_DELIMITER}OptHistory',
+        f'fedot.core.optimisers.opt_history_objects.opt_history/OptHistory',
 }
 
 
@@ -89,7 +89,7 @@ class Serializer(JSONEncoder, JSONDecoder):
         return isinstance
 
     @staticmethod
-    def _get_base_type(obj: Union[INSTANCE_OR_CALLABLE, Type[INSTANCE_OR_CALLABLE]]) -> int:
+    def _get_base_type(obj: Union[INSTANCE_OR_CALLABLE, Type[INSTANCE_OR_CALLABLE]]) -> Optional[Type]:
         contains = Serializer._get_field_checker(obj)
         for k_type in Serializer.CODERS_BY_TYPE:
             if contains(obj, k_type):
@@ -147,6 +147,7 @@ class Serializer(JSONEncoder, JSONDecoder):
 
         :return: class, function or method type
         """
+        class_path = LEGACY_CLASS_PATHS.get(class_path) or class_path
         module_name, class_name = class_path.split(MODULE_X_NAME_DELIMITER)
         obj_cls = import_module(module_name)
         for sub in class_name.split('.'):

--- a/fedot/core/serializers/serializer.py
+++ b/fedot/core/serializers/serializer.py
@@ -10,6 +10,14 @@ from fedot.core.optimisers.objective.objective import Objective
 MODULE_X_NAME_DELIMITER = '/'
 INSTANCE_OR_CALLABLE = TypeVar('INSTANCE_OR_CALLABLE', object, Callable)
 CLASS_PATH_KEY = '_class_path'
+LEGACY_CLASS_PATHS = {
+    'fedot.core.optimisers.gp_comp.individual/Individual':
+        f'fedot.core.optimisers.opt_history_objects.individual{MODULE_X_NAME_DELIMITER}Individual',
+    'fedot.core.optimisers.gp_comp.individual/ParentOperator':
+        f'fedot.core.optimisers.opt_history_objects.parent_operator{MODULE_X_NAME_DELIMITER}ParentOperator',
+    'fedot.core.optimisers.opt_history/OptHistory':
+        f'fedot.core.optimisers.opt_history_objects.opt_history{MODULE_X_NAME_DELIMITER}OptHistory',
+}
 
 
 class Serializer(JSONEncoder, JSONDecoder):
@@ -31,10 +39,10 @@ class Serializer(JSONEncoder, JSONDecoder):
             from fedot.core.dag.graph import Graph
             from fedot.core.dag.graph_node import GraphNode
             from fedot.core.operations.operation import Operation
-            from fedot.core.optimisers.gp_comp.individual import Individual
+            from fedot.core.optimisers.opt_history_objects.individual import Individual
+            from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
+            from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
             from fedot.core.optimisers.graph import OptGraph, OptNode
-            from fedot.core.optimisers.opt_history import OptHistory
-            from fedot.core.optimisers.gp_comp.individual import ParentOperator
             from fedot.core.utilities.data_structures import ComparableEnum
 
             from .coders import (

--- a/fedot/core/visualisation/opt_history/fitness_line.py
+++ b/fedot/core/visualisation/opt_history/fitness_line.py
@@ -12,7 +12,7 @@ from matplotlib.widgets import Button
 from fedot.core.log import default_log
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.fitness import null_fitness
-from fedot.core.optimisers.gp_comp.individual import Individual
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.utils import default_fedot_data_dir
 from fedot.core.visualisation.opt_history.history_visualization import HistoryVisualization
 from fedot.core.visualisation.opt_history.utils import show_or_save_figure

--- a/fedot/core/visualisation/opt_history/history_visualization.py
+++ b/fedot/core/visualisation/opt_history/history_visualization.py
@@ -7,7 +7,7 @@ from fedot.core.log import default_log
 from fedot.core.visualisation.opt_history.arg_constraint_wrapper import ArgConstraintWrapper
 
 if TYPE_CHECKING:
-    from fedot.core.optimisers.opt_history import OptHistory
+    from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 
 
 class HistoryVisualization(metaclass=ArgConstraintWrapper):

--- a/fedot/core/visualisation/opt_history/utils.py
+++ b/fedot/core/visualisation/opt_history/utils.py
@@ -14,7 +14,7 @@ from fedot.core.log import default_log
 from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_opt_node_tag
 
 if TYPE_CHECKING:
-    from fedot.core.optimisers.opt_history import OptHistory
+    from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 
 MatplotlibColorType = Union[str, Sequence[float]]
 LabelsColorMapType = Dict[str, MatplotlibColorType]

--- a/fedot/core/visualisation/opt_viz.py
+++ b/fedot/core/visualisation/opt_viz.py
@@ -10,7 +10,7 @@ from fedot.core.visualisation.opt_history.operations_animated_bar import Operati
 from fedot.core.visualisation.opt_history.operations_kde import OperationsKDE
 
 if TYPE_CHECKING:
-    from fedot.core.optimisers.opt_history import OptHistory
+    from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 
 
 class PlotTypesEnum(Enum):

--- a/fedot/core/visualisation/opt_viz_extra.py
+++ b/fedot/core/visualisation/opt_viz_extra.py
@@ -12,7 +12,7 @@ import seaborn as sns
 from matplotlib import pyplot as plt
 
 from fedot.core.log import default_log
-from fedot.core.optimisers.gp_comp.individual import Individual
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.pipelines.convert import pipeline_template_as_nx_graph
 from fedot.core.utils import default_fedot_data_dir
 from fedot.core.visualisation.graph_viz import GraphVisualiser

--- a/fedot/utilities/project_import_export.py
+++ b/fedot/utilities/project_import_export.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple, Union
 
 from fedot.core.data.data import InputData
 from fedot.core.log import LoggerAdapter, default_log
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utils import default_fedot_data_dir
 

--- a/test/integration/api_params/test_main_api_params.py
+++ b/test/integration/api_params/test_main_api_params.py
@@ -5,7 +5,7 @@ from typing import Callable, Union
 import pytest
 
 from fedot.api.main import Fedot
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.repository.tasks import TsForecastingParams
 from test.unit.api.test_main_api import get_dataset
 

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -7,8 +7,6 @@ import numpy as np
 import pytest
 
 from fedot.api.main import Fedot
-from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
-from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.dag.graph import Graph
 from fedot.core.dag.verification_rules import DEFAULT_DAG_RULES
 from fedot.core.data.data import InputData
@@ -16,13 +14,16 @@ from fedot.core.operations.model import Model
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.fitness import SingleObjFitness
 from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
-from fedot.core.optimisers.gp_comp.individual import Individual, ParentOperator
+from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, Crossover
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, Mutation
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.objective import PipelineObjectiveEvaluate
 from fedot.core.optimisers.objective.data_source_splitter import DataSourceSplitter
 from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_graph_generation_params import get_pipeline_generation_params
@@ -143,14 +144,14 @@ def test_newly_generated_history(n_jobs: int = 1):
 
     history = auto_model.history
 
-    assert auto_model.history is not None
+    assert history is not None
     assert len(history.individuals) == num_of_gens + 1  # num_of_gens + initial assumption
     assert len(history.archive_history) == num_of_gens + 1  # num_of_gens + initial assumption
     # Test history dumps
     dumped_history_json = history.save()
     loaded_history = OptHistory.load(dumped_history_json)
     assert dumped_history_json is not None
-    assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
+    # assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
     _test_individuals_in_history(history)
     _test_individuals_in_history(loaded_history)
 

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -147,12 +147,12 @@ def test_newly_generated_history(n_jobs: int = 1):
     assert history is not None
     assert len(history.individuals) == num_of_gens + 1  # num_of_gens + initial assumption
     assert len(history.archive_history) == num_of_gens + 1  # num_of_gens + initial assumption
+    _test_individuals_in_history(history)
     # Test history dumps
     dumped_history_json = history.save()
     loaded_history = OptHistory.load(dumped_history_json)
     assert dumped_history_json is not None
-    # assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
-    _test_individuals_in_history(history)
+    assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
     _test_individuals_in_history(loaded_history)
 
 

--- a/test/unit/optimizer/test_elitism_operator.py
+++ b/test/unit/optimizer/test_elitism_operator.py
@@ -1,15 +1,13 @@
-from typing import TYPE_CHECKING
-
 import pytest
 
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.evaluation import SimpleDispatcher
-from fedot.core.optimisers.gp_comp.individual import Individual
+from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.operators.elitism import Elitism, ElitismTypesEnum
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from test.unit.optimizer.test_evaluation import prepared_objective
 from test.unit.pipelines.test_node_cache import pipeline_first, pipeline_second, pipeline_third, pipeline_fourth, \
     pipeline_fifth
-from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 
 
 @pytest.fixture()

--- a/test/unit/optimizer/test_evaluation.py
+++ b/test/unit/optimizer/test_evaluation.py
@@ -5,8 +5,8 @@ import pytest
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.fitness import Fitness, null_fitness
 from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher, SimpleDispatcher
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.objective import Objective
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.optimisers.timer import OptimisationTimer
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum

--- a/test/unit/optimizer/test_generation_keeper.py
+++ b/test/unit/optimizer/test_generation_keeper.py
@@ -2,10 +2,10 @@ from typing import Sequence
 
 from fedot.core.optimisers.archive import GenerationKeeper
 from fedot.core.optimisers.fitness import Fitness, MultiObjFitness, null_fitness
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.optimisers.objective.objective import Objective
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.repository.quality_metrics_repository import ComplexityMetricsEnum, RegressionMetricsEnum
 
 

--- a/test/unit/optimizer/test_gp_operators.py
+++ b/test/unit/optimizer/test_gp_operators.py
@@ -1,10 +1,10 @@
 import datetime
 from copy import deepcopy
 from pathlib import Path
+from typing import Sequence, Optional
 
 import numpy as np
 import pytest
-from typing import Sequence, Optional
 
 from fedot.core.composer.gp_composer.specific_operators import boosting_mutation
 from fedot.core.dag.graph_node import GraphNode
@@ -16,7 +16,6 @@ from fedot.core.optimisers.fitness.multi_objective_fitness import MultiObjFitnes
 from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.gp_operators import filter_duplicates
 from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.gp_comp.operators.crossover import CrossoverTypesEnum, Crossover
 from fedot.core.optimisers.gp_comp.operators.mutation import MutationTypesEnum, Mutation, MutationStrengthEnum
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
@@ -24,6 +23,7 @@ from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.optimisers.objective import PipelineObjectiveEvaluate
 from fedot.core.optimisers.objective.data_source_splitter import DataSourceSplitter
 from fedot.core.optimisers.objective.objective import Objective
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.optimisers.optimizer import GraphGenerationParams
 from fedot.core.optimisers.timer import OptimisationTimer
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode

--- a/test/unit/optimizer/test_selection_operators.py
+++ b/test/unit/optimizer/test_selection_operators.py
@@ -1,12 +1,12 @@
 from functools import partial
 
-from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
-from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.debug.metrics import RandomMetric
 from fedot.core.optimisers.fitness.fitness import SingleObjFitness
 from fedot.core.optimisers.gp_comp.gp_operators import random_graph
-from fedot.core.optimisers.gp_comp.individual import Individual
+from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.operators.selection import SelectionTypesEnum, Selection, random_selection
+from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.pipelines.pipeline_graph_generation_params import get_pipeline_generation_params
 
 

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -4,9 +4,9 @@ import pytest
 
 from fedot.core.optimisers.fitness.fitness import SingleObjFitness
 from fedot.core.optimisers.fitness.multi_objective_fitness import MultiObjFitness
-from fedot.core.optimisers.gp_comp.individual import Individual
 from fedot.core.optimisers.graph import OptGraph, OptNode
-from fedot.core.optimisers.opt_history import OptHistory
+from fedot.core.optimisers.opt_history_objects.individual import Individual
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.visualisation.opt_viz import PlotTypesEnum
 
 

--- a/test/unit/visualization/test_visualisation_utils.py
+++ b/test/unit/visualization/test_visualisation_utils.py
@@ -1,6 +1,6 @@
 from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.fitness.multi_objective_fitness import MultiObjFitness
-from fedot.core.optimisers.gp_comp.individual import Individual
+from fedot.core.optimisers.opt_history_objects.individual import Individual
 from fedot.core.pipelines.convert import graph_structure_as_nx_graph, pipeline_template_as_nx_graph
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
 from fedot.core.pipelines.pipeline import Pipeline


### PR DESCRIPTION
- Moved all history-related objects to a separate directory.
- Allowed `Serializer` to associate older class paths with the new ones. 