### PR TITLE
Refactor PipelineAdapter (don't overwrite `__class__`)

### DIFF
--- a/fedot/core/adapter/__init__.py
+++ b/fedot/core/adapter/__init__.py
@@ -1,2 +1,2 @@
-from .adapter import BaseOptimizationAdapter, DirectAdapter
+from .adapter import BaseOptimizationAdapter, DirectAdapter, IdentityAdapter
 from .adapt_registry import AdaptRegistry, register_native

--- a/fedot/core/adapter/adapter.py
+++ b/fedot/core/adapter/adapter.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from typing import TYPE_CHECKING, TypeVar, Generic, Type, Optional, Dict, Any, Callable, Tuple, Sequence, Union
 
+from fedot.core.dag.graph import Graph
 from fedot.core.log import default_log
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.optimisers.opt_history_objects.individual import Individual
@@ -16,7 +17,7 @@ DomainStructureType = TypeVar('DomainStructureType')
 
 
 class BaseOptimizationAdapter(Generic[DomainStructureType]):
-    def __init__(self, base_graph_class: Type[DomainStructureType]):
+    def __init__(self, base_graph_class: Type[DomainStructureType] = Graph):
         self._log = default_log(self)
         self.domain_graph_class = base_graph_class
         self.opt_graph_class = OptGraph
@@ -109,6 +110,16 @@ class BaseOptimizationAdapter(Generic[DomainStructureType]):
     def _restore(self, opt_graph: OptGraph, metadata: Optional[Dict[str, Any]] = None) -> DomainStructureType:
         """Implementation of ``restore`` for single graph."""
         raise NotImplementedError()
+
+
+class IdentityAdapter(BaseOptimizationAdapter[DomainStructureType]):
+    """Identity adapter that performs no transformation, returning same graphs."""
+
+    def _adapt(self, adaptee: DomainStructureType) -> OptGraph:
+        return adaptee
+
+    def _restore(self, opt_graph: OptGraph, metadata: Optional[Dict[str, Any]] = None) -> DomainStructureType:
+        return opt_graph
 
 
 class DirectAdapter(BaseOptimizationAdapter[DomainStructureType]):

--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -51,7 +51,7 @@ class Graph(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def delete_subtree(self, subroot: GraphNode):
+    def delete_subtree(self, subtree: GraphNode):
         """Deletes given node with all its parents.
         Deletes all edges from removed nodes to remaining graph nodes
 

--- a/fedot/core/dag/graph_delegate.py
+++ b/fedot/core/dag/graph_delegate.py
@@ -30,8 +30,8 @@ class GraphDelegate(Graph):
     def delete_node(self, node: GraphNode):
         self.operator.delete_node(node)
 
-    def delete_subtree(self, subroot: GraphNode):
-        self.operator.delete_subtree(subroot)
+    def delete_subtree(self, subtree: GraphNode):
+        self.operator.delete_subtree(subtree)
 
     def node_children(self, node: GraphNode) -> Sequence[Optional[GraphNode]]:
         return self.operator.node_children(node=node)

--- a/fedot/core/dag/graph_node.py
+++ b/fedot/core/dag/graph_node.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from copy import copy
-from typing import List, Optional, Iterable, Sequence, Callable
+from typing import List, Optional, Iterable
 
 
 class GraphNode(ABC):
@@ -88,27 +88,3 @@ def descriptive_id_recursive(current_node: GraphNode, visited_nodes=None) -> str
     full_path_items.append(f'/{node_label}')
     full_path = ''.join(full_path_items)
     return full_path
-
-
-def map_nodes(transform: Callable, nodes: Sequence) -> Sequence:
-    """Maps nodes in dfs-order while respecting node edges.
-
-    :param transform: node transform function (maps node to node)
-    :param nodes: sequence of nodes for mapping
-    :return: sequence of transformed links with preserved relations
-    """
-    mapped_nodes = {}
-
-    def map_impl(node):
-        already_mapped = mapped_nodes.get(id(node))
-        if already_mapped:
-            return already_mapped
-        # map node itself
-        mapped_node = transform(node)
-        # remember it to avoid recursion
-        mapped_nodes[id(node)] = mapped_node
-        # map its children
-        mapped_node.nodes_from = list(map(map_impl, node.nodes_from))
-        return mapped_node
-
-    return list(map(map_impl, nodes))

--- a/fedot/core/dag/graph_node.py
+++ b/fedot/core/dag/graph_node.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from copy import copy
-from typing import List, Optional, Iterable
+from typing import List, Optional, Iterable, Sequence, Callable
 
 
 class GraphNode(ABC):
@@ -88,3 +88,27 @@ def descriptive_id_recursive(current_node: GraphNode, visited_nodes=None) -> str
     full_path_items.append(f'/{node_label}')
     full_path = ''.join(full_path_items)
     return full_path
+
+
+def map_nodes(transform: Callable, nodes: Sequence) -> Sequence:
+    """Maps nodes in dfs-order while respecting node edges.
+
+    :param transform: node transform function (maps node to node)
+    :param nodes: sequence of nodes for mapping
+    :return: sequence of transformed links with preserved relations
+    """
+    mapped_nodes = {}
+
+    def map_impl(node):
+        already_mapped = mapped_nodes.get(id(node))
+        if already_mapped:
+            return already_mapped
+        # map node itself
+        mapped_node = transform(node)
+        # remember it to avoid recursion
+        mapped_nodes[id(node)] = mapped_node
+        # map its children
+        mapped_node.nodes_from = list(map(map_impl, node.nodes_from))
+        return mapped_node
+
+    return list(map(map_impl, nodes))

--- a/fedot/core/dag/graph_utils.py
+++ b/fedot/core/dag/graph_utils.py
@@ -116,12 +116,15 @@ def node_depth(node: GraphNode) -> int:
         return 1 + max(node_depth(next_node) for next_node in node.nodes_from)
 
 
-def map_nodes(transform: Callable, nodes: Sequence) -> Sequence:
+def map_dag_nodes(transform: Callable, nodes: Sequence) -> Sequence:
     """Maps nodes in dfs-order while respecting node edges.
 
-    :param transform: node transform function (maps node to node)
-    :param nodes: sequence of nodes for mapping
-    :return: sequence of transformed links with preserved relations
+    Args:
+        transform: node transform function (maps node to node)
+        nodes: sequence of nodes for mapping
+
+    Returns:
+        Sequence: sequence of transformed links with preserved relations
     """
     mapped_nodes = {}
 

--- a/fedot/core/dag/graph_verifier.py
+++ b/fedot/core/dag/graph_verifier.py
@@ -1,6 +1,7 @@
 from typing import Sequence, Optional, Callable
 
-from fedot.core.adapter import BaseOptimizationAdapter, DirectAdapter
+from fedot.core.adapter import BaseOptimizationAdapter
+from fedot.core.adapter.adapter import IdentityAdapter
 from fedot.core.dag.graph import Graph
 from fedot.core.log import default_log
 
@@ -16,7 +17,7 @@ class GraphVerifier:
     def __init__(self, rules: Sequence[VerifierRuleType] = (),
                  adapter: Optional[BaseOptimizationAdapter] = None,
                  raise_on_failure: bool = False):
-        self._adapter = adapter or DirectAdapter()
+        self._adapter = adapter or IdentityAdapter()
         self._rules = rules
         self._log = default_log(self)
         self._raise = raise_on_failure

--- a/fedot/core/dag/linked_graph.py
+++ b/fedot/core/dag/linked_graph.py
@@ -103,10 +103,10 @@ class LinkedGraph(Graph, Copyable):
                 node in other_node.nodes_from]
 
     @copy_doc(Graph)
-    def connect_nodes(self, parent: GraphNode, child: GraphNode):
-        if child in self.node_children(parent):
+    def connect_nodes(self, node_parent: GraphNode, node_child: GraphNode):
+        if node_child in self.node_children(node_parent):
             return
-        child.nodes_from.append(parent)
+        node_child.nodes_from.append(node_parent)
 
     def _clean_up_leftovers(self, node: GraphNode):
         """Removes nodes and edges that do not affect the result of the pipeline.

--- a/fedot/core/optimisers/adapters.py
+++ b/fedot/core/optimisers/adapters.py
@@ -24,16 +24,7 @@ class PipelineAdapter(BaseOptimizationAdapter[Pipeline]):
         content = {'name': str(node.operation),
                    'params': node.parameters,
                    'metadata': node.metadata}
-
-        PipelineAdapter._clear_pipeline_node(node)
-
         return OptNode(content)
-
-    @staticmethod
-    def _clear_pipeline_node(node: Node):
-        node._fitted_operation = None
-        node._node_data = None
-        del node.metadata
 
     @staticmethod
     def _transform_to_pipeline_node(node: OptNode) -> Node:

--- a/fedot/core/optimisers/adapters.py
+++ b/fedot/core/optimisers/adapters.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Dict
 
 from fedot.core.adapter import BaseOptimizationAdapter
 from fedot.core.dag.linked_graph_node import LinkedGraphNode
-from fedot.core.dag.graph_node import map_nodes
+from fedot.core.dag.graph_utils import map_nodes
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode, Node
 from fedot.core.pipelines.pipeline import Pipeline

--- a/fedot/core/optimisers/adapters.py
+++ b/fedot/core/optimisers/adapters.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from typing import Any, Optional, Dict
 
 from fedot.core.adapter import BaseOptimizationAdapter
-from fedot.core.dag.graph_utils import map_nodes
+from fedot.core.dag.graph_utils import map_dag_nodes
 from fedot.core.optimisers.graph import OptGraph, OptNode
 from fedot.core.pipelines.node import PrimaryNode, SecondaryNode, Node
 from fedot.core.pipelines.pipeline import Pipeline
@@ -38,11 +38,11 @@ class PipelineAdapter(BaseOptimizationAdapter[Pipeline]):
             return SecondaryNode(operation_type=content['name'], content=content)
 
     def _adapt(self, adaptee: Pipeline) -> OptGraph:
-        adapted_nodes = map_nodes(self._transform_to_opt_node, adaptee.nodes)
+        adapted_nodes = map_dag_nodes(self._transform_to_opt_node, adaptee.nodes)
         return OptGraph(adapted_nodes)
 
     def _restore(self, opt_graph: OptGraph, metadata: Optional[Dict[str, Any]] = None) -> Pipeline:
-        restored_nodes = map_nodes(self._transform_to_pipeline_node, opt_graph.nodes)
+        restored_nodes = map_dag_nodes(self._transform_to_pipeline_node, opt_graph.nodes)
         pipeline = Pipeline(restored_nodes)
 
         metadata = metadata or {}

--- a/fedot/core/optimisers/adapters.py
+++ b/fedot/core/optimisers/adapters.py
@@ -11,8 +11,9 @@ from fedot.core.pipelines.pipeline import Pipeline
 class PipelineAdapter(BaseOptimizationAdapter[Pipeline]):
     """Optimization adapter for Pipeline<->OptGraph translation.
     It does 2 things:
-    - on restore: build Pipeline Nodes from information stored in OptNodes
-    - on adapt: clear OptGraph from metadata and 'heavy' data (like fitted models)
+    - on restore: recreate Pipeline Nodes from information stored in OptNodes
+    - on adapt: create light-weight OptGraph (without 'heavy' data like
+        fitted models) that can be used for reconstructing Pipelines.
     """
 
     def __init__(self):

--- a/fedot/core/optimisers/graph.py
+++ b/fedot/core/optimisers/graph.py
@@ -1,19 +1,5 @@
-from typing import List, Union
-
 from fedot.core.dag.graph_delegate import GraphDelegate
 from fedot.core.dag.linked_graph_node import LinkedGraphNode
-from fedot.core.log import default_log
 
 OptNode = LinkedGraphNode
-
-
-class OptGraph(GraphDelegate):
-    """Base class used for optimized structure
-
-    Args:
-        nodes: optimization graph nodes object(s)
-    """
-
-    def __init__(self, nodes: Union[OptNode, List[OptNode]] = ()):
-        super().__init__(nodes)
-        self.log = default_log(self)
+OptGraph = GraphDelegate

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Sequence
 
-from fedot.core.adapter import BaseOptimizationAdapter, DirectAdapter
+from fedot.core.adapter import BaseOptimizationAdapter, IdentityAdapter
 from fedot.core.composer.advisor import DefaultChangeAdvisor
 from fedot.core.dag.graph import Graph
 from fedot.core.dag.graph_verifier import GraphVerifier, VerifierRuleType
@@ -60,7 +60,7 @@ class GraphGenerationParams:
                  rules_for_constraint: Sequence[VerifierRuleType] = (),
                  advisor: Optional[DefaultChangeAdvisor] = None,
                  node_factory: Optional[OptNodeFactory] = None):
-        self.adapter = adapter or DirectAdapter()
+        self.adapter = adapter or IdentityAdapter()
         self.verifier = GraphVerifier(rules_for_constraint, self.adapter)
         self.advisor = advisor or DefaultChangeAdvisor()
         self.node_factory = node_factory or DefaultOptNodeFactory()

--- a/fedot/core/serializers/serializer.py
+++ b/fedot/core/serializers/serializer.py
@@ -51,7 +51,6 @@ class Serializer(JSONEncoder, JSONDecoder):
             from fedot.core.optimisers.opt_history_objects.individual import Individual
             from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
             from fedot.core.optimisers.opt_history_objects.parent_operator import ParentOperator
-            from fedot.core.optimisers.graph import OptGraph, OptNode
             from fedot.core.utilities.data_structures import ComparableEnum
 
             from .coders import (
@@ -86,10 +85,6 @@ class Serializer(JSONEncoder, JSONDecoder):
                 UUID: {_to_json: uuid_to_json, _from_json: uuid_from_json},
                 ComparableEnum: {_to_json: enum_to_json, _from_json: enum_from_json},
             }
-            Serializer.CODERS_BY_TYPE.update({
-                OptNode: Serializer.CODERS_BY_TYPE[LinkedGraphNode],
-                OptGraph: Serializer.CODERS_BY_TYPE[Graph],
-            })
 
     @staticmethod
     def _get_field_checker(obj: Union[INSTANCE_OR_CALLABLE, Type[INSTANCE_OR_CALLABLE]]) -> Callable[..., bool]:


### PR DESCRIPTION
Previously PipelineAdapter used a quite *hacky* way: it just was rewriting `__class__` field.
It's not the best approach, because it *assumes* that Pipeline & OptGraph have the same structure. This can lead to subtle bugs in the future if Pipeline and/or OptGraph implementations change.

This PR resolves this:
- It introduces a proper graph transformation function `map, that transforms each node directly and rebuilds all links in a DFS traverse.
- It implements new default `IdentityAdapter` instead of bug-prone `DirectAdapter` that was unconditionally rewriting `__class__` field

Overall, this properly isolates OptGraph-level from Pipeline-level, that's required for GOLEM