### PR TITLE
Visualizations hotfixes

### DIFF
--- a/fedot/core/dag/graph.py
+++ b/fedot/core/dag/graph.py
@@ -166,7 +166,7 @@ class Graph(ABC):
         return len(self.nodes)
 
     def show(self, save_path: Optional[Union[PathLike, str]] = None, engine: str = 'matplotlib',
-             node_color: Optional[NodeColorType] = None, dpi: int = 300,
+             node_color: Optional[NodeColorType] = None, dpi: int = 100,
              node_size_scale: float = 1.0, font_size_scale: float = 1.0, edge_curvature_scale: float = 1.0):
         """Visualizes graph or saves its picture to the specified ``path``
 

--- a/fedot/core/visualisation/graph_viz.py
+++ b/fedot/core/visualisation/graph_viz.py
@@ -40,7 +40,7 @@ class GraphVisualiser:
 
     def visualise(self, graph: GraphType, save_path: Optional[Union[os.PathLike, str]] = None,
                   engine: str = 'matplotlib', node_color: Optional[NodeColorType] = None,
-                  dpi: int = 300, node_size_scale: float = 1.0, font_size_scale: float = 1.0,
+                  dpi: int = 100, node_size_scale: float = 1.0, font_size_scale: float = 1.0,
                   edge_curvature_scale: float = 1.0):
         if not graph.nodes:
             raise ValueError('Empty graph can not be visualized.')
@@ -77,7 +77,7 @@ class GraphVisualiser:
 
     @staticmethod
     def __draw_with_graphviz(graph: GraphType, save_path: Optional[Union[os.PathLike, str]] = None,
-                             node_color=__get_colors_by_tags.__func__, dpi=300):
+                             node_color=__get_colors_by_tags.__func__, dpi=100):
         nx_graph, nodes = graph_structure_as_nx_graph(graph)
         # Define colors
         if callable(node_color):
@@ -150,7 +150,7 @@ class GraphVisualiser:
 
     def __draw_with_networkx(self, graph: GraphType, save_path=None,
                              node_color: Optional[NodeColorType] = None,
-                             dpi: int = 300, node_size_scale: float = 1.0, font_size_scale: float = 1.0,
+                             dpi: int = 100, node_size_scale: float = 1.0, font_size_scale: float = 1.0,
                              edge_curvature_scale: float = 1.0,
                              in_graph_converter_function: Callable = graph_structure_as_nx_graph):
         fig, ax = plt.subplots(figsize=(7, 7))

--- a/fedot/core/visualisation/opt_history/fitness_box.py
+++ b/fedot/core/visualisation/opt_history/fitness_box.py
@@ -10,7 +10,7 @@ from fedot.core.visualisation.opt_history.history_visualization import HistoryVi
 
 class FitnessBox(HistoryVisualization):
     def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None,
-                  dpi: int = 300, best_fraction: Optional[float] = None):
+                  dpi: int = 100, best_fraction: Optional[float] = None):
         """ Visualizes fitness values across generations in the form of boxplot.
 
         :param save_path: path to save the visualization. If set, then the image will be saved, and if not,

--- a/fedot/core/visualisation/opt_history/fitness_box.py
+++ b/fedot/core/visualisation/opt_history/fitness_box.py
@@ -27,11 +27,10 @@ class FitnessBox(HistoryVisualization):
         fitness = (fitness - min(fitness)) / (max(fitness) - min(fitness))
         colormap = sns.color_palette('YlOrRd', as_cmap=True)
 
-        plot = sns.boxplot(data=df_history, x='generation', y='fitness', palette=fitness.map(colormap))
-        fig = plot.figure
+        fig, ax = plt.subplots(figsize=(6.4, 4.8), facecolor='w')
+        sns.boxplot(data=df_history, x='generation', y='fitness', palette=fitness.map(colormap), ax=ax)
         fig.set_dpi(dpi)
         fig.set_facecolor('w')
-        ax = plt.gca()
 
         ax.set_title('Fitness by generations')
         ax.set_xlabel('Generation')

--- a/fedot/core/visualisation/opt_history/fitness_line.py
+++ b/fedot/core/visualisation/opt_history/fitness_line.py
@@ -135,7 +135,7 @@ def plot_fitness_line_per_generations(axis: plt.Axes, generations, label: Option
 
 
 class FitnessLine(HistoryVisualization):
-    def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
+    def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 100,
                   per_time: bool = False):
         """ Visualizes the best fitness values during the evolution in the form of line.
         :param save_path: path to save the visualization. If set, then the image will be saved,
@@ -159,7 +159,7 @@ class FitnessLineInteractive(HistoryVisualization):
 
     @with_alternate_matplotlib_backend
     def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None,
-                  dpi: int = 300, per_time: bool = False, use_tags: bool = True):
+                  dpi: int = 100, per_time: bool = False, use_tags: bool = True):
         """ Visualizes the best fitness values during the evolution in the form of line.
         Additionally, shows the structure of the best individuals and the moment of their discovering.
         :param save_path: path to save the visualization. If set, then the image will be saved, and if not,

--- a/fedot/core/visualisation/opt_history/fitness_line.py
+++ b/fedot/core/visualisation/opt_history/fitness_line.py
@@ -131,6 +131,7 @@ def plot_fitness_line_per_generations(axis: plt.Axes, generations, label: Option
 
     axis.step(best_generations, best_fitnesses, where='post', label=label)
     axis.set_xticks(range(len(generations)))
+    axis.locator_params(nbins=10)
     return best_individuals
 
 

--- a/fedot/core/visualisation/opt_history/fitness_line.py
+++ b/fedot/core/visualisation/opt_history/fitness_line.py
@@ -130,6 +130,7 @@ def plot_fitness_line_per_generations(axis: plt.Axes, generations, label: Option
         best_generations.append(len(generations) - 1)
 
     axis.step(best_generations, best_fitnesses, where='post', label=label)
+    axis.set_xticks(range(len(generations)))
     return best_individuals
 
 

--- a/fedot/core/visualisation/opt_history/fitness_line.py
+++ b/fedot/core/visualisation/opt_history/fitness_line.py
@@ -144,7 +144,7 @@ class FitnessLine(HistoryVisualization):
         :param per_time: defines whether to show time grid if it is available in history.
         """
 
-        ax = plt.gca()
+        fig, ax = plt.subplots(figsize=(6.4, 4.8), facecolor='w')
         if per_time:
             xlabel = 'Time, s'
             plot_fitness_line_per_time(ax, self.history.individuals)
@@ -152,7 +152,7 @@ class FitnessLine(HistoryVisualization):
             xlabel = 'Generation'
             plot_fitness_line_per_generations(ax, self.history.individuals)
         setup_fitness_plot(ax, xlabel)
-        show_or_save_figure(plt.gcf(), save_path, dpi)
+        show_or_save_figure(fig, save_path, dpi)
 
 
 class FitnessLineInteractive(HistoryVisualization):

--- a/fedot/core/visualisation/opt_history/fitness_line.py
+++ b/fedot/core/visualisation/opt_history/fitness_line.py
@@ -136,7 +136,7 @@ def plot_fitness_line_per_generations(axis: plt.Axes, generations, label: Option
 
 class FitnessLine(HistoryVisualization):
     def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None, dpi: int = 300,
-                  per_time: bool = True):
+                  per_time: bool = False):
         """ Visualizes the best fitness values during the evolution in the form of line.
         :param save_path: path to save the visualization. If set, then the image will be saved,
             and if not, it will be displayed.
@@ -159,7 +159,7 @@ class FitnessLineInteractive(HistoryVisualization):
 
     @with_alternate_matplotlib_backend
     def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None,
-                  dpi: int = 300, per_time: bool = True, use_tags: bool = True):
+                  dpi: int = 300, per_time: bool = False, use_tags: bool = True):
         """ Visualizes the best fitness values during the evolution in the form of line.
         Additionally, shows the structure of the best individuals and the moment of their discovering.
         :param save_path: path to save the visualization. If set, then the image will be saved, and if not,

--- a/fedot/core/visualisation/opt_history/operations_animated_bar.py
+++ b/fedot/core/visualisation/opt_history/operations_animated_bar.py
@@ -14,7 +14,7 @@ from fedot.core.visualisation.opt_history.utils import get_history_dataframe, ge
 
 
 class OperationsAnimatedBar(HistoryVisualization):
-    def visualize(self, save_path: Union[os.PathLike, str] = 'history_animated_bars.gif', dpi: int = 300,
+    def visualize(self, save_path: Union[os.PathLike, str] = 'history_animated_bars.gif', dpi: int = 100,
                   best_fraction: Optional[float] = None, show_fitness: bool = True, use_tags: bool = True,
                   tags_model: Optional[List[str]] = None, tags_data: Optional[List[str]] = None):
         """ Visualizes operations used across generations in the form of animated bar plot.

--- a/fedot/core/visualisation/opt_history/operations_kde.py
+++ b/fedot/core/visualisation/opt_history/operations_kde.py
@@ -70,6 +70,7 @@ class OperationsKDE(HistoryVisualization):
         fig.set_dpi(dpi)
         fig.set_facecolor('w')
         ax = plt.gca()
+        ax.set_xticks(range(len(self.history.individuals)))
         str_fraction_of_pipelines = 'all' if best_fraction is None else f'top {best_fraction * 100}% of'
         ax.set_ylabel(f'Fraction in {str_fraction_of_pipelines} generation pipelines')
 

--- a/fedot/core/visualisation/opt_history/operations_kde.py
+++ b/fedot/core/visualisation/opt_history/operations_kde.py
@@ -46,7 +46,7 @@ class OperationsKDE(HistoryVisualization):
         operations_found = [t for t in tags_all if t in operations_found]  # Sort and filter.
         if use_tags:
             nodes_per_tag = df_history.groupby(operation_column_name)['node'].unique()
-            legend_per_tag = {tag: get_description_of_operations_by_tag(tag, nodes_per_tag[tag])
+            legend_per_tag = {tag: get_description_of_operations_by_tag(tag, nodes_per_tag[tag], 22)
                               for tag in operations_found}
             df_history[operation_column_name] = df_history[operation_column_name].map(legend_per_tag)
             operations_found = map(legend_per_tag.get, operations_found)

--- a/fedot/core/visualisation/opt_history/operations_kde.py
+++ b/fedot/core/visualisation/opt_history/operations_kde.py
@@ -71,6 +71,7 @@ class OperationsKDE(HistoryVisualization):
         fig.set_facecolor('w')
         ax = plt.gca()
         ax.set_xticks(range(len(self.history.individuals)))
+        ax.locator_params(nbins=10)
         str_fraction_of_pipelines = 'all' if best_fraction is None else f'top {best_fraction * 100}% of'
         ax.set_ylabel(f'Fraction in {str_fraction_of_pipelines} generation pipelines')
 

--- a/fedot/core/visualisation/opt_history/operations_kde.py
+++ b/fedot/core/visualisation/opt_history/operations_kde.py
@@ -12,7 +12,7 @@ from fedot.core.visualisation.opt_history.utils import get_history_dataframe, ge
 
 class OperationsKDE(HistoryVisualization):
     def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None,
-                  dpi: int = 300, best_fraction: Optional[float] = None, use_tags: bool = True,
+                  dpi: int = 100, best_fraction: Optional[float] = None, use_tags: bool = True,
                   tags_model: Optional[List[str]] = None, tags_data: Optional[List[str]] = None):
         """ Visualizes operations used across generations in the form of KDE.
 

--- a/fedot/core/visualisation/opt_history/utils.py
+++ b/fedot/core/visualisation/opt_history/utils.py
@@ -93,17 +93,30 @@ def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str],
 
     def format_wrapped_text(wrapped_text: List[str], part_to_format: str, latex_format_tag: str = 'it') -> List[str]:
 
-        long_text = ''.join(wrapped_text)
+        long_text = ' '.join(wrapped_text)
         first_tag_pos = long_text.find(part_to_format)
         second_tag_pos = first_tag_pos + len(part_to_format)
+        if first_tag_pos == -1:
+            return wrapped_text
 
-        line_len = len(wrapped_text[0])
+        first_tag_line, first_tag_char, second_tag_line, second_tag_char = (-1,) * 4
 
-        first_tag_line = first_tag_pos // line_len
-        first_tag_char = first_tag_pos % line_len
+        line_start = 0
+        for line_num, line in enumerate(wrapped_text):
+            line_end = line_start + len(line)
 
-        second_tag_line = second_tag_pos // line_len
-        second_tag_char = second_tag_pos % line_len
+            if line_start <= first_tag_pos < line_end:
+                first_tag_line = line_num
+                first_tag_char = first_tag_pos - line_start
+
+            if line_start <= second_tag_pos < line_end:
+                second_tag_line = line_num
+                second_tag_char = second_tag_pos - line_start
+
+            line_start = line_end
+
+        if any(val == -1 for val in (first_tag_line, first_tag_char, second_tag_line, second_tag_char)):
+            return wrapped_text
 
         if first_tag_line == second_tag_line:
             wrapped_text[first_tag_line] = (

--- a/fedot/core/visualisation/opt_history/utils.py
+++ b/fedot/core/visualisation/opt_history/utils.py
@@ -148,7 +148,7 @@ def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str],
     return description
 
 
-def show_or_save_figure(figure: plt.Figure, save_path: Optional[Union[os.PathLike, str]], dpi: int = 300):
+def show_or_save_figure(figure: plt.Figure, save_path: Optional[Union[os.PathLike, str]], dpi: int = 100):
     if not save_path:
         plt.show()
     else:

--- a/fedot/core/visualisation/opt_history/utils.py
+++ b/fedot/core/visualisation/opt_history/utils.py
@@ -81,7 +81,7 @@ def get_history_dataframe(history: OptHistory, tags_model: Optional[List[str]] =
     return df_history
 
 
-def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str], max_line_length: int = 22,
+def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str], max_line_length: int,
                                          format_tag: str = 'it'):
     def make_text_fancy(text: str):
         return text.replace('_', ' ')
@@ -91,51 +91,18 @@ def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str],
         formatted_text = formatted_text.replace(' ', '\\;')
         return formatted_text
 
-    def format_wrapped_text(wrapped_text: List[str], part_to_format: str, latex_format_tag: str = 'it') -> List[str]:
-
-        long_text = ' '.join(wrapped_text)
-        first_tag_pos = long_text.find(part_to_format)
-        second_tag_pos = first_tag_pos + len(part_to_format)
-        if first_tag_pos == -1:
-            return wrapped_text
-
-        first_tag_line, first_tag_char, second_tag_line, second_tag_char = (-1,) * 4
-
-        line_start = 0
+    def format_wrapped_text_from_beginning(wrapped_text: List[str], part_to_format: str, latex_format_tag: str = 'it') \
+            -> List[str]:
         for line_num, line in enumerate(wrapped_text):
-            line_end = line_start + len(line)
+            if part_to_format in line:
+                # The line contains the whole part_to_format.
+                wrapped_text[line_num] = line.replace(part_to_format, format_text(part_to_format, latex_format_tag))
+                break
+            if part_to_format.startswith(line):
+                # The whole line should be formatted.
+                wrapped_text[line_num] = format_text(line, latex_format_tag)
+                part_to_format = part_to_format[len(line):].strip()
 
-            if line_start <= first_tag_pos < line_end:
-                first_tag_line = line_num
-                first_tag_char = first_tag_pos - line_start
-
-            if line_start <= second_tag_pos < line_end:
-                second_tag_line = line_num
-                second_tag_char = second_tag_pos - line_start
-
-            line_start = line_end
-
-        if any(val == -1 for val in (first_tag_line, first_tag_char, second_tag_line, second_tag_char)):
-            return wrapped_text
-
-        if first_tag_line == second_tag_line:
-            wrapped_text[first_tag_line] = (
-                wrapped_text[first_tag_line][:first_tag_char] +
-                format_text(wrapped_text[first_tag_line][first_tag_char:second_tag_char], latex_format_tag) +
-                wrapped_text[first_tag_line][second_tag_char:]
-            )
-        else:
-            for line in range(first_tag_line + 1, second_tag_line):
-                wrapped_text[line] = format_text(wrapped_text[line], latex_format_tag)
-
-            wrapped_text[first_tag_line] = (
-                wrapped_text[first_tag_line][:first_tag_char] +
-                format_text(wrapped_text[first_tag_line][first_tag_char:], latex_format_tag)
-            )
-            wrapped_text[second_tag_line] = (
-                format_text(wrapped_text[second_tag_line][:second_tag_char], latex_format_tag) +
-                wrapped_text[second_tag_line][second_tag_char:]
-            )
         return wrapped_text
 
     tag = make_text_fancy(tag)
@@ -143,7 +110,7 @@ def get_description_of_operations_by_tag(tag: str, operations_by_tag: List[str],
     description = f'{tag}: {operations_by_tag}.'
     description = make_text_fancy(description)
     description = wrap(description, max_line_length)
-    description = format_wrapped_text(description, tag, format_tag)
+    description = format_wrapped_text_from_beginning(description, tag, format_tag)
     description = '\n'.join(description)
     return description
 


### PR DESCRIPTION
- Made default DPI equal to 100 for all matplotlib visualizations.
- Made width of the KDE legend more adaptive.
- Made plot size fixed where it is possible.
- Limited number of ticks for axes where it was necessary.
- Made `fitness_line` plotted per generations by default.