### PR TITLE
OptHistory returns to GraphOptimizer

### DIFF
--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -121,6 +121,9 @@ class ApiComposer:
             collect_intermediate_metric=composer_params['collect_intermediate_metric'],
             keep_n_best=composer_params['keep_n_best'],
 
+            keep_history=True,
+            history_dir=composer_params.get('history_folder'),
+
             cv_folds=composer_params['cv_folds'],
             validation_blocks=composer_params['validation_blocks'],
         )
@@ -256,7 +259,6 @@ class ApiComposer:
             .with_optimizer_params(parameters=optimizer_params,
                                    external_parameters=composer_params.get('optimizer_external_params')) \
             .with_metrics(metric_functions) \
-            .with_history(composer_params.get('history_folder')) \
             .with_cache(self.pipelines_cache, self.preprocessing_cache) \
             .with_graph_generation_param(graph_generation_params=graph_generation_params) \
             .build()
@@ -330,7 +332,8 @@ def _divide_parameters(common_dict: dict) -> List[dict]:
                                 early_stopping_generations=None, optimizer=None, optimizer_external_params=None,
                                 collect_intermediate_metric=False, max_pipeline_fit_time=None,
                                 initial_assumption=None, preset='auto',
-                                use_pipelines_cache=True, use_preprocessing_cache=True, cache_folder=None)
+                                use_pipelines_cache=True, use_preprocessing_cache=True, cache_folder=None,
+                                keep_history=True, history_dir=None,)
 
     tuner_params_dict = dict(with_tuning=False)
 

--- a/fedot/core/composer/composer.py
+++ b/fedot/core/composer/composer.py
@@ -5,6 +5,7 @@ from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.log import default_log
 from fedot.core.optimisers.composer_requirements import ComposerRequirements
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphOptimizer
 from fedot.core.pipelines.pipeline import Pipeline
 
@@ -14,15 +15,18 @@ class Composer(ABC):
     Base class used for receiving composite operations via optimization
 
     Args:
-        optimiser: optimiser generated in :class:`~fedot.core.composer.ComposerBuilder`
+        optimizer: optimizer generated in :class:`~fedot.core.composer.ComposerBuilder`
         composer_requirements: requirements for composition process
-        initial_pipelines: defines the initial state of the population. If None then initial population is random.
     """
 
     def __init__(self, optimizer: GraphOptimizer, composer_requirements: Optional[ComposerRequirements] = None):
         self.composer_requirements = composer_requirements
         self.optimizer = optimizer
         self.log = default_log(self)
+
+    @property
+    def history(self) -> OptHistory:
+        return self.optimizer.history
 
     @abstractmethod
     def compose_pipeline(self, data: Union[InputData, MultiModalData]) -> Union[Pipeline, List[Pipeline]]:

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -1,5 +1,4 @@
 import platform
-from functools import partial
 from multiprocessing import set_start_method
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Type, Union
@@ -14,7 +13,6 @@ from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.initial_graphs_generator import InitialPopulationGenerator, GenerationFunction
 from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory, log_to_history
 from fedot.core.optimisers.optimizer import GraphOptimizer, GraphOptimizerParameters, GraphGenerationParams
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_graph_generation_params import get_pipeline_generation_params
@@ -27,7 +25,6 @@ from fedot.core.repository.quality_metrics_repository import (
 )
 from fedot.core.repository.tasks import Task
 from fedot.core.utilities.data_structures import ensure_wrapped_in_sequence
-from fedot.core.utils import default_fedot_data_dir
 from fedot.remote.remote_evaluator import RemoteEvaluator
 from fedot.utilities.define_metric_by_task import MetricByTask
 

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -9,7 +9,6 @@ from fedot.core.caching.preprocessing_cache import PreprocessingCache
 from fedot.core.composer.composer import Composer
 from fedot.core.composer.gp_composer.gp_composer import GPComposer
 from fedot.core.log import LoggerAdapter, default_log
-from fedot.core.optimisers.adapters import PipelineAdapter
 from fedot.core.optimisers.gp_comp.gp_optimizer import EvoGraphOptimizer
 from fedot.core.optimisers.gp_comp.gp_params import GPGraphOptimizerParameters
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
@@ -166,17 +165,9 @@ class ComposerBuilder:
                                        graph_generation_params=self.graph_generation_params,
                                        graph_optimizer_params=self.optimizer_parameters,
                                        **self.optimizer_external_parameters)
-        history = None
-        if self._keep_history:
-            # Clean results of the previous run
-            history = OptHistory(objective=objective)
-            history.clean_results(self._full_history_dir)
-            history_callback = partial(log_to_history, history=history, save_dir=self._full_history_dir)
-            optimiser.set_optimisation_callback(history_callback)
 
         composer = self.composer_cls(optimiser,
                                      self.composer_requirements,
-                                     history,
                                      self.pipelines_cache,
                                      self.preprocessing_cache)
 

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -103,13 +103,6 @@ class ComposerBuilder:
         self.initial_population_generation_function = generation_function
         return self
 
-    def with_history(self, history_folder: Optional[str] = None):
-        self._keep_history = True
-        if history_folder:
-            history_folder = Path(default_fedot_data_dir(), history_folder)
-        self._full_history_dir = history_folder
-        return self
-
     def with_cache(self, pipelines_cache: Optional[OperationsCache] = None,
                    preprocessing_cache: Optional[PreprocessingCache] = None):
         self.pipelines_cache = pipelines_cache

--- a/fedot/core/composer/gp_composer/gp_composer.py
+++ b/fedot/core/composer/gp_composer/gp_composer.py
@@ -9,7 +9,6 @@ from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import Pipelin
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import PipelineObjectiveEvaluate
 from fedot.core.optimisers.objective.data_source_splitter import DataSourceSplitter
-from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphOptimizer
 from fedot.core.pipelines.pipeline import Pipeline
 
@@ -17,16 +16,15 @@ from fedot.core.pipelines.pipeline import Pipeline
 class GPComposer(Composer):
     """
     Genetic programming based composer
+
     :param optimizer: optimizer generated in ComposerBuilder.
     :param composer_requirements: requirements for composition process.
-    :param history: optimization history
     :param pipelines_cache: Cache manager for fitted models, optional.
     :param preprocessing_cache: Cache manager for optional preprocessing encoders and imputers, optional.
     """
 
     def __init__(self, optimizer: GraphOptimizer,
                  composer_requirements: PipelineComposerRequirements,
-                 history: Optional[OptHistory] = None,
                  pipelines_cache: Optional[OperationsCache] = None,
                  preprocessing_cache: Optional[PreprocessingCache] = None):
         super().__init__(optimizer, composer_requirements)
@@ -34,7 +32,6 @@ class GPComposer(Composer):
         self.pipelines_cache: Optional[OperationsCache] = pipelines_cache
         self.preprocessing_cache: Optional[PreprocessingCache] = preprocessing_cache
 
-        self.history: Optional[OptHistory] = history
         self.best_models: Collection[Pipeline] = ()
 
     def compose_pipeline(self, data: Union[InputData, MultiModalData]) -> Union[Pipeline, Sequence[Pipeline]]:

--- a/fedot/core/optimisers/composer_requirements.py
+++ b/fedot/core/optimisers/composer_requirements.py
@@ -1,6 +1,8 @@
 import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
+
+from fedot.core.utils import default_fedot_data_dir
 
 
 @dataclass
@@ -21,6 +23,13 @@ class ComposerRequirements:
     :param show_progress: bool indicating whether to show progress using tqdm or not
     :param collect_intermediate_metric: save metrics for intermediate (non-root) nodes in pipeline
 
+    History options:
+    :param keep_history: if True, then save generations to history; if False, don't keep history.
+    :param history_dir: directory for saving optimization history, optional.
+      If the path is relative, then save relative to `default_fedot_data_dir`.
+      If absolute -- then save directly by specified path.
+      If None -- do not save the history to disk and keep it only in-memory.
+
     Model validation options:
     :param cv_folds: number of cross-validation folds
     :param validation_blocks: number of validation blocks for time series validation
@@ -35,6 +44,9 @@ class ComposerRequirements:
     n_jobs: int = 1
     show_progress: bool = True
     collect_intermediate_metric: bool = False
+
+    keep_history: bool = True
+    history_dir: Optional[str] = field(default_factory=default_fedot_data_dir)
 
     cv_folds: Optional[int] = None
     validation_blocks: Optional[int] = None

--- a/fedot/core/optimisers/opt_history_objects/opt_history.py
+++ b/fedot/core/optimisers/opt_history_objects/opt_history.py
@@ -5,7 +5,6 @@ import io
 import itertools
 import os
 import shutil
-from copy import copy
 from pathlib import Path
 from typing import List, Optional, Sequence, Union, TYPE_CHECKING
 
@@ -18,8 +17,6 @@ from fedot.core.utils import default_fedot_data_dir
 from fedot.core.visualisation.opt_viz import OptHistoryVisualizer
 
 if TYPE_CHECKING:
-    from fedot.core.optimisers.archive import GenerationKeeper
-    from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
     from fedot.core.optimisers.opt_history_objects.individual import Individual
 
 

--- a/fedot/core/optimisers/opt_history_objects/opt_history.py
+++ b/fedot/core/optimisers/opt_history_objects/opt_history.py
@@ -45,8 +45,8 @@ class OptHistory:
                 # if path is not absolute, treat it as relative to data dir
                 default_save_dir = Path(default_fedot_data_dir()) / default_save_dir
         else:
-            default_save_dir = Path(default_fedot_data_dir())
-        self._default_save_dir = default_save_dir
+            default_save_dir = default_fedot_data_dir()
+        self._default_save_dir = str(default_save_dir)
 
     def is_empty(self) -> bool:
         return not self.individuals

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -99,7 +99,8 @@ class GraphOptimizer:
         self.graph_generation_params = graph_generation_params or GraphGenerationParams()
         self.graph_optimizer_params = graph_optimizer_parameters or GraphOptimizerParameters()
         self._optimisation_callback: OptimisationCallback = do_nothing_callback
-        self.history = OptHistory(graph_optimizer_parameters.multi_objective, requirements.history_dir) \
+        mo = False if not graph_optimizer_parameters else graph_optimizer_parameters.multi_objective
+        self.history = OptHistory(mo, requirements.history_dir) \
             if requirements and requirements.keep_history else None
 
     @property

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Optional, Sequence
 
 from fedot.core.adapter import BaseOptimizationAdapter, IdentityAdapter
@@ -12,6 +13,7 @@ from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import GraphFunction, Objective, ObjectiveFunction
+from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.optimisers.opt_node_factory import DefaultOptNodeFactory, OptNodeFactory
 from fedot.core.optimisers.gp_comp.evaluation import DelegateEvaluator
 
@@ -92,6 +94,7 @@ class GraphOptimizer:
                  graph_generation_params: Optional[GraphGenerationParams] = None,
                  graph_optimizer_parameters: Optional[GraphOptimizerParameters] = None):
         self.log = default_log(self)
+        self.history = OptHistory(objective, requirements.history_dir) if requirements.keep_history else None
         self.initial_graphs = initial_graphs
         self._objective = objective
         self.requirements = requirements

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -99,7 +99,7 @@ class GraphOptimizer:
         self.graph_generation_params = graph_generation_params or GraphGenerationParams()
         self.graph_optimizer_params = graph_optimizer_parameters or GraphOptimizerParameters()
         self._optimisation_callback: OptimisationCallback = do_nothing_callback
-        self.history = OptHistory(objective, requirements.history_dir) \
+        self.history = OptHistory(graph_optimizer_parameters.multi_objective, requirements.history_dir) \
             if requirements and requirements.keep_history else None
 
     @property

--- a/fedot/core/optimisers/optimizer.py
+++ b/fedot/core/optimisers/optimizer.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Callable, Optional, Sequence
 
 from fedot.core.adapter import BaseOptimizationAdapter, IdentityAdapter
@@ -94,13 +93,14 @@ class GraphOptimizer:
                  graph_generation_params: Optional[GraphGenerationParams] = None,
                  graph_optimizer_parameters: Optional[GraphOptimizerParameters] = None):
         self.log = default_log(self)
-        self.history = OptHistory(objective, requirements.history_dir) if requirements.keep_history else None
         self.initial_graphs = initial_graphs
         self._objective = objective
         self.requirements = requirements
         self.graph_generation_params = graph_generation_params or GraphGenerationParams()
         self.graph_optimizer_params = graph_optimizer_parameters or GraphOptimizerParameters()
         self._optimisation_callback: OptimisationCallback = do_nothing_callback
+        self.history = OptHistory(objective, requirements.history_dir) \
+            if requirements and requirements.keep_history else None
 
     @property
     def objective(self) -> Objective:

--- a/fedot/core/optimisers/populational_optimizer.py
+++ b/fedot/core/optimisers/populational_optimizer.py
@@ -1,24 +1,20 @@
 from abc import abstractmethod
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from tqdm import tqdm
 
 from fedot.core.dag.graph import Graph
 from fedot.core.optimisers.archive import GenerationKeeper
-from fedot.core.optimisers.composer_requirements import ComposerRequirements
 from fedot.core.optimisers.gp_comp.evaluation import MultiprocessingDispatcher
 from fedot.core.optimisers.gp_comp.operators.operator import PopulationT
 from fedot.core.optimisers.gp_comp.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.optimisers.graph import OptGraph
 from fedot.core.optimisers.objective import GraphFunction, ObjectiveFunction
 from fedot.core.optimisers.objective.objective import Objective
-from fedot.core.optimisers.opt_history_objects.opt_history import OptHistory
 from fedot.core.optimisers.optimizer import GraphGenerationParams, GraphOptimizer, GraphOptimizerParameters
 from fedot.core.optimisers.timer import OptimisationTimer
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utilities.grouped_condition import GroupedCondition
-from fedot.core.utils import default_fedot_data_dir
 
 if TYPE_CHECKING:
     pass

--- a/fedot/core/visualisation/opt_viz_extra.py
+++ b/fedot/core/visualisation/opt_viz_extra.py
@@ -115,10 +115,10 @@ class OptHistoryExtraVisualizer:
             plt.clf()
         plt.close('all')
 
-    def visualise_history(self, history: OptHistory):
+    def visualise_history(self, history: OptHistory, metric_index: int = 0):
         try:
             self._clean(with_gif=True)
-            all_historical_fitness = history.all_historical_quality
+            all_historical_fitness = history.all_historical_quality(metric_index)
             historical_graphs = [ind.graph
                                  for ind in list(itertools.chain(*history.individuals))]
             self._visualise_graphs(historical_graphs, all_historical_fitness)

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -145,7 +145,6 @@ def test_composition_time(data_fixture, request):
     params = GPGraphOptimizerParameters(pop_size=2)
 
     builder = ComposerBuilder(task) \
-        .with_history() \
         .with_requirements(req_terminated_evolution) \
         .with_optimizer_params(params) \
         .with_metrics(metric_function)

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -162,7 +162,6 @@ def test_composition_time(data_fixture, request):
     params = GPGraphOptimizerParameters(pop_size=2)
 
     builder = ComposerBuilder(task) \
-        .with_history() \
         .with_requirements(req_completed_evolution) \
         .with_optimizer_params(params) \
         .with_metrics(metric_function)
@@ -188,7 +187,6 @@ def test_parameter_free_composer_build_pipeline_correct(data_fixture, request):
     params = GPGraphOptimizerParameters(pop_size=2, genetic_scheme_type=GeneticSchemeTypesEnum.parameter_free)
 
     gp_composer = ComposerBuilder(task=Task(TaskTypesEnum.classification)) \
-        .with_history() \
         .with_optimizer_params(params) \
         .with_requirements(req) \
         .with_metrics(ClassificationMetricsEnum.ROCAUC) \
@@ -263,7 +261,6 @@ def test_gp_composer_with_adaptive_depth(data_fixture, request):
                                         adaptive_depth_max_stagnation=num_gen - 1,
                                         genetic_scheme_type=GeneticSchemeTypesEnum.steady_state)
     composer = ComposerBuilder(task=Task(TaskTypesEnum.classification)) \
-        .with_history() \
         .with_requirements(req) \
         .with_optimizer_params(params) \
         .with_metrics(quality_metric) \

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -81,7 +81,7 @@ def test_history_properties(generate_history):
     generations_quantity = 2
     pop_size = 10
     history = generate_history
-    assert len(history.all_historical_quality) == pop_size * generations_quantity
+    assert len(history.all_historical_quality()) == pop_size * generations_quantity
     assert len(history.historical_fitness) == generations_quantity
     assert len(history.historical_fitness[0]) == pop_size
     assert len(history.all_historical_fitness) == pop_size * generations_quantity
@@ -241,7 +241,6 @@ def test_history_backward_compatibility():
                for ind in chain(*history.individuals)
                for parent_op in ind.operators_from_prev_generation
                for parent_ind in parent_op.parent_individuals)
-    assert isinstance(history._objective, Objective)
     _test_individuals_in_history(history)
 
 

--- a/test/unit/visualization/test_composing_history.py
+++ b/test/unit/visualization/test_composing_history.py
@@ -98,7 +98,7 @@ def test_all_historical_quality(generate_history):
         for ind_num, individual in enumerate(population):
             fitness = MultiObjFitness(values=eval_fitness[ind_num], weights=weights)
             object.__setattr__(individual, 'fitness', fitness)
-    all_quality = history.all_historical_quality
+    all_quality = history.all_historical_quality()
     assert all_quality[0] == -0.9 and all_quality[4] == -1.4 and all_quality[5] == -1.3 and all_quality[10] == -1.2
 
 


### PR DESCRIPTION
Previous decision with hiding writing to opt history inside an opaque callback proved to be inconvenient.
Returning direct access to OptHistory from Optimizer