### PR TITLE
fix: increase timer & decrease num of generations for quality integration test

### DIFF
--- a/test/integration/quality/test_quality_improvement.py
+++ b/test/integration/quality/test_quality_improvement.py
@@ -56,8 +56,8 @@ def test_multiobjective_improvement():
     metrics = [quality_metric_1, quality_metric_2]
 
     timeout = 10
-    composer_params = dict(num_of_generations=5,
-                           pop_size=5,
+    composer_params = dict(num_of_generations=1,
+                           pop_size=10,
                            with_tuning=False,
                            preset='fast_train',
                            metric=metrics)


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

- Increases time for composition from 4 to 10 minutes
- Decreases number of generations from 10 to 1

`pop_size` doesn't affect the runtime as much as `num_of_generations`.

Test runtime measurements:

1. num_of_generations = 1, execution = 4.5+ minutes
2. num_of_generations = 2, execution = 8.5+ minutes
3. num_of_generations = 3, execution = 12.5+ minutes
4. num_of_generations = 4, execution = 16.5+ minutes

## Context

The time limit for running tests on GitHub.
