### PR TITLE
fix: RANSAC implementation and merging issues

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
@@ -75,7 +75,7 @@ class RegRANSACImplementation(FilterImplementation):
     def fit(self, input_data: InputData):
         iter_ = 0
         residual_threshold = self.params.get('residual_threshold')
-        residual_threshold_step = np.mean(np.abs(input_data.target - np.mean(input_data.target))) // self.max_iter
+        residual_threshold_step = np.mean(np.abs(input_data.target - np.mean(input_data.target))) / self.max_iter
 
         while iter_ < self.max_iter:
             try:

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
@@ -70,21 +70,28 @@ class RegRANSACImplementation(FilterImplementation):
     def __init__(self, params: Optional[OperationParameters]):
         super().__init__(params)
         self.max_iter = 10
+        self.min_inliers_ratio = 0.4
 
     def fit(self, input_data: InputData):
         iter_ = 0
         residual_threshold = self.params.get('residual_threshold')
+        residual_threshold_step = np.mean(np.abs(input_data.target - np.mean(input_data.target))) // self.max_iter
 
         while iter_ < self.max_iter:
             try:
                 self.operation.inlier_mask_ = None
                 self.params.update(residual_threshold=residual_threshold)
+                self.operation.residual_threshold = residual_threshold
+
                 self.operation.fit(input_data.features, input_data.target)
-                return self.operation
+                if self.operation.inlier_mask_.mean() >= self.min_inliers_ratio:
+                    return self.operation
             except ValueError:
-                self.log.info("RANSAC: multiplied residual_threshold on 2")
-                residual_threshold = residual_threshold * 2
-                iter_ += 1
+                pass
+
+            self.log.info(f"RANSAC: increased residual_threshold by {residual_threshold_step}")
+            residual_threshold = residual_threshold + residual_threshold_step
+            iter_ += 1
 
         return self.operation
 

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
@@ -83,7 +83,7 @@ class RegRANSACImplementation(FilterImplementation):
                 self.params.update(residual_threshold=residual_threshold)
                 self.operation.residual_threshold = residual_threshold
 
-                self.operation.fit(input_data.features, input_data.target)
+                self.operation.fit(input_data.features, input_data.target.squeeze())
                 if self.operation.inlier_mask_.mean() >= self.min_inliers_ratio:
                     return self.operation
             except ValueError:

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -517,13 +517,13 @@ class PipelineSearchSpace(SearchSpace):
                     'sampling-scope': [0.1, 1000],
                     'type': 'continuous'},
                 'max_trials': {
-                    'hyperopt-dist': hp.uniform,
+                    'hyperopt-dist': hp.uniformint,
                     'sampling-scope': [50, 500],
-                    'type': 'continuous'},
+                    'type': 'discrete'},
                 'max_skips': {
-                    'hyperopt-dist': hp.uniform,
-                    'sampling-scope': [50, 500000],
-                    'type': 'continuous'}
+                    'hyperopt-dist': hp.uniformint,
+                    'sampling-scope': [50, 50000],
+                    'type': 'discrete'}
             },
             'ransac_non_lin_reg': {
                 'min_samples': {
@@ -535,13 +535,13 @@ class PipelineSearchSpace(SearchSpace):
                     'sampling-scope': [0.1, 1000],
                     'type': 'continuous'},
                 'max_trials': {
-                    'hyperopt-dist': hp.uniform,
+                    'hyperopt-dist': hp.uniformint,
                     'sampling-scope': [50, 500],
-                    'type': 'continuous'},
+                    'type': 'discrete'},
                 'max_skips': {
-                    'hyperopt-dist': hp.uniform,
-                    'sampling-scope': [50, 500000],
-                    'type': 'continuous'}
+                    'hyperopt-dist': hp.uniformint,
+                    'sampling-scope': [50, 50000],
+                    'type': 'discrete'}
             },
             'isolation_forest_reg': {
                 'max_samples': {

--- a/fedot/core/pipelines/verification.py
+++ b/fedot/core/pipelines/verification.py
@@ -25,7 +25,9 @@ from fedot.core.pipelines.verification_rules import (
     has_no_conflicts_with_data_flow,
     has_no_data_flow_conflicts_in_ts_pipeline,
     has_primary_nodes,
-    only_non_lagged_operations_are_primary, has_correct_location_of_resample
+    only_non_lagged_operations_are_primary,
+    has_correct_location_of_resample,
+    has_no_parallel_branches_with_filtering
 )
 from fedot.core.repository.tasks import TaskTypesEnum
 
@@ -40,7 +42,8 @@ common_rules = [has_one_root,
                 has_no_conflicts_in_decompose,
                 has_correct_data_connections,
                 has_correct_data_sources,
-                has_correct_location_of_resample]
+                has_correct_location_of_resample,
+                has_no_parallel_branches_with_filtering]
 
 ts_rules = [only_non_lagged_operations_are_primary,
             has_no_data_flow_conflicts_in_ts_pipeline]

--- a/fedot/core/pipelines/verification_rules.py
+++ b/fedot/core/pipelines/verification_rules.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from golem.core.dag.linked_graph_node import LinkedGraphNode
+
 from fedot.core.operations.atomized_model import AtomizedModel
 from fedot.core.operations.model import Model
 from fedot.core.pipelines.node import PipelineNode
@@ -366,3 +368,30 @@ def __check_multitask_operation_location(pipeline: Pipeline, operations_for_clas
         return True
     else:
         raise ValueError(f'{ERROR_PREFIX} Current pipeline can not solve multitask problem')
+
+
+def has_no_parallel_branches_with_filtering(pipeline: Pipeline):
+    """
+    Checks whether pipeline has parallel branches with filtering operations.
+    If so, merging these branches may be problematic — branches may have
+    different sets of targets, even without intersection.
+    """
+
+    filtering_parents_per_node = dict()
+    __node_branch_contains_filtering(node=pipeline.root_node, filtering_parents_per_node=filtering_parents_per_node)
+    if any([val for val in filtering_parents_per_node.values() if val > 1]):
+        raise ValueError(f'{ERROR_PREFIX} Pipeline has parallel branches containing filtering operations')
+
+    return True
+
+
+def __node_branch_contains_filtering(node: LinkedGraphNode, filtering_parents_per_node: dict) -> bool:
+    if not isinstance(node, PipelineNode):
+        return False
+
+    parents_with_filtering = sum(
+        [__node_branch_contains_filtering(parent_node, filtering_parents_per_node) for parent_node in node.nodes_from]
+    )
+    filtering_parents_per_node[node] = parents_with_filtering
+
+    return bool(parents_with_filtering) or "filtering" in node.operation.metadata.tags

--- a/fedot/core/repository/data/default_operation_params.json
+++ b/fedot/core/repository/data/default_operation_params.json
@@ -133,13 +133,13 @@
   },
   "ransac_lin_reg": {
     "min_samples": 0.4,
-    "residual_threshold": 1,
+    "residual_threshold": 0.5,
     "max_trials": 100,
     "max_skips": 1000
   },
   "ransac_non_lin_reg": {
     "min_samples": 0.4,
-    "residual_threshold": 1,
+    "residual_threshold": 0.5,
     "max_trials": 100,
     "max_skips": 1000
   },

--- a/fedot/core/repository/data/default_operation_params.json
+++ b/fedot/core/repository/data/default_operation_params.json
@@ -133,13 +133,13 @@
   },
   "ransac_lin_reg": {
     "min_samples": 0.4,
-    "residual_threshold": 10,
+    "residual_threshold": 1,
     "max_trials": 100,
     "max_skips": 1000
   },
   "ransac_non_lin_reg": {
     "min_samples": 0.4,
-    "residual_threshold": 10,
+    "residual_threshold": 1,
     "max_trials": 100,
     "max_skips": 1000
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Base framework
-thegolem==0.4.1
+thegolem==0.4.2
 
 
 # Data

--- a/test/integration/pipelines/tuning/test_pipeline_tuning.py
+++ b/test/integration/pipelines/tuning/test_pipeline_tuning.py
@@ -441,7 +441,7 @@ def test_early_stop_in_tuning(data_fixture, request):
                            loss_function=ClassificationMetricsEnum.ROCAUC,
                            iterations=1000,
                            early_stopping_rounds=1)
-    assert time() - start_pipeline_tuner < 1.1 + 0.1
+    assert time() - start_pipeline_tuner < 1.3
 
     start_sequential_tuner = time()
     _ = run_pipeline_tuner(tuner=SequentialTuner,
@@ -450,7 +450,7 @@ def test_early_stop_in_tuning(data_fixture, request):
                            loss_function=ClassificationMetricsEnum.ROCAUC,
                            iterations=1000,
                            early_stopping_rounds=1)
-    assert time() - start_sequential_tuner < 1.1 + 0.1
+    assert time() - start_sequential_tuner < 1.3
 
     start_node_tuner = time()
     _ = run_node_tuner(train_data=train_data,
@@ -458,7 +458,7 @@ def test_early_stop_in_tuning(data_fixture, request):
                        loss_function=ClassificationMetricsEnum.ROCAUC,
                        iterations=1000,
                        early_stopping_rounds=1)
-    assert time() - start_node_tuner < 1.1 + 0.1
+    assert time() - start_node_tuner < 1.3
 
 
 def test_search_space_correctness_after_customization():

--- a/test/unit/adapter/test_adapt_verification_rules.py
+++ b/test/unit/adapter/test_adapt_verification_rules.py
@@ -9,6 +9,7 @@ SOME_PIPELINE_RULES = (
     has_primary_nodes,
     has_no_conflicts_with_data_flow,
     has_correct_data_connections,
+    has_no_parallel_branches_with_filtering,
 )
 
 

--- a/test/unit/pipelines/test_pipeline_verification.py
+++ b/test/unit/pipelines/test_pipeline_verification.py
@@ -382,6 +382,7 @@ def test_pipeline_with_resample_node():
 
     assert str(exc.value) == f'{PIPELINE_ERROR_PREFIX} Resample node is not single parent node for child operation'
 
+
 def test_incorrect_pipeline_with_parallel_filtering_branches():
     incorrect_pipeline = pipeline_with_incorrect_parallel_filtering_branches()
 

--- a/test/unit/pipelines/test_pipeline_verification.py
+++ b/test/unit/pipelines/test_pipeline_verification.py
@@ -15,6 +15,7 @@ from fedot.core.pipelines.verification_rules import (
     has_parent_contain_single_resample,
     has_no_conflicts_during_multitask,
     has_no_conflicts_after_class_decompose,
+    has_no_parallel_branches_with_filtering,
 )
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 from golem.core.dag.verification_rules import has_no_cycle
@@ -198,6 +199,36 @@ def pipeline_with_incorrect_resample_node():
     return pipeline
 
 
+def pipeline_with_incorrect_parallel_filtering_branches():
+    """ Incorrect pipeline
+        locf - ransac_non_lin_reg \
+                                   ridge
+        ets - ransac_lin_reg     /
+    """
+    locf_node = PipelineNode(operation_type='locf')
+    ransac_non_lin_reg_node = PipelineNode(operation_type='ransac_non_lin_reg', nodes_from=[locf_node])
+    ets_node = PipelineNode(operation_type='ets')
+    ransac_lin_reg_node = PipelineNode(operation_type='ransac_lin_reg', nodes_from=[ets_node])
+    pipeline = Pipeline(PipelineNode(operation_type='ridge', nodes_from=[ransac_non_lin_reg_node, ransac_lin_reg_node]))
+
+    return pipeline
+
+
+def correct_pipeline_with_filtering_branch():
+    """ Correct pipeline with filtering branch
+                                              locf \
+                                                     ridge
+        ets - ransac_lin_reg - ransac_non_lin_reg  /
+    """
+    locf_node = PipelineNode(operation_type='locf')
+    ets_node = PipelineNode(operation_type='ets')
+    ransac_lin_reg_node = PipelineNode(operation_type='ransac_lin_reg', nodes_from=[ets_node])
+    ransac_non_lin_reg_node = PipelineNode(operation_type='ransac_non_lin_reg', nodes_from=[ransac_lin_reg_node])
+    pipeline = Pipeline(PipelineNode(operation_type='ridge', nodes_from=[locf_node, ransac_non_lin_reg_node]))
+
+    return pipeline
+
+
 def test_multi_root_pipeline_raise_exception():
     pipeline = pipeline_with_multiple_roots()
 
@@ -350,3 +381,16 @@ def test_pipeline_with_resample_node():
         has_parent_contain_single_resample(incorrect_pipeline)
 
     assert str(exc.value) == f'{PIPELINE_ERROR_PREFIX} Resample node is not single parent node for child operation'
+
+def test_incorrect_pipeline_with_parallel_filtering_branches():
+    incorrect_pipeline = pipeline_with_incorrect_parallel_filtering_branches()
+
+    with pytest.raises(ValueError) as exc:
+        has_no_parallel_branches_with_filtering(incorrect_pipeline)
+
+    assert str(exc.value) == f'{PIPELINE_ERROR_PREFIX} Pipeline has parallel branches containing filtering operations'
+
+
+def test_pipeline_with_filtering_branch_correct():
+    pipeline = correct_pipeline_with_filtering_branch()
+    assert has_no_parallel_branches_with_filtering(pipeline)


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->

## Summary

Disabled filtering nodes in parallel pipeline branches to avoid merge issues. Improved the RANSAC implementation by changing the behavior of the `residual_threshold` variable.
