### PR TITLE
Show single-step forecasts in prediction plots

### DIFF
--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -47,7 +47,8 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_
     first_idx = pred_start - padding
 
     plt.plot(np.arange(pred_start, pred_start + len(predict)),
-             predict, label='Predicted', c='blue')
+             predict, label='Predicted', c='blue',
+             marker='o' if len(predict) == 1 else None)
     plt.plot(np.arange(first_idx, len(actual_time_series)),
              actual_time_series[first_idx:], label='Actual values', c='green')
 

--- a/test/unit/data/test_visualisation.py
+++ b/test/unit/data/test_visualisation.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from fedot.core.data.data import InputData, OutputData
+from fedot.core.data.visualisation import plot_forecast
+from fedot.core.repository.dataset_types import DataTypesEnum
+from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
+
+
+def test_single_step_forecast_is_visible():
+    task = Task(
+        TaskTypesEnum.ts_forecasting,
+        TsForecastingParams(forecast_length=1),
+    )
+    data = InputData(
+        idx=np.arange(4),
+        features=np.array([1.0, 2.0, 3.0, 4.0]),
+        target=None,
+        task=task,
+        data_type=DataTypesEnum.ts,
+    )
+    prediction = OutputData(
+        idx=np.array([4]),
+        predict=np.array([5.0]),
+        task=task,
+        data_type=DataTypesEnum.ts,
+    )
+
+    with patch("matplotlib.pyplot.show"):
+        plot_forecast(data, prediction)
+
+    predicted_line = next(
+        line for line in plt.gca().get_lines() if line.get_label() == "Predicted"
+    )
+    assert predicted_line.get_marker() == "o"
+    plt.close()


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

A one-step forecast was passed to Matplotlib as a line containing only one point. With no line segment and no marker, the predicted value was invisible.

This change adds a marker only when the prediction contains one point. Multi-step forecast rendering remains unchanged, and a regression test verifies the predicted point is visible.

## Context

Fixes #1180

## Verification

- `MPLBACKEND=Agg pytest -q test/unit/data/test_visualisation.py`
- `MPLBACKEND=Agg pytest -q test/unit/data/test_data.py test/unit/data/test_visualisation.py` (14 passed)
- repository autopep8 check on the changed files
