### PR TITLE
fix: wrong discretization threshold for binary features in simple_imputation

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
@@ -472,7 +472,7 @@ class ImputationImplementation(DataOperationImplementation):
             filled_column = filled_numerical_features[:, bin_id]
             min_value = self.ids_binary_integer_features[bin_id]['min']
             max_value = self.ids_binary_integer_features[bin_id]['max']
-            mean_value = (max_value - min_value) / 2
+            mean_value = (max_value + min_value) / 2
 
             filled_column[filled_column > mean_value] = max_value
             filled_column[filled_column < mean_value] = min_value

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -494,6 +494,41 @@ def test_imputation_binary_features_with_equal_categories_correct():
     assert np.isclose(predicted.predict[1, 1], 5.0)
 
 
+def test_imputation_binary_features_with_non_zero_categories_correct():
+    """
+    Check filling gaps in binary integer columns whose two categories do not
+    include zero (e.g. {1, 2}). The imputed value must be discretized to the
+    nearest category and the original values must stay unchanged.
+    """
+    supp_data = SupplementaryData(col_type_ids={'features': np.array([TYPE_TO_ID[int]])})
+    task = Task(TaskTypesEnum.classification)
+    features = np.array([[1],
+                         [2],
+                         [1],
+                         [np.nan],
+                         [1]])
+    target = np.array([['no'], ['yes'], ['no'], ['no'], ['no']])
+    nan_data = InputData(
+        idx=np.arange(len(features)),
+        features=features,
+        target=target,
+        numerical_idx=np.array([0]),
+        categorical_idx=np.array([]),
+        task=task,
+        data_type=DataTypesEnum.table,
+        supplementary_data=supp_data
+    )
+
+    imputation_node = PipelineNode('simple_imputation')
+    imputation_node.fit(nan_data)
+    predicted = imputation_node.predict(nan_data)
+
+    # Mean of known values is 1.25 -> the gap must be filled with category 1
+    assert np.isclose(predicted.predict[3, 0], 1)
+    # Original values must not be changed by the discretization
+    assert np.allclose(predicted.predict[[0, 1, 2, 4], 0], [1, 2, 1, 1])
+
+
 def test_label_encoding_correct():
     """
     Check if LabelEncoder can perform transformations correctly. Also the dataset


### PR DESCRIPTION
Closes #1441

## Summary

When filling gaps, `ImputationImplementation` detects binary columns (exactly two unique values) and, after imputation, snaps the reconstructed values to the nearest of the two categories. The discretization threshold was computed as half the **range** `(max - min) / 2` instead of the **midpoint** between the categories `(max + min) / 2` (`sklearn_transformations.py`, `_correct_binary_ids_features`).

The two formulas coincide only when `min == 0`, so `{0, 1}` columns are unaffected — which is exactly the case covered by the existing tests, and why the bug went unnoticed. But for any binary column that does not contain zero, the threshold falls below both categories and the **entire column** (including originally non-missing values) is silently overwritten with the max category.

Example: the column `[1, 2, 1, NaN, 1]` (categories `{1, 2}`, threshold with the old formula = 0.5) turns into `[2, 2, 2, 2, 2]` after `simple_imputation`. With the fix (threshold = 1.5) the result is `[1, 2, 1, 1, 1]`, as expected.

## Changes

- Fixed the threshold formula in `_correct_binary_ids_features`.
- Added a regression test with a binary `{1, 2}` column containing a gap: the gap must be filled with the nearest category and the original values must stay unchanged.

Behaviour for `{0, 1}` columns is bit-for-bit identical, existing tests are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
