### PR TITLE
ref: added TensorData creator API

### DIFF
--- a/fedot/__init__.py
+++ b/fedot/__init__.py
@@ -1,6 +1,6 @@
 """ This file is part of the FEDOT framework for automated machine learning. """
 
-from fedot import *
-from fedot.api import Fedot, FedotBuilder
+from fedot.api import Fedot, FedotBuilder, create_data, create_data_lazy
+from fedot.core.data.tensor_data.tensor_data import TensorData
 from fedot.validation import FedotInvalidKeysError, FedotValidationError, ValidationContext
 from fedot.version import __version__

--- a/fedot/api/__init__.py
+++ b/fedot/api/__init__.py
@@ -1,2 +1,5 @@
 from fedot.api.main import Fedot
 from fedot.api.builder import FedotBuilder
+from fedot.api.create_data import create_data, create_data_lazy
+
+__all__ = ['Fedot', 'FedotBuilder', 'create_data', 'create_data_lazy']

--- a/fedot/api/api_utils/api_data.py
+++ b/fedot/api/api_utils/api_data.py
@@ -6,15 +6,9 @@ import numpy as np
 import torch
 from golem.core.log import default_log
 
-from fedot.api.api_utils.api_data_rules import (
-    build_definition_plan,
-    iter_shared_index_assignments,
-    normalize_features_for_definition,
-    plan_prediction,
-)
+from fedot.api.api_utils.api_data_rules import plan_prediction
 from fedot.api.api_utils.data_definition import data_strategy_selector, FeaturesType, TargetType
 from fedot.core.data.input_data.data import InputData, OutputData, data_type_is_table
-from fedot.core.data.common.enums import StateEnum
 from fedot.preprocessing.data_preprocessing import convert_into_column
 from fedot.core.data.multimodal.multi_modal import MultiModalData
 from fedot.core.pipelines.ensembling.pipeline_ensemble import PipelineEnsemble

--- a/fedot/api/api_utils/api_data_rules.py
+++ b/fedot/api/api_utils/api_data_rules.py
@@ -1,7 +1,6 @@
 ﻿from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Tuple
 
-from fedot.core.data.common.enums import StateEnum
 from fedot.core.repository.tasks import TaskTypesEnum
 
 
@@ -23,24 +22,11 @@ class PredictionPlan:
 class StrategyResolution:
     strategy_factory: Any
 
-# TODO @romankuklo: needed for TD creation API
-@dataclass(frozen=True)
-class TensorDataDefinitionPlan:
-    backend_name: str
-    state: StateEnum
-
 
 @dataclass(frozen=True)
 class TensorDataCreationRequest:
     backend_name: str
     spec_kwargs: dict
-
-
-def build_definition_plan(backend_name: str, is_predict: bool) -> TensorDataDefinitionPlan:
-    return TensorDataDefinitionPlan(
-        backend_name=backend_name,
-        state=StateEnum.PREDICT if is_predict else StateEnum.FIT,
-    )
 
 
 class DataDefinitionResolutionError(TypeError):

--- a/fedot/api/api_utils/params.py
+++ b/fedot/api/api_utils/params.py
@@ -1,4 +1,4 @@
-﻿import datetime
+import datetime
 from collections import UserDict
 from copy import deepcopy, copy
 from dataclasses import dataclass
@@ -67,7 +67,6 @@ class ApiParams(UserDict):
         self.graph_generation_params = None
         self.optimizer_params = None
 
-    # TODO @romankuklo: use it when TDCreator will be in API
     def prepare_creation(
         self,
         *,
@@ -75,6 +74,11 @@ class ApiParams(UserDict):
         is_predict: bool = False,
         trace_uuid: Optional[str] = None,
     ) -> TensorDataCreationRequest:
+        """
+        Build creator kwargs from ``tensor_data_config`` plus runtime task/state.
+
+        Used by :meth:`~fedot.api.main.Fedot.create_data`.
+        """
         config = dict(self.tensor_data_config)
         backend_name = config.pop('backend_name', 'cpu')
 

--- a/fedot/api/create_data.py
+++ b/fedot/api/create_data.py
@@ -1,0 +1,151 @@
+from typing import Any, Dict, Optional, Tuple
+
+from fedot.core.backend.backend import Backend
+from fedot.core.data.common.enums import StateEnum
+from fedot.core.data.tensor_data.tensor_data import TensorData
+from fedot.core.data.tensor_data.tensor_data_creator import TensorDataCreator
+
+
+def _resolve_target_argument(target: Any, target_idx: Any) -> Tuple[Any, Any]:
+    """Map public ``target`` to creator ``target`` / ``target_idx``."""
+    if isinstance(target, str):
+        if target_idx is not None:
+            raise ValueError(
+                'Pass either target=<column name> or target_idx=..., not both.'
+            )
+        return None, target
+    return target, target_idx
+
+
+def _resolve_from_data(
+    from_data: Optional[TensorData],
+    *,
+    task: Any,
+    data_type: Any,
+    spec_kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Fill predict-time defaults from a previously created ``TensorData``."""
+    resolved = dict(spec_kwargs)
+
+    if from_data is None:
+        if task is not None:
+            resolved['task'] = task
+        if data_type is not None:
+            resolved['data_type'] = data_type
+        return resolved
+
+    if not isinstance(from_data, TensorData):
+        raise TypeError(
+            f'from_data must be TensorData, got {type(from_data).__name__}.'
+        )
+
+    resolved.setdefault('state', StateEnum.PREDICT)
+    resolved['task'] = task if task is not None else from_data.task
+    resolved['data_type'] = data_type if data_type is not None else from_data.data_type
+    if 'trace_uuid' not in resolved:
+        resolved['trace_uuid'] = from_data.trace_uuid
+    return resolved
+
+
+def _build_create_data_kwargs(
+    *,
+    target: Any = None,
+    target_idx: Any = None,
+    backend: str = Backend.DEFAULT_NAME,
+    task: Any = None,
+    data_type: Any = None,
+    from_data: Optional[TensorData] = None,
+    **options: Any,
+) -> Tuple[str, Dict[str, Any]]:
+    resolved_target, resolved_target_idx = _resolve_target_argument(target, target_idx)
+    spec_kwargs = _resolve_from_data(
+        from_data,
+        task=task,
+        data_type=data_type,
+        spec_kwargs=dict(options),
+    )
+    if resolved_target is not None:
+        spec_kwargs['target'] = resolved_target
+    if resolved_target_idx is not None:
+        spec_kwargs['target_idx'] = resolved_target_idx
+
+    return Backend.normalize_name(backend), spec_kwargs
+
+
+def create_data(
+    features: Any,
+    target: Any = None,
+    *,
+    backend: str = Backend.DEFAULT_NAME,
+    task: Any = None,
+    data_type: Any = None,
+    from_data: Optional[TensorData] = None,
+    target_idx: Any = None,
+    **options: Any,
+) -> TensorData:
+    """
+    Create :class:`~fedot.core.data.tensor_data.tensor_data.TensorData` for Fedot.
+
+    This is the public entrypoint for turning raw sources (numpy / pandas / CSV /
+    paths) into the internal ``TensorData`` type used by :class:`~fedot.api.main.Fedot`.
+
+    Args:
+        features: Features matrix, dataframe, or path supported by the data readers.
+        target: Target values, or a column name (``str``) to extract from ``features``.
+        backend: Compute backend, ``'cpu'`` (default) or ``'gpu'``.
+        task: FEDOT task or task name. Defaults to classification when omitted.
+        data_type: Data type or alias (e.g. ``'tabular'``, ``'time_series'``).
+        from_data: Previously created train :class:`TensorData`. When set, predict
+            mode is used and ``task``, ``data_type``, and ``trace_uuid`` are taken
+            from it (unless overridden explicitly).
+        target_idx: Target column index/name when not using ``target=<column name>``.
+        **options: Extra :class:`~fedot.core.data.tensor_data.data_spec.DataSpec`
+            options (``encoding_strategy``, ``ts_orientation``, ``use_cache``, …).
+
+    Returns:
+        Prepared :class:`TensorData` on the requested backend.
+
+    Examples:
+        >>> train = create_data(X_train, target=y_train)
+        >>> test = create_data(X_test, from_data=train)
+        >>> train = create_data('train.csv', target='target')
+    """
+    backend_name, spec_kwargs = _build_create_data_kwargs(
+        target=target,
+        target_idx=target_idx,
+        backend=backend,
+        task=task,
+        data_type=data_type,
+        from_data=from_data,
+        **options,
+    )
+    return TensorDataCreator.create(features, backend_name, **spec_kwargs)
+
+
+def create_data_lazy(
+    features: Any,
+    target: Any = None,
+    *,
+    backend: str = Backend.DEFAULT_NAME,
+    task: Any = None,
+    data_type: Any = None,
+    from_data: Optional[TensorData] = None,
+    target_idx: Any = None,
+    **options: Any,
+):
+    """
+    Lazy variant of :func:`create_data`.
+
+    Returns a :class:`~fedot.core.data.tensor_data.lazy_tensor.LazyTensor` that
+    materializes ``TensorData`` on first access.
+    """
+    backend_name, spec_kwargs = _build_create_data_kwargs(
+        target=target,
+        target_idx=target_idx,
+        backend=backend,
+        task=task,
+        data_type=data_type,
+        from_data=from_data,
+        **options,
+    )
+    return TensorDataCreator.create_lazy(features, backend_name, **spec_kwargs)

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -120,10 +120,14 @@ class Fedot:
             :class:`~fedot.api.builder.FedotBuilder`.
 
             ``tensor_data_config`` is a dictionary of options for
+            :func:`~fedot.api.create_data.create_data` /
             :class:`~fedot.core.data.tensor_data.tensor_data_creator.TensorDataCreator`
             (for example ``backend_name``, ``use_cache``, ``encoding_strategy``,
             ``custom_strategy``, ``data_type``, ``ts_orientation``). It is validated
             during initialization and stored on :attr:`~fedot.api.api_utils.params.ApiParams.tensor_data_config`.
+            Prefer :meth:`create_data` (or the module-level :func:`~fedot.api.create_data.create_data`)
+            to build :class:`~fedot.core.data.tensor_data.tensor_data.TensorData` before
+            :meth:`fit` / :meth:`predict`.
     """
 
     def __init__(self,
@@ -348,6 +352,66 @@ class Fedot:
             if self.current_pipeline is None:
                 raise ValueError('No models were found')
 
+    def create_data(
+        self,
+        features,
+        target=None,
+        *,
+        from_data: Optional[TensorData] = None,
+        **options,
+    ) -> TensorData:
+        """
+        Build :class:`~fedot.core.data.tensor_data.tensor_data.TensorData` using this
+        model's ``problem`` and ``tensor_data_config``.
+
+        Typical flow::
+
+            train = model.create_data(X_train, target=y_train)
+            model.fit(train)
+            test = model.create_data(X_test, from_data=train)
+            pred = model.predict(test)
+
+        Args:
+            features: Features matrix, dataframe, or path.
+            target: Target values, or a column name (``str``) to extract from ``features``.
+            from_data: Train :class:`TensorData` for predict-time creation
+                (sets predict state and reuses ``trace_uuid``).
+            **options: Extra creator options; override ``tensor_data_config`` keys.
+
+        Returns:
+            Prepared :class:`TensorData`.
+        """
+        from fedot.api.create_data import create_data as _create_data
+
+        is_predict = from_data is not None
+        trace_uuid = from_data.trace_uuid if from_data is not None else options.get('trace_uuid')
+        request = self.params.prepare_creation(
+            is_predict=is_predict,
+            trace_uuid=trace_uuid if is_predict else None,
+        )
+
+        config_kwargs = dict(request.spec_kwargs)
+        config_kwargs.update(options)
+        config_kwargs.pop('target', None)
+        config_kwargs.pop('backend', None)
+        config_kwargs.pop('backend_name', None)
+
+        task = options.get('task') if from_data is not None else config_kwargs.pop('task', None)
+        data_type = options.get('data_type') if from_data is not None else config_kwargs.pop('data_type', None)
+        if from_data is not None:
+            config_kwargs.pop('task', None)
+            config_kwargs.pop('data_type', None)
+
+        return _create_data(
+            features,
+            target=target,
+            backend=options.get('backend', request.backend_name),
+            task=task,
+            data_type=data_type,
+            from_data=from_data,
+            **config_kwargs,
+        )
+
     def fit(self,
             tensor_data: TensorData,
             predefined_model: Union[str, Pipeline] = None) -> Pipeline:
@@ -451,9 +515,8 @@ class Fedot:
         """Runs prediction on a prepared :class:`TensorData` instance.
 
         Args:
-            tensor_data: test data already converted to ``TensorData`` (e.g. via
-                :class:`~fedot.core.data.tensor_data.tensor_data_creator.TensorDataCreator`).
-            output_mode: prediction format for classification models.
+            tensor_data: test data from :func:`~fedot.api.create_data.create_data` or
+                :meth:`create_data` (typically with ``from_data=train``).
             path_to_save: if specified, path to save prediction to.
         """
         if self.current_pipeline is None:

--- a/fedot/api/some.py
+++ b/fedot/api/some.py
@@ -1,8 +1,7 @@
 import numpy as np
 
-from fedot import Fedot
-from fedot.core.data.common.enums import StateEnum
-from fedot.core.data.tensor_data.tensor_data_creator import TensorDataCreator
+from fedot import Fedot, create_data
+
 
 def _to_numpy(value):
     if hasattr(value, 'detach'):
@@ -19,14 +18,10 @@ if __name__ == '__main__':
     ], dtype=np.float32)
     target = np.array([0, 1, 0, 1], dtype=np.int64)
 
-    tensor_data = TensorDataCreator.create(
-        features, 
-        target=target, 
-        backend_name='cpu',
-    )
     model = Fedot(problem='classification')
+    tensor_data = model.create_data(features, target=target)
     pipeline = model.fit(
-        tensor_data=tensor_data,
+        tensor_data,
         predefined_model='torch_linear',
     )
 
@@ -39,16 +34,7 @@ if __name__ == '__main__':
     test_features[0] += 1.0
     test_features[-1] -= 1.0
 
-    test_tensor_data = TensorDataCreator.create(
-        test_features,
-        backend_name='cpu',
-        task=tensor_data.task,
-        state=StateEnum.PREDICT,
-        trace_uuid=tensor_data.trace_uuid,
-    )
-
+    test_tensor_data = create_data(test_features, from_data=tensor_data)
     test_prediction = model.predict(test_tensor_data)
-    test_labels = model.predict(test_tensor_data, )
     print('test features:\n', test_features)
     print('test probabilities:', _to_numpy(test_prediction.predict))
-    print('test labels:', _to_numpy(test_labels.predict))

--- a/fedot/core/data/tensor_data/tensor_data.py
+++ b/fedot/core/data/tensor_data/tensor_data.py
@@ -73,18 +73,15 @@ class TensorData:
         trace_uuid: UUID of the trace used for tracing.
 
     Examples:
-        Create `TensorData` from a numpy array using the creator:
+        Prefer the public helper:
 
-        >>> from fedot.core.data.tensor_data.td_creator import TensorDataCreator
-        >>> td = TensorDataCreator.create(array, backend_name='cpu')
+        >>> from fedot import create_data
+        >>> train = create_data(array, target=y)
+        >>> test = create_data(x_test, from_data=train)
 
-        Create `TensorData` from a CSV file and extract a target column:
+        Or extract a target column from a CSV / dataframe:
 
-        >>> td = TensorDataCreator.create(
-        ...     'path/to/file.csv',
-        ...     backend_name='cpu',
-        ...     target_idx='target',
-        ... )
+        >>> train = create_data('path/to/file.csv', target='target')
     """
     task: Union[Task, str]
     data_type: Union[DataTypesEnum, str]

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -23,7 +23,11 @@ from fedot.core.data.tensor_data.tensor_data import TensorData
 from fedot.core.operations.data_operation import DataOperation
 from fedot.core.operations.model import Model
 from fedot.core.pipelines.node import PipelineNode
-from fedot.core.pipelines.pipeline_rules import build_pipeline_postprocess_plan, OutputModeEnum
+from fedot.core.pipelines.pipeline_rules import (
+    build_pipeline_postprocess_plan,
+    resolve_pipeline_predict_modes,
+    OutputModeEnum,
+)
 from fedot.core.pipelines.schemas import (
     validate_pipeline_is_fitted,
     validate_single_root_node,
@@ -199,24 +203,24 @@ class Pipeline(GraphDelegate, Serializable):
             operations_cache.try_load_into_pipeline(self, fold_id)
 
     def predict(self,
-                           tensor_data: TensorData,
-                           output_mode: Union[OutputModeEnum, str] = OutputModeEnum.AUTO,
-                           predictions_cache: Optional[PredictionsCache] = None,
-                           fold_id: Optional[int] = None) -> TensorData:
+                tensor_data: TensorData,
+                output_mode: Union[OutputModeEnum, str] = OutputModeEnum.AUTO,
+                predictions_cache: Optional[PredictionsCache] = None,
+                fold_id: Optional[int] = None) -> TensorData:
         validate_pipeline_is_fitted(self.is_fitted)
 
-        output_mode = output_mode if output_mode is not None else OutputModeEnum.AUTO
-        
+        modes = resolve_pipeline_predict_modes(output_mode, tensor_data.task.task_type)
+
         copied_tensor_data = deepcopy(tensor_data)
 
         copied_tensor_data = self._assign_data_to_nodes(copied_tensor_data)
         result = self.root_node.predict(
             tensor_data=copied_tensor_data,
-            output_mode=output_mode,
+            output_mode=modes.operation_output_mode,
             predictions_cache=predictions_cache,
             fold_id=fold_id,
         )
-        result = self._postprocess(result, output_mode)
+        result = self._postprocess(result, modes.pipeline_output_mode)
         return result
 
     def save(self, path: str = None, create_subdir: bool = True, is_datetime_in_path: bool = False) -> Tuple[str, dict]:

--- a/fedot/core/pipelines/pipeline_rules.py
+++ b/fedot/core/pipelines/pipeline_rules.py
@@ -15,11 +15,22 @@ class OutputModeEnum(Enum):
 
 SUPPORTED_PIPELINE_OUTPUT_MODES = tuple(mode.value for mode in OutputModeEnum)
 
+# Legacy / operation-level modes still accepted by ``Pipeline.predict``.
+SUPPORTED_OPERATION_OUTPUT_MODES = ('labels', 'probs', 'full_probs', 'default', False)
+
 
 @dataclass(frozen=True)
 class PipelinePostprocessPlan:
     should_flatten_prediction: bool
     should_restore_inverse_target_encoding: bool
+
+
+@dataclass(frozen=True)
+class PipelinePredictModes:
+    """Split ``Pipeline.predict(output_mode=...)`` into node vs postprocess modes."""
+
+    operation_output_mode: Any
+    pipeline_output_mode: OutputModeEnum
 
 
 def normalize_output_mode(output_mode: Union[OutputModeEnum, str, Any]) -> OutputModeEnum:
@@ -29,6 +40,40 @@ def normalize_output_mode(output_mode: Union[OutputModeEnum, str, Any]) -> Outpu
     if hasattr(output_mode, 'value'):
         output_mode = output_mode.value
     return OutputModeEnum(output_mode)
+
+
+def resolve_pipeline_predict_modes(
+    output_mode: Union[OutputModeEnum, str, Any, None],
+    task_type: TaskTypesEnum,
+) -> PipelinePredictModes:
+    """
+    Resolve ``Pipeline.predict`` output mode into operation + postprocess modes.
+
+    Pipeline modes (``auto`` / ``raw`` / ``decoded`` / ``flattened``) drive
+    ``_postprocess``. Operation modes (``labels`` / ``probs`` / …) are passed to
+    the root node. Legacy operation modes keep postprocess as ``raw``.
+    """
+    if output_mode is None:
+        output_mode = OutputModeEnum.AUTO
+
+    mode_name = output_mode.value if hasattr(output_mode, 'value') else output_mode
+    if mode_name in SUPPORTED_OPERATION_OUTPUT_MODES:
+        return PipelinePredictModes(
+            operation_output_mode=mode_name,
+            pipeline_output_mode=OutputModeEnum.RAW,
+        )
+
+    from fedot.core.pipelines.schemas import validate_pipeline_output_mode
+
+    pipeline_mode = normalize_output_mode(validate_pipeline_output_mode(output_mode))
+    needs_labels = (
+        pipeline_mode in (OutputModeEnum.AUTO, OutputModeEnum.DECODED)
+        and task_type is TaskTypesEnum.classification
+    )
+    return PipelinePredictModes(
+        operation_output_mode='labels' if needs_labels else 'default',
+        pipeline_output_mode=pipeline_mode,
+    )
 
 
 def build_pipeline_postprocess_plan(

--- a/tests/api/api_utils/test_api_data_rules.py
+++ b/tests/api/api_utils/test_api_data_rules.py
@@ -1,18 +1,14 @@
-﻿import types
-
-import numpy as np
+﻿import numpy as np
 import pandas as pd
 import pytest
 
 from fedot.api.api_utils.api_data_rules import (
     DataDefinitionResolutionError,
-    build_definition_plan,
     iter_shared_index_assignments,
     normalize_features_for_definition,
     plan_prediction,
     resolve_strategy,
 )
-from fedot.core.data.common.enums import StateEnum
 from fedot.core.repository.tasks import TaskTypesEnum
 
 
@@ -66,15 +62,3 @@ def test_resolve_strategy_raises_typed_error_for_unsupported_source():
     with pytest.raises(DataDefinitionResolutionError):
         resolve_strategy(123, [(np.ndarray, _StrategyA),
                          (pd.DataFrame, _StrategyB)])
-
-
-def test_build_tensordata_definition_plan_is_explicit_for_backend_and_stage():
-    fit_plan = build_definition_plan(
-        backend_name='cpu', is_predict=False)
-    predict_plan = build_definition_plan(
-        backend_name='gpu', is_predict=True)
-
-    assert fit_plan.backend_name == 'cpu'
-    assert fit_plan.state == StateEnum.FIT
-    assert predict_plan.backend_name == 'gpu'
-    assert predict_plan.state == StateEnum.PREDICT

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,1 @@
+from tests.fixtures.isolated_cache import isolated_cache_dir

--- a/tests/api/test_create_data.py
+++ b/tests/api/test_create_data.py
@@ -1,0 +1,128 @@
+import numpy as np
+import pytest
+import torch
+
+from fedot import Fedot, TensorData, create_data
+from fedot.api.create_data import _build_create_data_kwargs, _resolve_target_argument
+from fedot.core.data.common.enums import StateEnum
+from fedot.core.repository.tasks import TaskTypesEnum
+from fedot.validation.errors import FedotValidationError
+
+
+@pytest.mark.unit
+def test_resolve_target_argument_maps_column_name_to_target_idx():
+    target, target_idx = _resolve_target_argument('label', None)
+    assert target is None
+    assert target_idx == 'label'
+
+
+@pytest.mark.unit
+def test_resolve_target_argument_rejects_column_name_with_target_idx():
+    with pytest.raises(ValueError, match='not both'):
+        _resolve_target_argument('label', 0)
+
+
+@pytest.mark.unit
+def test_build_create_data_kwargs_from_data_sets_predict_defaults():
+    train = TensorData(
+        task='classification',
+        data_type='tabular',
+        features=torch.tensor([[1.0, 2.0]], dtype=torch.float32),
+        target=torch.tensor([0.0]),
+        trace_uuid='trace-abc',
+    )
+
+    backend_name, spec_kwargs = _build_create_data_kwargs(from_data=train)
+
+    assert backend_name == 'cpu'
+    assert spec_kwargs['state'] is StateEnum.PREDICT
+    assert spec_kwargs['task'] is train.task
+    assert spec_kwargs['data_type'] is train.data_type
+    assert spec_kwargs['trace_uuid'] == 'trace-abc'
+
+
+@pytest.mark.unit
+def test_create_data_fit_and_from_data_predict(isolated_cache_dir):
+    features = np.array([
+        [1.0, 0.1, 'cat'],
+        [2.0, 0.2, 'dog'],
+        [3.0, 0.3, 'cat'],
+        [4.0, 0.4, 'dog'],
+    ], dtype=object)
+
+    train = create_data(features)
+    assert isinstance(train, TensorData)
+    assert train.state is StateEnum.FIT
+    assert train.trace_uuid is not None
+    assert train.features.shape[0] == 4
+    assert train.target is not None
+    assert train.features.shape[1] < features.shape[1]
+
+    test_features = np.array([
+        [5.0, 0.5],
+        [6.0, 0.6],
+    ], dtype=object)
+    test = create_data(test_features, from_data=train)
+
+    assert test.state is StateEnum.PREDICT
+    assert test.trace_uuid == train.trace_uuid
+    assert test.task.task_type is train.task.task_type
+    assert test.target is None
+
+
+@pytest.mark.unit
+def test_create_data_accepts_explicit_target_array(isolated_cache_dir):
+    x = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    y = np.array([0, 1], dtype=np.int64)
+
+    train = create_data(x, target=y)
+
+    assert train.features.shape == (2, 2)
+    assert train.target is not None
+    assert train.target.shape[0] == 2
+
+
+@pytest.mark.unit
+def test_fedot_create_data_uses_problem_and_tensor_data_config(isolated_cache_dir):
+    model = Fedot(
+        problem='classification',
+        tensor_data_config={'use_cache': False},
+    )
+    x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]], dtype=np.float32)
+    y = np.array([0, 1, 0, 1], dtype=np.int64)
+
+    train = model.create_data(x, target=y)
+
+    assert train.task.task_type is TaskTypesEnum.classification
+    assert train.state is StateEnum.FIT
+
+    test = model.create_data(x[:2], from_data=train)
+    assert test.state is StateEnum.PREDICT
+    assert test.trace_uuid == train.trace_uuid
+
+
+@pytest.mark.unit
+def test_fedot_create_data_predict_requires_trace_uuid():
+    model = Fedot(problem='classification')
+    train_without_trace = TensorData(
+        task='classification',
+        data_type='tabular',
+        features=torch.tensor([[1.0, 2.0]], dtype=torch.float32),
+        trace_uuid=None,
+    )
+
+    with pytest.raises(FedotValidationError, match='trace_uuid is required'):
+        model.create_data(
+            np.array([[1.0, 2.0]], dtype=np.float32),
+            from_data=train_without_trace,
+        )
+
+
+@pytest.mark.unit
+def test_public_exports():
+    import fedot
+    from fedot.api import create_data as api_create_data
+
+    assert fedot.create_data is create_data
+    assert api_create_data is create_data
+    assert fedot.TensorData is TensorData

--- a/tests/core/pipelines/test_pipeline.py
+++ b/tests/core/pipelines/test_pipeline.py
@@ -66,7 +66,12 @@ def test_pipeline_predict_assigns_data_and_delegates_to_root_node():
     ))
 
     try:
-        tensor_data = SimpleNamespace(name='tensor-data')
+        tensor_data = TensorData(
+            task=Task(TaskTypesEnum.classification),
+            data_type=DataTypesEnum.tabular,
+            features=torch.zeros((2, 2)),
+            target=torch.tensor([0, 1]),
+        )
         result = pipeline.predict(tensor_data, output_mode='labels')
     finally:
         Pipeline.is_fitted = original_is_fitted
@@ -77,4 +82,42 @@ def test_pipeline_predict_assigns_data_and_delegates_to_root_node():
     assert captured['tensor_data'] is assigned[0]
     assert captured['output_mode'] == 'labels'
     assert result[0] == 'postprocessed'
-    assert result[2] == 'labels'
+    assert result[2] is OutputModeEnum.RAW
+
+
+def test_pipeline_predict_auto_classification_passes_labels_to_node():
+    pipeline = Pipeline()
+    captured = {}
+    pipeline._assign_data_to_nodes = lambda data: data
+    pipeline._postprocess = lambda result, output_mode: (
+        'postprocessed', result, output_mode)
+
+    original_is_fitted = Pipeline.is_fitted
+    original_root_node = Pipeline.root_node
+    Pipeline.is_fitted = property(lambda self: True)
+    Pipeline.root_node = property(lambda self: SimpleNamespace(
+        predict=lambda tensor_data, output_mode, predictions_cache, fold_id: (
+            captured.update({'output_mode': output_mode}),
+            TensorData(
+                task=Task(TaskTypesEnum.classification),
+                data_type=DataTypesEnum.tabular,
+                features=torch.zeros((2, 2)),
+                predict=torch.tensor([0, 1]),
+            ),
+        )[1]
+    ))
+
+    try:
+        tensor_data = TensorData(
+            task=Task(TaskTypesEnum.classification),
+            data_type=DataTypesEnum.tabular,
+            features=torch.zeros((2, 2)),
+            target=torch.tensor([0, 1]),
+        )
+        result = pipeline.predict(tensor_data, output_mode=OutputModeEnum.AUTO)
+    finally:
+        Pipeline.is_fitted = original_is_fitted
+        Pipeline.root_node = original_root_node
+
+    assert captured['output_mode'] == 'labels'
+    assert result[2] is OutputModeEnum.AUTO

--- a/tests/core/pipelines/test_pipeline_rules.py
+++ b/tests/core/pipelines/test_pipeline_rules.py
@@ -4,6 +4,7 @@ from fedot.core.pipelines.pipeline_rules import (
     OutputModeEnum,
     build_pipeline_postprocess_plan,
     normalize_output_mode,
+    resolve_pipeline_predict_modes,
 )
 from fedot.core.pipelines.schemas import validate_pipeline_output_mode
 from fedot.core.repository.tasks import TaskTypesEnum
@@ -17,7 +18,22 @@ def test_normalize_output_mode_accepts_enum_and_string():
 
 def test_validate_pipeline_output_mode_rejects_unknown_value():
     with pytest.raises(FedotValidationError, match='Invalid output mode'):
-        validate_pipeline_output_mode('labels')
+        validate_pipeline_output_mode('unknown_mode')
+
+
+def test_resolve_pipeline_predict_modes_auto_classification_uses_labels():
+    modes = resolve_pipeline_predict_modes(
+        OutputModeEnum.AUTO, TaskTypesEnum.classification)
+
+    assert modes.operation_output_mode == 'labels'
+    assert modes.pipeline_output_mode is OutputModeEnum.AUTO
+
+
+def test_resolve_pipeline_predict_modes_keeps_legacy_operation_modes():
+    modes = resolve_pipeline_predict_modes('probs', TaskTypesEnum.classification)
+
+    assert modes.operation_output_mode == 'probs'
+    assert modes.pipeline_output_mode is OutputModeEnum.RAW
 
 
 def test_build_pipeline_postprocess_plan_for_auto_modes():


### PR DESCRIPTION
- Public create_data / create_data_lazy in fedot.api to build TensorData before fit/predict (backend='cpu' by default, target= as array or column name, from_data= for predict + trace_uuid).
- Fedot.create_data injects problem and tensor_data_config via prepare_creation.
- Pipeline.predict: split pipeline modes (AUTO/DECODED/…) from operation modes via resolve_pipeline_predict_modes.